### PR TITLE
Improve concurrency queue

### DIFF
--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["**"]
 
+concurrency:
+  group: ${{ github.event_name == 'merge_group' && format('merge_group-{0}', github.event.merge_group.head_sha) || format('pull_request-{0}', github.event.pull_request.number) }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: write


### PR DESCRIPTION
Improve the concurrency of the branches, so if a branch gets two pushes, the previous job gets canceled