### PR TITLE
Prover: Add AIR for CPU table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,16 +21,146 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "elf"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "hashbrown"
@@ -44,10 +174,127 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "lambdaworks-crypto"
+version = "0.13.0"
+source = "git+https://github.com/lambdaclass/lambdaworks.git#e17bcc29450cdd6d908e82ca998b20823253722a"
+dependencies = [
+ "digest",
+ "lambdaworks-math",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "sha2",
+ "sha3",
+]
+
+[[package]]
+name = "lambdaworks-math"
+version = "0.13.0"
+source = "git+https://github.com/lambdaclass/lambdaworks.git#e17bcc29450cdd6d908e82ca998b20823253722a"
+dependencies = [
+ "getrandom",
+ "num-bigint",
+ "num-traits",
+ "rand",
+ "rayon",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.178"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -61,6 +308,11 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
+dependencies = [
+ "lambdaworks-crypto",
+ "lambdaworks-math",
+ "stark-platinum-prover",
+]
 
 [[package]]
 name = "quote"
@@ -72,12 +324,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -98,6 +423,59 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
+name = "stark-platinum-prover"
+version = "0.13.0"
+source = "git+https://github.com/lambdaclass/lambdaworks.git#e17bcc29450cdd6d908e82ca998b20823253722a"
+dependencies = [
+ "bincode",
+ "itertools",
+ "lambdaworks-crypto",
+ "lambdaworks-math",
+ "log",
+ "num-integer",
+ "rand",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha3",
+ "thiserror",
 ]
 
 [[package]]
@@ -132,10 +510,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "version_check"
@@ -144,12 +534,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
 name = "vm"
 version = "0.1.0"
 dependencies = [
  "elf",
  "hashbrown",
  "thiserror",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+lambdaworks-crypto = { git = "https://github.com/lambdaclass/lambdaworks.git" }
+lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks.git" }
+stark-platinum-prover = { git = "https://github.com/lambdaclass/lambdaworks.git" }

--- a/prover/src/air/constraints_templates.rs
+++ b/prover/src/air/constraints_templates.rs
@@ -1,0 +1,379 @@
+use lambdaworks_math::field::{
+    element::FieldElement,
+    fields::fft_friendly::{
+        babybear_u32::Babybear31PrimeField, quartic_babybear_u32::Degree4BabyBearU32ExtensionField,
+    },
+};
+use stark_platinum_prover::{
+    constraints::transition::TransitionConstraint, traits::TransitionEvaluationContext,
+};
+
+/// Enforces that a specific trace column contains only binary values (0 or 1).
+/// For a trace value `x` in the specified column, the constraint enforces:
+/// x * (x - 1) = 0
+pub struct BitConstraint {
+    column_idx: usize,
+    constraint_idx: usize,
+}
+
+impl BitConstraint {
+    /// Creates a new binary constraint for the specified column.
+    /// * `column_idx` - The trace column index that must contain only 0 or 1
+    /// * `constraint_idx` - Unique constraint identifier used by the STARK prover
+    pub fn new(column_idx: usize, constraint_idx: usize) -> Self {
+        Self {
+            column_idx,
+            constraint_idx,
+        }
+    }
+}
+
+impl TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>
+    for BitConstraint
+{
+    fn degree(&self) -> usize {
+        2
+    }
+
+    fn constraint_idx(&self) -> usize {
+        self.constraint_idx
+    }
+
+    fn exemptions_period(&self) -> Option<usize> {
+        None
+    }
+
+    fn periodic_exemptions_offset(&self) -> Option<usize> {
+        None
+    }
+
+    fn end_exemptions(&self) -> usize {
+        0
+    }
+
+    /// Evaluates the bit constraint: `flag * (flag - 1) = 0`
+    ///
+    /// This method is called during both by the Prover and Verifier.
+    /// Prover to work with base field elements while the verifier
+    /// operates in a larger extension field.
+    fn evaluate(
+        &self,
+        evaluation_context: &TransitionEvaluationContext<
+            Babybear31PrimeField,
+            Degree4BabyBearU32ExtensionField,
+        >,
+        transition_evaluations: &mut [FieldElement<Degree4BabyBearU32ExtensionField>],
+    ) {
+        match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values: _periodic_values,
+                rap_challenges: _rap_challenges,
+            } => {
+                let step = frame.get_evaluation_step(0);
+                let flag = step.get_main_evaluation_element(0, self.column_idx);
+                let one = FieldElement::<Babybear31PrimeField>::one();
+                let bit_constraint = flag * (flag - one);
+                transition_evaluations[self.constraint_idx()] = bit_constraint.to_extension();
+            }
+
+            TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values: _periodic_values,
+                rap_challenges: _rap_challenges,
+            } => {
+                let step = frame.get_evaluation_step(0);
+                let flag = step.get_main_evaluation_element(0, self.column_idx);
+                let one = FieldElement::<Degree4BabyBearU32ExtensionField>::one();
+                let bit_constraint = flag * (flag - one);
+                transition_evaluations[self.constraint_idx()] = bit_constraint;
+            }
+        }
+    }
+}
+
+/// Helper function to create multiple bit constraints for different columns.
+///
+/// # Arguments
+/// * `column_idx` - Slice of column indices to constrain
+/// * `constraint_idx_start` - Starting index for constraint numbering (sequential from here)
+///
+/// # Returns
+/// A vector of boxed `BitConstraint` trait objects, one for each specified column.
+pub fn new_bit_constraints(
+    column_idx: &[usize],
+    constraint_idx_start: usize,
+) -> Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>> {
+    column_idx
+        .iter()
+        .enumerate()
+        .map(|(i, &column_idx)| {
+            Box::new(BitConstraint::new(column_idx, constraint_idx_start + i))
+                as Box<
+                    dyn TransitionConstraint<
+                        Babybear31PrimeField,
+                        Degree4BabyBearU32ExtensionField,
+                    >,
+                >
+        })
+        .collect()
+}
+
+/// Identifies which carry bit (from a two-word addition) to constrain.
+///
+/// A 32-bit addition is split into two 16-bit word additions:
+/// - **Carry 0**: The carry out of the low word (bits 0-15)
+/// - **Carry 1**: The carry out of the high word (bits 16-31), which includes carry_0 as input
+#[derive(Clone)]
+pub enum CarryIndex {
+    Zero,
+    One,
+}
+
+/// Enforces correct carry bit values in multi-limb addition operations.
+///
+/// For 32-bit addition split into two 16-bit words (each composed of two 8-bit limbs):
+///
+/// Carry 0:
+/// lhs_0 = lhs[0] + 256 * lhs[1]
+/// rhs_0 = rhs[0] + 256 * rhs[1]
+/// res_0 = res[0] + 256 * res[1]
+///
+/// carry_0 = (lhs_0 + rhs_0 - res_0) / 65536
+/// constraint: carry_0 * (carry_0 - 1) = 0
+///
+/// Carry 1:
+/// lhs_1 = lhs[2] + 256 * lhs[3]
+/// rhs_1 = rhs[2] + 256 * rhs[3]
+/// res_1 = res[2] + 256 * res[3]
+///
+/// carry_1 = (lhs_1 + rhs_1 - res_1 + carry_0) / 65536
+/// constraint: flag * carry_1 * (carry_1 - 1) = 0
+///
+/// The `flag` factor allows selective activation: the constraint is only enforced when one
+/// flag column is active. (No more than 1 flag can be active at the same time)
+///
+/// Constraint Degree 3 (cubic), due to the multiplication of three terms: `flag * carry * (carry - 1)`.
+#[derive(Clone)]
+pub struct CarryBitConstraint {
+    carry_idx: CarryIndex,
+    flags_idx: Vec<usize>,
+    lhs_start_idx: usize,
+    rhs_start_idx: usize,
+    res_start_idx: usize,
+    constraint_idx: usize,
+}
+
+impl CarryBitConstraint {
+    /// Creates a new carry bit constraint.
+    ///
+    /// # Arguments
+    /// * `carry_idx` - Which carry to constrain (Zero or One)
+    /// * `flags_idx` - Columns containing activation flags
+    /// * `lhs_start_idx` - Starting column index for left operand's 4 limbs
+    /// * `rhs_start_idx` - Starting column index for right operand's 4 limbs
+    /// * `res_start_idx` - Starting column index for result's 4 limbs
+    /// * `constraint_idx` - Unique constraint identifier
+    fn new(
+        carry_idx: CarryIndex,
+        flags_idx: Vec<usize>,
+        lhs_start_idx: usize,
+        rhs_start_idx: usize,
+        res_start_idx: usize,
+        constraint_idx: usize,
+    ) -> Self {
+        Self {
+            carry_idx,
+            flags_idx,
+            lhs_start_idx,
+            rhs_start_idx,
+            res_start_idx,
+            constraint_idx,
+        }
+    }
+}
+
+impl TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>
+    for CarryBitConstraint
+{
+    fn degree(&self) -> usize {
+        3
+    }
+
+    fn constraint_idx(&self) -> usize {
+        self.constraint_idx
+    }
+
+    fn exemptions_period(&self) -> Option<usize> {
+        None
+    }
+
+    fn periodic_exemptions_offset(&self) -> Option<usize> {
+        None
+    }
+
+    fn end_exemptions(&self) -> usize {
+        0
+    }
+
+    /// Evaluates the carry bit constraint: `flag * carry * (carry - 1) = 0`
+    ///
+    /// This ensures that when the instruction flag is active (flag = 1), the computed
+    /// carry bit must be binary (0 or 1). When the flag is inactive (flag = 0),
+    /// the constraint is trivially satisfied regardless of carry value.
+    ///
+    /// This method is called during both by the Prover and Verifier.
+    /// Prover to work with base field elements while the verifier
+    /// operates in a larger extension field.
+    fn evaluate(
+        &self,
+        evaluation_context: &TransitionEvaluationContext<
+            Babybear31PrimeField,
+            Degree4BabyBearU32ExtensionField,
+        >,
+        transition_evaluations: &mut [FieldElement<Degree4BabyBearU32ExtensionField>],
+    ) {
+        match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values: _periodic_values,
+                rap_challenges: _rap_challenges,
+            } => {
+                let step = frame.get_evaluation_step(0);
+
+                let two_fifty_six = FieldElement::<Babybear31PrimeField>::from(256);
+
+                // Sum all activation flags
+                let flag = self
+                    .flags_idx
+                    .iter()
+                    .fold(FieldElement::<Babybear31PrimeField>::zero(), |acc, &idx| {
+                        acc + step.get_main_evaluation_element(0, idx)
+                    });
+
+                // Compute the low word using the first 2 operand limbs.
+                let lhs_0 = step.get_main_evaluation_element(0, self.lhs_start_idx)
+                    + two_fifty_six * step.get_main_evaluation_element(0, self.lhs_start_idx + 1);
+                let rhs_0 = step.get_main_evaluation_element(0, self.rhs_start_idx)
+                    + two_fifty_six * step.get_main_evaluation_element(0, self.rhs_start_idx + 1);
+                let res_0 = step.get_main_evaluation_element(0, self.res_start_idx)
+                    + two_fifty_six * step.get_main_evaluation_element(0, self.res_start_idx + 1);
+
+                let one = FieldElement::<Babybear31PrimeField>::one();
+                let inverse = FieldElement::<Babybear31PrimeField>::from(65536)
+                    .inv()
+                    .unwrap();
+                let carry_0 = (lhs_0 + rhs_0 - res_0) * inverse;
+
+                let bit_constraint: FieldElement<Babybear31PrimeField> = match self.carry_idx {
+                    CarryIndex::Zero => flag * carry_0 * (carry_0 - one),
+                    CarryIndex::One => {
+                        // Compute the high word using the first 2 operand limbs.
+                        let lhs_1 = step.get_main_evaluation_element(0, self.lhs_start_idx + 2)
+                            + two_fifty_six
+                                * step.get_main_evaluation_element(0, self.lhs_start_idx + 3);
+                        let rhs_1 = step.get_main_evaluation_element(0, self.rhs_start_idx + 2)
+                            + two_fifty_six
+                                * step.get_main_evaluation_element(0, self.rhs_start_idx + 3);
+                        let res_1 = step.get_main_evaluation_element(0, self.res_start_idx + 2)
+                            + two_fifty_six
+                                * step.get_main_evaluation_element(0, self.res_start_idx + 3);
+                        let carry_1 = (lhs_1 + rhs_1 - res_1 + carry_0) * inverse;
+                        flag * carry_1 * (carry_1 - one)
+                    }
+                };
+                transition_evaluations[self.constraint_idx()] = bit_constraint.to_extension();
+            }
+
+            TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values: _periodic_values,
+                rap_challenges: _rap_challenges,
+            } => {
+                let step = frame.get_evaluation_step(0);
+
+                let two_fifty_six = FieldElement::<Babybear31PrimeField>::from(256);
+
+                let flag = self.flags_idx.iter().fold(
+                    FieldElement::<Degree4BabyBearU32ExtensionField>::zero(),
+                    |acc, &idx| acc + step.get_main_evaluation_element(0, idx),
+                );
+
+                let lhs_0 = step.get_main_evaluation_element(0, self.lhs_start_idx)
+                    + two_fifty_six * step.get_main_evaluation_element(0, self.lhs_start_idx + 1);
+                let rhs_0 = step.get_main_evaluation_element(0, self.rhs_start_idx)
+                    + two_fifty_six * step.get_main_evaluation_element(0, self.rhs_start_idx + 1);
+                let res_0 = step.get_main_evaluation_element(0, self.res_start_idx)
+                    + two_fifty_six * step.get_main_evaluation_element(0, self.res_start_idx + 1);
+
+                let one = FieldElement::<Degree4BabyBearU32ExtensionField>::one();
+                let inverse = FieldElement::<Degree4BabyBearU32ExtensionField>::from(65536)
+                    .inv()
+                    .unwrap();
+                let carry_0 = (lhs_0 + rhs_0 - res_0) * inverse;
+
+                let bit_constraint = match self.carry_idx {
+                    CarryIndex::Zero => flag * carry_0 * (carry_0 - one),
+                    CarryIndex::One => {
+                        let lhs_1 = step.get_main_evaluation_element(0, self.lhs_start_idx + 2)
+                            + two_fifty_six
+                                * step.get_main_evaluation_element(0, self.lhs_start_idx + 3);
+                        let rhs_1 = step.get_main_evaluation_element(0, self.rhs_start_idx + 2)
+                            + two_fifty_six
+                                * step.get_main_evaluation_element(0, self.rhs_start_idx + 3);
+                        let res_1 = step.get_main_evaluation_element(0, self.res_start_idx + 2)
+                            + two_fifty_six
+                                * step.get_main_evaluation_element(0, self.res_start_idx + 3);
+                        let carry_1 = (lhs_1 + rhs_1 - res_1 + carry_0) * inverse;
+                        flag * carry_1 * (carry_1 - one)
+                    }
+                };
+                transition_evaluations[self.constraint_idx()] = bit_constraint
+            }
+        }
+    }
+}
+
+/// Creates a pair of carry bit constraints for a complete 32-bit addition operation.
+///
+/// A full 32-bit addition with 8-bit limb decomposition requires validating two carry bits:
+/// - Carry from the low word (bits 0-15)
+/// - Carry from the high word (bits 16-31)
+///
+/// This helper function creates both constraints with sequential constraint indices.
+///
+/// ## Arguments
+/// * `flags_idx` - Column indices for instruction selector flags
+/// * `lhs_start_idx` - Starting column for left operand (requires 4 consecutive columns)
+/// * `rhs_start_idx` - Starting column for right operand (requires 4 consecutive columns)
+/// * `res_start_idx` - Starting column for result (requires 4 consecutive columns)
+/// * `constraint_idx_start` - Starting constraint index (will use idx and idx+1)
+///
+/// ## Returns
+/// A vector of two boxed constraints: [carry_0_constraint, carry_1_constraint]
+pub fn new_add_constraint(
+    flags_idx: Vec<usize>,
+    lhs_start_idx: usize,
+    rhs_start_idx: usize,
+    res_start_idx: usize,
+    constraint_idx_start: usize,
+) -> Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>> {
+    vec![
+        Box::new(CarryBitConstraint::new(
+            CarryIndex::Zero,
+            flags_idx.clone(),
+            lhs_start_idx,
+            rhs_start_idx,
+            res_start_idx,
+            constraint_idx_start,
+        )),
+        Box::new(CarryBitConstraint::new(
+            CarryIndex::One,
+            flags_idx,
+            lhs_start_idx,
+            rhs_start_idx,
+            res_start_idx,
+            constraint_idx_start + 1,
+        )),
+    ]
+}

--- a/prover/src/air/constraints_templates.rs
+++ b/prover/src/air/constraints_templates.rs
@@ -8,6 +8,8 @@ use stark_platinum_prover::{
     constraints::transition::TransitionConstraint, traits::TransitionEvaluationContext,
 };
 
+pub const INV_65536: u64 = 2013235201;
+
 /// Enforces that a specific trace column contains only binary values (0 or 1).
 /// For a trace value `x` in the specified column, the constraint enforces:
 /// x * (x - 1) = 0
@@ -260,9 +262,7 @@ impl TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField
                     + two_fifty_six * step.get_main_evaluation_element(0, self.res_start_idx + 1);
 
                 let one = FieldElement::<Babybear31PrimeField>::one();
-                let inverse = FieldElement::<Babybear31PrimeField>::from(65536)
-                    .inv()
-                    .unwrap();
+                let inverse = FieldElement::<Babybear31PrimeField>::from(INV_65536);
                 let carry_0 = (lhs_0 + rhs_0 - res_0) * inverse;
 
                 let bit_constraint: FieldElement<Babybear31PrimeField> = match self.carry_idx {
@@ -307,9 +307,7 @@ impl TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField
                     + two_fifty_six * step.get_main_evaluation_element(0, self.res_start_idx + 1);
 
                 let one = FieldElement::<Degree4BabyBearU32ExtensionField>::one();
-                let inverse = FieldElement::<Degree4BabyBearU32ExtensionField>::from(65536)
-                    .inv()
-                    .unwrap();
+                let inverse = FieldElement::<Degree4BabyBearU32ExtensionField>::from(INV_65536);
                 let carry_0 = (lhs_0 + rhs_0 - res_0) * inverse;
 
                 let bit_constraint = match self.carry_idx {

--- a/prover/src/air/constraints_templates.rs
+++ b/prover/src/air/constraints_templates.rs
@@ -375,3 +375,46 @@ pub fn new_add_constraint(
         )),
     ]
 }
+
+/// Creates a pair of carry bit constraints for a complete 32-bit substraction operation.
+///
+/// This uses the same constraints than addition
+/// check that: lhs - rhs  = res is equivalent to: res + rhs = lhs
+///
+/// This helper function creates both constraints with sequential constraint indices.
+///
+/// ## Arguments
+/// * `flags_idx` - Column indices for instruction selector flags
+/// * `lhs_start_idx` - Starting column for left operand (requires 4 consecutive columns)
+/// * `rhs_start_idx` - Starting column for right operand (requires 4 consecutive columns)
+/// * `res_start_idx` - Starting column for result (requires 4 consecutive columns)
+/// * `constraint_idx_start` - Starting constraint index (will use idx and idx+1)
+///
+/// ## Returns
+/// A vector of two boxed constraints: [carry_0_constraint, carry_1_constraint]
+pub fn new_sub_constraint(
+    flags_idx: Vec<usize>,
+    lhs_start_idx: usize,
+    rhs_start_idx: usize,
+    res_start_idx: usize,
+    constraint_idx_start: usize,
+) -> Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>> {
+    vec![
+        Box::new(CarryBitConstraint::new(
+            CarryIndex::Zero,
+            flags_idx.clone(),
+            res_start_idx,
+            rhs_start_idx,
+            lhs_start_idx,
+            constraint_idx_start,
+        )),
+        Box::new(CarryBitConstraint::new(
+            CarryIndex::One,
+            flags_idx,
+            res_start_idx,
+            rhs_start_idx,
+            lhs_start_idx,
+            constraint_idx_start + 1,
+        )),
+    ]
+}

--- a/prover/src/air/constraints_templates.rs
+++ b/prover/src/air/constraints_templates.rs
@@ -334,7 +334,7 @@ impl TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField
 
 /// Creates a pair of carry bit constraints for a complete 32-bit addition operation.
 ///
-/// A full 32-bit addition with 8-bit limb decomposition requires validating two carry bits:
+/// A full 32-bit addition with 16-bit limb decomposition requires validating two carry bits:
 /// - Carry from the low word (bits 0-15)
 /// - Carry from the high word (bits 16-31)
 ///

--- a/prover/src/air/cpu_air.rs
+++ b/prover/src/air/cpu_air.rs
@@ -18,6 +18,11 @@ type FE = FieldElement<Babybear31PrimeField>;
 
 type CPUTraceTable = TraceTable<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>;
 
+/// AIR for the `CPU` trace.
+///
+/// Enforces two types of constraints:
+/// - **Bit constraints**: selected columns must be binary.
+/// - **32-bit add constraint** (limb-decomposed): enforces `lhs + rhs = res` when the ADD instruction is executed
 pub struct CPUTableAIR {
     context: AirContext,
     constraints:
@@ -37,15 +42,19 @@ impl AIR for CPUTableAIR {
         _pub_inputs: &Self::PublicInputs,
         proof_options: &ProofOptions,
     ) -> Self {
-        // Constraint IS_BIT[f[i]] where:
-        // f = [write_register, memory_2bytes, memory_4bytes, signed, signed2, muldiv_selector, ADD, SUB, SLT, AND, OR, XOR, SL, SR, JALR, BEQ, BLT, LOAD, STORE, MUL, DIVREM, ECALL, EBREAK]
+        // Bit constraints:
+        // Enforce that these columns are binary. They include:
+        // - decode flags like `write_register`, `signed`, `mp_selector`, `muldiv_selector`
+        // - the one-hot instruction flags (ADD, SUB, ..., EBREAK)
         let bit_columns_index_to_constraint = [
             7, 8, 9, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
         ];
         let bit_constraints = new_bit_constraints(&bit_columns_index_to_constraint, 0);
 
         let next_index = bit_columns_index_to_constraint.len();
-
+        // Add constraint
+        // Enforces that lhs (Word4L) + rhs (Word4L) = res (Word4L), with carry bits constrained.
+        // It is enforced only on rows where the selected instruction flags are active.
         let add_constraints = new_add_constraint(
             vec![15, 26, 27], // flags_idx,
             34,               // lhs_start_idx,
@@ -107,7 +116,7 @@ impl AIR for CPUTableAIR {
     }
 }
 
-// We assume that the columns have a power of two number of rows.
+// Assumption: the number of rows is a power of two
 pub fn build_cpu_trace(columns: Vec<Vec<FE>>) -> CPUTraceTable {
     TraceTable::from_columns_main(columns, 1)
 }

--- a/prover/src/air/cpu_air.rs
+++ b/prover/src/air/cpu_air.rs
@@ -1,0 +1,113 @@
+use crate::air::constraints_templates::{new_add_constraint, new_bit_constraints};
+
+use lambdaworks_math::field::{
+    element::FieldElement,
+    fields::fft_friendly::{
+        babybear_u32::Babybear31PrimeField, quartic_babybear_u32::Degree4BabyBearU32ExtensionField,
+    },
+};
+use stark_platinum_prover::{
+    constraints::{boundary::BoundaryConstraints, transition::TransitionConstraint},
+    context::AirContext,
+    proof::options::ProofOptions,
+    trace::TraceTable,
+    traits::AIR,
+};
+
+type FE = FieldElement<Babybear31PrimeField>;
+
+type CPUTraceTable = TraceTable<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>;
+
+pub struct CPUTableAIR {
+    context: AirContext,
+    constraints:
+        Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>>,
+    trace_length: usize,
+}
+
+impl AIR for CPUTableAIR {
+    type Field = Babybear31PrimeField;
+    type FieldExtension = Degree4BabyBearU32ExtensionField;
+    type PublicInputs = ();
+
+    const STEP_SIZE: usize = 1;
+
+    fn new(
+        trace_length: usize,
+        _pub_inputs: &Self::PublicInputs,
+        proof_options: &ProofOptions,
+    ) -> Self {
+        // Constraint IS_BIT[f[i]] where:
+        // f = [write_register, memory_2bytes, memory_4bytes, signed, signed2, muldiv_selector, ADD, SUB, SLT, AND, OR, XOR, SL, SR, JALR, BEQ, BLT, LOAD, STORE, MUL, DIVREM, ECALL, EBREAK]
+        let bit_columns_index_to_constraint = [
+            7, 8, 9, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+        let bit_constraints = new_bit_constraints(&bit_columns_index_to_constraint, 0);
+
+        let next_index = bit_columns_index_to_constraint.len();
+
+        let add_constraints = new_add_constraint(
+            vec![15, 26, 27], // flags_idx,
+            34,               // lhs_start_idx,
+            44,               // rhs_start_idx,
+            48,               // res_start_idx,
+            next_index,       // constraint_idx_start,
+        );
+
+        let mut constraints = bit_constraints;
+        constraints.extend(add_constraints);
+
+        let num_transition_constraints = constraints.len();
+
+        let context = AirContext {
+            proof_options: proof_options.clone(),
+            trace_columns: 54,
+            transition_offsets: vec![0],
+            num_transition_constraints,
+        };
+
+        Self {
+            context,
+            trace_length,
+            constraints,
+        }
+    }
+
+    fn transition_constraints(
+        &self,
+    ) -> &Vec<Box<dyn TransitionConstraint<Self::Field, Self::FieldExtension>>> {
+        &self.constraints
+    }
+
+    fn boundary_constraints(
+        &self,
+        _rap_challenges: &[FieldElement<Self::FieldExtension>],
+    ) -> BoundaryConstraints<Self::FieldExtension> {
+        BoundaryConstraints::from_constraints(vec![])
+    }
+
+    fn context(&self) -> &AirContext {
+        &self.context
+    }
+
+    fn composition_poly_degree_bound(&self) -> usize {
+        self.trace_length * 2
+    }
+
+    fn trace_length(&self) -> usize {
+        self.trace_length
+    }
+
+    fn trace_layout(&self) -> (usize, usize) {
+        (54, 0)
+    }
+
+    fn pub_inputs(&self) -> &Self::PublicInputs {
+        &()
+    }
+}
+
+// We assume that the columns have a power of two number of rows.
+pub fn build_cpu_trace(columns: Vec<Vec<FE>>) -> CPUTraceTable {
+    TraceTable::from_columns_main(columns, 1)
+}

--- a/prover/src/air/mod.rs
+++ b/prover/src/air/mod.rs
@@ -1,2 +1,2 @@
 pub mod constraints_templates;
-pub mod cpu_table;
+pub mod cpu_air;

--- a/prover/src/air/mod.rs
+++ b/prover/src/air/mod.rs
@@ -1,0 +1,2 @@
+pub mod constraints_templates;
+pub mod cpu_table;

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod air;
+pub mod tests;

--- a/prover/src/main.rs
+++ b/prover/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/prover/src/tests/cpu_table.rs
+++ b/prover/src/tests/cpu_table.rs
@@ -201,7 +201,7 @@ pub fn build_cpu_columns_example() -> Vec<Vec<FE>> {
         FE::from(&50u32),
         FE::from(&60u32),
         FE::from(&70u32),
-        FE::from(&80u32),
+        FE::from(&10u32),
     ];
     // Column index: 39
     let rv2_2 = vec![FE::zero(); 4];
@@ -221,7 +221,7 @@ pub fn build_cpu_columns_example() -> Vec<Vec<FE>> {
         FE::from(&60u32), // rv1 + rv2 = 10 + 50
         FE::from(&1u32),  // LOAD: copy a value from memory to `rd`.
         FE::zero(),
-        FE::from(&40u32), // rv2 - rv1 = 80 - 40
+        FE::from(&30u32), // rv1 - rv2 = 40 - 10
     ];
     // Column index: 43
     let rvd_2 = vec![FE::zero(); 4];
@@ -236,7 +236,7 @@ pub fn build_cpu_columns_example() -> Vec<Vec<FE>> {
         FE::from(&50),              // ADD -> rv2
         FE::one(),                  // LOAD -> imm
         FE::from(&((1 << 12) - 1)), // STORE -> imm
-        FE::from(&80),              // SUB -> rv2
+        FE::from(&10),              // SUB -> rv2
     ];
     // Column index: 45
     let arg2_2 = vec![FE::zero(); 4];
@@ -256,7 +256,7 @@ pub fn build_cpu_columns_example() -> Vec<Vec<FE>> {
         FE::from(&60u32),   // rv1 + rv2 = 10 + 50
         FE::from(&21u32),   // rv1 + imm = 20 + 1.
         FE::from(&4125u32), // rv1 + imm = 30 + 2^12 - 1 = 4125.
-        FE::from(&40u32),   // rv2 - rv1 = 80 - 40
+        FE::from(&30u32),   // rv2 - rv1 = 40 - 10 = 30
     ];
     // Column index: 49
     let res_2 = vec![FE::zero(); 4];

--- a/prover/src/tests/cpu_table.rs
+++ b/prover/src/tests/cpu_table.rs
@@ -1,0 +1,318 @@
+use lambdaworks_math::field::{
+    element::FieldElement, fields::fft_friendly::babybear_u32::Babybear31PrimeField,
+};
+
+type FE = FieldElement<Babybear31PrimeField>;
+
+// In this example we build a cpu table with four rows. Each row has the following instruction:
+// ADD, LOAD, STORE, SUB.
+// ADD: rv1 + rv2.
+// LOAD: Copy value from address `rs1 + imm` to `rsd`.
+// STORE: Copy rv2 to address `rs1 + imm`.
+// SUB: rv2 - rv1.
+pub fn build_cpu_columns_example() -> Vec<Vec<FE>> {
+    let mut columns = Vec::new();
+    // Timestamp: A word2L column containing the values 4 * i for i = 1,...
+    // Column index: 0
+    let timestamp_1 = vec![
+        FE::from(&4u32),
+        FE::from(&8u32),
+        FE::from(&12u32),
+        FE::from(&16u32),
+    ];
+    // Column index: 1
+    let timestamp_2 = vec![FE::zero(); 4];
+
+    columns.push(timestamp_1);
+    columns.push(timestamp_2);
+
+    // ----- 30 uncompressed decode columns -----
+
+    // Word2L pc.
+    // Column index: 2
+    let pc_1 = vec![
+        FE::from(&4u32),
+        FE::from(&8u32),
+        FE::from(&12u32),
+        FE::from(&16u32),
+    ];
+    // Column index: 3
+    let pc_2 = vec![FE::zero(); 4];
+
+    columns.push(pc_1);
+    columns.push(pc_2);
+
+    // Index of source register 1.
+    // Column index: 4
+    let rs_1 = vec![FE::from(&1), FE::from(&2), FE::from(&3), FE::from(&4)];
+    columns.push(rs_1);
+
+    // Index of source register 2.
+    // Column index: 5
+    let rs_2 = vec![FE::from(&5), FE::from(&6), FE::from(&7), FE::from(&8)];
+    columns.push(rs_2);
+
+    // Index of destination register.
+    // Column index: 6
+    let rd = vec![FE::from(&9), FE::from(&10), FE::from(&11), FE::from(&12)];
+    columns.push(rd);
+
+    // Flag: Whether the result should be written to `rd`.
+    // In our example:
+    // ADD and SUB write to `rd` (See Page 29).
+    // LOAD writes and STORE doesn't `rd` (See Page 34).
+    // https://docs.riscv.org/reference/isa/_attachments/riscv-unprivileged.pdf>
+    // Column index: 7
+    let write_register = vec![FE::one(), FE::one(), FE::zero(), FE::one()];
+    columns.push(write_register);
+
+    // Does the memory access (read or write) touch at least 2 bytes.
+    // Flag.
+    // Column index: 8
+    let memory_2_bytes = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(memory_2_bytes);
+
+    // Does the memory access (read or write) touch 4 bytes.
+    // Flag.
+    // Column index: 9
+    let memory_4_bytes = vec![FE::zero(), FE::zero(), FE::one(), FE::zero()];
+    columns.push(memory_4_bytes);
+
+    // The 32-bit version of the immediate.
+    // In the example:
+    // ADD and SUB between registers: No immedaite.
+    // LOAD and STORE: The address is obtained by adding rs1 to the sign-extended 12-bit offset immediate.
+    // Column index: 10
+    let imm_1 = vec![
+        FE::zero(),
+        FE::one(),
+        FE::from(&((1 << 12) - 1)),
+        FE::zero(),
+    ];
+    // Column index: 11
+    let imm_2 = vec![FE::zero(); 4];
+
+    columns.push(imm_1);
+    columns.push(imm_2);
+
+    // Flag to indicate signed or unsigned input interpretation.
+    // Column index: 12
+    let signed = vec![FE::zero(), FE::one(), FE::one(), FE::zero()];
+    columns.push(signed);
+
+    // Flag: multi-purpose selector used by different ALU operations for different purposes.
+    // In our example: Currently is not used for neither ADD, SUB, LOAD or STORE.
+    // Column index: 13
+    let mp_selector = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(mp_selector);
+
+    // Flag that selects which output of MUL (lo/hi) or DIV (quo/rem) is wanted.
+    // Column index: 14
+    let muldiv_selector = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(muldiv_selector);
+
+    // One-hot 17 columns of flags:
+    // Instructions in this example: add, load, store, sub.
+    // Column index: 15
+    let add = vec![FE::one(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(add);
+    // Column index: 16
+    let sub = vec![FE::zero(), FE::zero(), FE::zero(), FE::one()];
+    columns.push(sub);
+    // Column index: 17
+    let slt = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(slt);
+    // Column index: 18
+    let and = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(and);
+    // Column index: 19
+    let or = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(or);
+    // Column index: 20
+    let xor = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(xor);
+    // Column index: 21
+    let sl = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(sl);
+    // Column index: 22
+    let sr = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(sr);
+    // Column index: 23
+    let jalr = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(jalr);
+    // Column index: 24
+    let beq = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(beq);
+    // Column index: 25
+    let blt = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(blt);
+    // Column index: 26
+    let load = vec![FE::zero(), FE::one(), FE::zero(), FE::zero()];
+    columns.push(load);
+    // Column index: 27
+    let store = vec![FE::zero(), FE::zero(), FE::one(), FE::zero()];
+    columns.push(store);
+    // Column index: 28
+    let mul = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(mul);
+    // Column index: 29
+    let divrem = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(divrem);
+    // Column index: 30
+    let ecall = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(ecall);
+    // Column index: 31
+    let ebreak = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(ebreak);
+
+    // ----- End Decode Columns -----
+
+    // Column index: 32
+    let next_pc_1 = vec![FE::from(8), FE::from(12), FE::from(16), FE::from(20)];
+    // Column index: 333
+    let next_pc_2 = vec![FE::zero(); 4];
+
+    columns.push(next_pc_1);
+    columns.push(next_pc_2);
+
+    // rv1 Word4L
+    // Column index: 34
+    let rv1_1 = vec![
+        FE::from(&10u32),
+        FE::from(&20u32),
+        FE::from(&30u32),
+        FE::from(&40u32),
+    ];
+    // Column index: 35
+    let rv1_2 = vec![FE::zero(); 4];
+    // Column index: 36
+    let rv1_3 = vec![FE::zero(); 4];
+    // Column index: 37
+    let rv1_4 = vec![FE::zero(); 4];
+
+    columns.push(rv1_1);
+    columns.push(rv1_2);
+    columns.push(rv1_3);
+    columns.push(rv1_4);
+
+    // rv2 Word4L
+    // Column index: 38
+    let rv2_1 = vec![
+        FE::from(&50u32),
+        FE::from(&60u32),
+        FE::from(&70u32),
+        FE::from(&80u32),
+    ];
+    // Column index: 39
+    let rv2_2 = vec![FE::zero(); 4];
+    // Column index: 10
+    let rv2_3 = vec![FE::zero(); 4];
+    // Column index: 41
+    let rv2_4 = vec![FE::zero(); 4];
+
+    columns.push(rv2_1);
+    columns.push(rv2_2);
+    columns.push(rv2_3);
+    columns.push(rv2_4);
+
+    // rvd Word2L
+    // Column index: 42
+    let rvd_1 = vec![
+        FE::from(&60u32), // rv1 + rv2 = 10 + 50
+        FE::from(&1u32),  // LOAD: copy a value from memory to `rd`.
+        FE::zero(),
+        FE::from(&40u32), // rv2 - rv1 = 80 - 40
+    ];
+    // Column index: 43
+    let rvd_2 = vec![FE::zero(); 4];
+
+    columns.push(rvd_1);
+    columns.push(rvd_2);
+
+    // The second argument of the (ALU) operation being performed; a multiplex between rv2 and imm.
+    // Definition: (1 - STORE - LOAD)·rv2 + (1 - BEQ - BLT)·imm
+    // Column index: 44
+    let arg2_1 = vec![
+        FE::from(&50),              // ADD -> rv2
+        FE::one(),                  // LOAD -> imm
+        FE::from(&((1 << 12) - 1)), // STORE -> imm
+        FE::from(&80),              // SUB -> rv2
+    ];
+    // Column index: 45
+    let arg2_2 = vec![FE::zero(); 4];
+    // Column index: 46
+    let arg2_3 = vec![FE::zero(); 4];
+    // Column index: 47
+    let arg2_4 = vec![FE::zero(); 4];
+
+    columns.push(arg2_1);
+    columns.push(arg2_2);
+    columns.push(arg2_3);
+    columns.push(arg2_4);
+
+    // The word2L ALU result.
+    // Column index: 48
+    let res_1 = vec![
+        FE::from(&60u32),   // rv1 + rv2 = 10 + 50
+        FE::from(&21u32),   // rv1 + imm = 20 + 1.
+        FE::from(&4125u32), // rv1 + imm = 30 + 2^12 - 1 = 4125.
+        FE::from(&40u32),   // rv2 - rv1 = 80 - 40
+    ];
+    // Column index: 49
+    let res_2 = vec![FE::zero(); 4];
+    // Column index: 50
+    let res_3 = vec![FE::zero(); 4];
+    // Column index: 51
+    let res_4 = vec![FE::zero(); 4];
+
+    columns.push(res_1);
+    columns.push(res_2);
+    columns.push(res_3);
+    columns.push(res_4);
+
+    // Flag: Wether rv1 and arg2 are equal.
+    // Column index: 52
+    let is_equal = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(is_equal);
+
+    // Flag: Whether a branch is taken.
+    // Column index: 53
+    let branch_cond = vec![FE::zero(), FE::zero(), FE::zero(), FE::zero()];
+    columns.push(branch_cond);
+
+    columns
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::air::cpu_air::{CPUTableAIR, build_cpu_trace};
+    use lambdaworks_crypto::fiat_shamir::default_transcript::DefaultTranscript;
+    use lambdaworks_math::field::fields::fft_friendly::quartic_babybear_u32::Degree4BabyBearU32ExtensionField;
+    use stark_platinum_prover::{
+        proof::options::ProofOptions,
+        prover::{IsStarkProver, Prover},
+        verifier::{IsStarkVerifier, Verifier},
+    };
+    #[test]
+    fn test_prove_cpu_table() {
+        let columns = build_cpu_columns_example();
+        let mut trace = build_cpu_trace(columns);
+        let proof_options = ProofOptions::default_test_options();
+
+        let proof = Prover::<CPUTableAIR>::prove(
+            &mut trace,
+            &(),
+            &proof_options,
+            DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
+        )
+        .unwrap();
+
+        assert!(Verifier::<CPUTableAIR>::verify(
+            &proof,
+            &(),
+            &proof_options,
+            DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
+        ));
+    }
+}

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod cpu_table;


### PR DESCRIPTION
This PR adds:

- Basic structure for the prover workspace.

- A `constraints_template` module that provides helper functions for easily creating bit, add and sub constraints for the CPU table.

- The initial AIR definition for the CPU table, including the first bit, add  and sub constraints with their corresponding flags.

- Tests that build and verify a CPU table containing a few valid rows for ADD, LOAD,  STORE  and SUB instructions.