### PR TITLE
Add make command to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@ We are developing an open-source verifiable virtual machine that allows users to
 
 Right now, this is a project under development and experimentation and must not be used in production!
 
+## Getting Started
+
+### Dependencies
+
+- Rust 1.90.0
+- Risc-V toolchain (To run executor tests)
+
+### Setup executor
+
+```sh
+cd executor
+make deps
+```
+
+**Note:** At the moment, `make deps` only works on macOS.
+
+Then, you can check that the executor works by running:
+
+```sh
+make test
+```
+
 ## Design choices
 
 - The Instruction Set Architecture is RISCV64IM

--- a/executor/Makefile
+++ b/executor/Makefile
@@ -1,3 +1,5 @@
+UNAME := $(shell uname)
+
 ASM_PROGRAMS_DIR=./programs/asm
 ASM_ARTIFACTS_DIR=./program_artifacts/asm
 
@@ -57,3 +59,23 @@ test-rust: compile-programs-rust
 
 test-no-compile:
 	cargo test
+
+.PHONY: deps
+deps:
+ifeq ($(UNAME), Linux)
+deps: deps-linux
+endif
+ifeq ($(UNAME), Darwin)
+deps: deps-macos
+endif
+
+.PHONY: deps-linux
+deps-linux:
+	@# TODO
+	@echo "not yet implemented"
+	@exit 1
+
+.PHONY: deps-macos
+deps-macos:
+	brew tap riscv-software-src/riscv       
+	brew install riscv-software-src/riscv/riscv-gnu-toolchain


### PR DESCRIPTION
The make command only runs in macOS at the moment.
This PR also adds a Dependencies and Setup section to show that the user has to install the Risc-V toolchain to make tests to run successfully.