### PR TITLE
Remove panicking operations

### DIFF
--- a/executor/src/elf.rs
+++ b/executor/src/elf.rs
@@ -82,8 +82,15 @@ impl ElfProgram {
         let phentsize = ehdr.e_phentsize as usize;
         let phnum = ehdr.e_phnum as usize;
         for i in 0..phnum {
-            let offset = phoff + i * phentsize;
-            let phdr = ProgramHeader::parse(&input[offset..offset + phentsize])?;
+            let offset = phoff
+                .checked_add(i.checked_mul(phentsize).ok_or(ElfError::InvalidProgram)?)
+                .ok_or(ElfError::InvalidProgram)?;
+            let phdr = ProgramHeader::parse(
+                &input[offset
+                    ..offset
+                        .checked_add(phentsize)
+                        .ok_or(ElfError::InvalidProgram)?],
+            )?;
             phdrs.push(phdr);
         }
         Ok(phdrs)
@@ -214,6 +221,8 @@ pub enum ElfError {
     Casting,
     #[error("Program Header size is invalid")]
     ProgramHeaderSize,
+    #[error("Invalid program")]
+    InvalidProgram,
 }
 
 impl Elf {
@@ -250,11 +259,23 @@ impl Elf {
                     image.insert(addr, 0);
                 } else {
                     let mut word = 0;
-                    let len = (program_header.p_filesz - i).min(WORD_SIZE);
+                    let len = (program_header
+                        .p_filesz
+                        .checked_sub(i)
+                        .ok_or(ElfError::InvalidProgram)?)
+                    .min(WORD_SIZE);
                     for j in 0..len {
-                        let offset = (program_header.p_offset + i + j) as usize;
+                        let offset = (program_header
+                            .p_offset
+                            .checked_add(i)
+                            .ok_or(ElfError::InvalidProgram)?
+                            .checked_add(j)
+                            .ok_or(ElfError::InvalidProgram)?)
+                            as usize;
                         let byte = input.get(offset).ok_or(ElfError::InvalidOffset)?;
-                        word |= (*byte as u32) << (j * 8);
+                        word |= (*byte as u32)
+                            .checked_shl(j.checked_mul(8).ok_or(ElfError::InvalidProgram)?)
+                            .ok_or(ElfError::InvalidProgram)?;
                     }
                     image.insert(addr, word);
                 }

--- a/executor/src/vm/instruction/decoding.rs
+++ b/executor/src/vm/instruction/decoding.rs
@@ -313,7 +313,7 @@ fn parse_i_instruction(instruction: u32, opcode: Opcode) -> Result<Instruction, 
     let csr = (instruction >> 20) & I_TYPE_IMM_MASK;
     let imm = csr as i32;
     let mut imm: i32 = if (instruction & SIGN_MASK) != 0 {
-        imm - (1 << 11)
+        imm.wrapping_sub(1 << 11)
     } else {
         imm
     };
@@ -442,7 +442,7 @@ fn parse_b_instruction(instruction: u32, opcode: Opcode) -> Result<Instruction, 
         | ((instruction >> 7) & 0x1e)
         | ((instruction & 0x80) << 4)) as i32;
     let imm: i32 = if (instruction & SIGN_MASK) != 0 {
-        imm + 0xFFFFF000u32 as i32
+        imm.wrapping_add(0xFFFFF000u32 as i32)
     } else {
         imm
     };
@@ -475,7 +475,7 @@ fn parse_j_instruction(instruction: u32, opcode: Opcode) -> Result<Instruction, 
     let imm =
         instruction & 0xff000 | ((instruction & 0x100000) >> 9) | ((instruction >> 20) & 0x7fe);
     let imm: i32 = if (instruction & SIGN_MASK) != 0 {
-        imm as i32 - (1 << 20)
+        (imm as i32).wrapping_sub(1 << 20)
     } else {
         imm as i32
     };

--- a/executor/src/vm/instruction/execution.rs
+++ b/executor/src/vm/instruction/execution.rs
@@ -31,43 +31,43 @@ impl Instruction {
     ) -> Result<Log, ExecutionError> {
         Ok(match self {
             Instruction::ArithImm { dst, src, imm, op } => {
-                let op1 = registers.read(src) as i32;
+                let op1 = registers.read(src)? as i32;
                 if matches!(op, ArithOp::Sub) {
                     return Err(ExecutionError::SubImmNotSupported);
                 }
                 let res = op.apply(op1, imm) as u32;
-                registers.write(dst, res);
+                registers.write(dst, res)?;
                 Log {
                     instruction: self,
                     current_pc: pc,
-                    next_pc: pc + REGULAR_PC_UPDATE,
+                    next_pc: pc.wrapping_add(REGULAR_PC_UPDATE),
                     src1_val: op1 as u32,
                     src2_val: 0,
                     dst_val: res,
                 }
             }
             Instruction::JumpAndLinkRegister { dst, base, offset } => {
-                let base_value = registers.read(base);
-                let new_pc = ((base_value as i32 + offset) & !1) as u32;
-                registers.write(dst, pc + REGULAR_PC_UPDATE);
+                let base_value = registers.read(base)?;
+                let new_pc = (((base_value as i32).wrapping_add(offset)) & !1) as u32;
+                registers.write(dst, pc.wrapping_add(REGULAR_PC_UPDATE))?;
                 Log {
                     instruction: self,
                     current_pc: pc,
                     next_pc: new_pc,
                     src1_val: base_value,
                     src2_val: 0,
-                    dst_val: pc + REGULAR_PC_UPDATE,
+                    dst_val: pc.wrapping_add(REGULAR_PC_UPDATE),
                 }
             }
             Instruction::JumpAndLink { dst, offset } => {
-                registers.write(dst, pc + REGULAR_PC_UPDATE);
+                registers.write(dst, pc.wrapping_add(REGULAR_PC_UPDATE))?;
                 Log {
                     instruction: self,
                     current_pc: pc,
-                    next_pc: (pc as i32 + offset) as u32,
+                    next_pc: (pc as i32).wrapping_add(offset) as u32,
                     src1_val: 0,
                     src2_val: 0,
-                    dst_val: pc + REGULAR_PC_UPDATE,
+                    dst_val: pc.wrapping_add(REGULAR_PC_UPDATE),
                 }
             }
             Instruction::Store {
@@ -76,9 +76,9 @@ impl Instruction {
                 base,
                 width,
             } => {
-                let read_value = registers.read(src);
-                let base = registers.read(base);
-                let addr = base + offset;
+                let read_value = registers.read(src)?;
+                let base = registers.read(base)?;
+                let addr = base.wrapping_add(offset);
                 match width {
                     LoadStoreWidth::Byte => {
                         let value = read_value & 0xFF;
@@ -101,7 +101,7 @@ impl Instruction {
                 Log {
                     instruction: self,
                     current_pc: pc,
-                    next_pc: pc + REGULAR_PC_UPDATE,
+                    next_pc: pc.wrapping_add(REGULAR_PC_UPDATE),
                     src1_val: base,
                     src2_val: read_value,
                     dst_val: 0,
@@ -113,8 +113,8 @@ impl Instruction {
                 base,
                 width,
             } => {
-                let base = registers.read(base);
-                let addr = (base as i32 + offset) as u32;
+                let base = registers.read(base)?;
+                let addr = (base as i32).wrapping_add(offset) as u32;
                 let value = match width {
                     LoadStoreWidth::Byte => memory.load_byte(addr) as u32,
                     LoadStoreWidth::Half => memory.load_half(addr)? as u32,
@@ -122,11 +122,11 @@ impl Instruction {
                     LoadStoreWidth::ByteUnsigned => memory.load_byte(addr) as u32,
                     LoadStoreWidth::HalfUnsigned => memory.load_half(addr)? as u32,
                 };
-                registers.write(dst, value);
+                registers.write(dst, value)?;
                 Log {
                     instruction: self,
                     current_pc: pc,
-                    next_pc: pc + REGULAR_PC_UPDATE,
+                    next_pc: pc.wrapping_add(REGULAR_PC_UPDATE),
                     src1_val: base,
                     src2_val: 0,
                     dst_val: value,
@@ -138,11 +138,11 @@ impl Instruction {
                 cond,
                 offset,
             } => {
-                let (a, b) = (registers.read(src1), registers.read(src2));
+                let (a, b) = (registers.read(src1)?, registers.read(src2)?);
                 let new_pc = if cond.apply(a, b) {
-                    (pc as i32 + offset) as u32
+                    (pc as i32).wrapping_add(offset) as u32
                 } else {
-                    pc + REGULAR_PC_UPDATE
+                    pc.wrapping_add(REGULAR_PC_UPDATE)
                 };
                 Log {
                     instruction: self,
@@ -154,18 +154,18 @@ impl Instruction {
                 }
             }
             Instruction::LoadUpperImm { dst, imm } => {
-                registers.write(dst, imm);
+                registers.write(dst, imm)?;
                 Log {
                     instruction: self,
                     current_pc: pc,
-                    next_pc: pc + REGULAR_PC_UPDATE,
+                    next_pc: pc.wrapping_add(REGULAR_PC_UPDATE),
                     src1_val: 0,
                     src2_val: 0,
                     dst_val: imm,
                 }
             }
             Instruction::AddUpperImmToPc { dst, imm } => {
-                registers.write(dst, pc.wrapping_add(imm));
+                registers.write(dst, pc.wrapping_add(imm))?;
                 Log {
                     instruction: self,
                     current_pc: pc,
@@ -181,14 +181,14 @@ impl Instruction {
                 src2,
                 op,
             } => {
-                let a = registers.read(src1);
-                let b = registers.read(src2);
+                let a = registers.read(src1)?;
+                let b = registers.read(src2)?;
                 let res = op.apply(a as i32, b as i32) as u32;
-                registers.write(dst, res);
+                registers.write(dst, res)?;
                 Log {
                     instruction: self,
                     current_pc: pc,
-                    next_pc: pc + REGULAR_PC_UPDATE,
+                    next_pc: pc.wrapping_add(REGULAR_PC_UPDATE),
                     src1_val: a,
                     src2_val: b,
                     dst_val: res,
@@ -204,7 +204,7 @@ impl Instruction {
                 Log {
                     instruction: self,
                     current_pc: pc,
-                    next_pc: pc + REGULAR_PC_UPDATE,
+                    next_pc: pc.wrapping_add(REGULAR_PC_UPDATE),
                     src1_val: 0,
                     src2_val: 0,
                     dst_val: 0,
@@ -222,15 +222,19 @@ impl ArithOp {
             ArithOp::Xor => a ^ b,
             ArithOp::Or => a | b,
             ArithOp::And => a & b,
-            ArithOp::ShiftLeftLogical => a << b,
-            ArithOp::ShiftRightLogical => ((a as u32) >> (b as u32)) as i32,
-            ArithOp::ShiftRightArith => a >> b,
+            ArithOp::ShiftLeftLogical => a.wrapping_shl(b as u32),
+            ArithOp::ShiftRightLogical => ((a as u32).wrapping_shr(b as u32)) as i32,
+            ArithOp::ShiftRightArith => a.wrapping_shr(b as u32),
             ArithOp::SetLessThan => (a < b) as i32,
             ArithOp::SetLessThanU => ((a as u32) < (b as u32)) as i32,
-            ArithOp::Mul => (a as i64 * b as i64) as i32,
-            ArithOp::MulHigh => (((a as i64) * (b as i64)) >> 32) as i32,
-            ArithOp::MulHighSignedUnsigned => ((a as i64 * (b as u32) as i64) >> 32) as i32,
-            ArithOp::MulHighUnsigned => (((a as u32) as u64 * (b as u32) as u64) >> 32) as i32,
+            ArithOp::Mul => ((a as i64).wrapping_mul(b as i64)) as i32,
+            ArithOp::MulHigh => (((a as i64).wrapping_mul(b as i64)) >> 32) as i32,
+            ArithOp::MulHighSignedUnsigned => {
+                (((a as i64).wrapping_mul(b as u32 as i64)) >> 32) as i32
+            }
+            ArithOp::MulHighUnsigned => {
+                ((((a as u32) as u64).wrapping_mul(b as u32 as u64)) >> 32) as i32
+            }
             ArithOp::Div => {
                 if b == 0 {
                     u32::MAX as i32
@@ -286,4 +290,6 @@ pub enum ExecutionError {
     StoreHalfUnsignedNotSupported,
     #[error("Memory error: {0}")]
     MemoryError(#[from] crate::vm::memory::MemoryError),
+    #[error("Register error: {0}")]
+    RegisterError(#[from] crate::vm::registers::RegisterError),
 }

--- a/executor/src/vm/registers.rs
+++ b/executor/src/vm/registers.rs
@@ -18,20 +18,27 @@ impl Default for Registers {
 
 impl Registers {
     /// Read the current value of the given register
-    pub fn read(&self, register: u32) -> u32 {
+    pub fn read(&self, register: u32) -> Result<u32, RegisterError> {
+        if register > 31 {
+            return Err(RegisterError::InvalidRegister(register));
+        }
         if register == 0 {
-            0
+            Ok(0)
         } else {
-            self.0[register as usize - 1]
+            Ok(self.0[register as usize - 1])
         }
     }
 
     /// Update the value of the given register
     /// Writes to register zero are a no-op
-    pub fn write(&mut self, register: u32, value: u32) {
+    pub fn write(&mut self, register: u32, value: u32) -> Result<(), RegisterError> {
+        if register > 31 {
+            return Err(RegisterError::InvalidRegister(register));
+        }
         if register != 0 {
             self.0[register as usize - 1] = value
         }
+        Ok(())
     }
 
     /// Read the return values (aka registers a0 & a1)
@@ -56,4 +63,10 @@ impl Display for Registers {
             .join(", ");
         writeln!(f, "[{}]", registers)
     }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum RegisterError {
+    #[error("Invalid register number: {0}")]
+    InvalidRegister(u32),
 }


### PR DESCRIPTION
This PR removes panicking operations + , - , * , /, >> and <<. And replaces then with the corresponding wrapping or checked option.

Closes #45 