### PR TITLE
feat(executor): add `--verbose` flag to cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,11 +100,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
 name = "cli"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "executor",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "cpufeatures"
@@ -151,6 +248,18 @@ name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -265,6 +374,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ppv-lite86"
@@ -458,6 +573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +626,12 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -567,6 +694,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/bin/cli/Cargo.toml
+++ b/bin/cli/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 executor = { path = "../../executor" }
+clap = { version = "4.3.10", features = ["derive"] }

--- a/bin/cli/README.md
+++ b/bin/cli/README.md
@@ -6,4 +6,6 @@ Usage:
 ```bash
     cargo run --bin cli COMPILED_PROGRAM_ELF
 ```
- You can supply any compiled elf file, you can find some at `executor/program_artifacts`
+ You can supply any compiled elf file, you can find some at `executor/program_artifacts`.
+
+You may also add the flag `--verbose` to print out the register values before each step and the instruction to be executed.

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -1,11 +1,22 @@
+use std::path::PathBuf;
+
+use clap::{Parser, ValueHint};
 use executor::{elf::Elf, vm::execution::run_program};
 
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[arg(value_parser, value_hint=ValueHint::FilePath)]
+    filename: PathBuf,
+    #[arg(long = "verbose", value_parser)]
+    verbose: bool,
+}
+
 fn main() {
-    let mut args = std::env::args();
-    let elf_filename = args.nth(1).expect("No filename given");
-    let elf_data = std::fs::read(elf_filename).expect("Failed to read elf file");
+    let args = Args::parse_from(std::env::args());
+    let elf_data = std::fs::read(args.filename).expect("Failed to read elf file");
     let program = Elf::load(&elf_data).expect("Failed to load elf program");
-    let (_, _logs) =
-        run_program(program.image, program.entry_point).expect("Failed to run program");
+    let (_, _logs) = run_program(program.image, program.entry_point, args.verbose)
+        .expect("Failed to run program");
     // TODO: Prove program execution using logs
 }

--- a/executor/src/main.rs
+++ b/executor/src/main.rs
@@ -11,6 +11,6 @@ fn main() -> Result<(), ExecutorError> {
     program.image.iter().for_each(|(addr, word)| {
         println!("0x{addr:08x}: 0x{word:08x}");
     });
-    run_program(program.image, program.entry_point)?;
+    run_program(program.image, program.entry_point, true)?;
     Ok(())
 }

--- a/executor/src/vm/execution.rs
+++ b/executor/src/vm/execution.rs
@@ -13,10 +13,11 @@ use crate::vm::{
 pub fn run_program(
     instruction_map: BTreeMap<u32, u32>,
     entrypoint: u32,
+    verbose: bool,
 ) -> Result<((i32, i32), Vec<Log>), ExecutorError> {
     let mut memory = Memory::default();
     load_program(instruction_map, &mut memory)?;
-    run_from_entrypoint(&mut memory, entrypoint)
+    run_from_entrypoint(&mut memory, entrypoint, verbose)
 }
 
 fn load_program(
@@ -32,6 +33,7 @@ fn load_program(
 fn run_from_entrypoint(
     memory: &mut Memory,
     entrypoint: u32,
+    verbose: bool,
 ) -> Result<((i32, i32), Vec<Log>), ExecutorError> {
     let mut pc = entrypoint;
     let mut registers = Registers::default();
@@ -39,6 +41,10 @@ fn run_from_entrypoint(
     while pc != 0 {
         let next_instruction = memory.load_word(pc)?;
         let instruction = Instruction::parse(next_instruction)?;
+        if verbose {
+            println!("registers: {}", &registers);
+            println!("Executing instruction at 0x{:08x}: {:?}", pc, instruction);
+        }
         let log = instruction.run(&mut pc, &mut registers, memory)?;
         logs.push(log);
     }

--- a/executor/src/vm/instruction/execution.rs
+++ b/executor/src/vm/instruction/execution.rs
@@ -15,8 +15,6 @@ impl Instruction {
         registers: &mut Registers,
         memory: &mut Memory,
     ) -> Result<Log, ExecutionError> {
-        println!("registers: {}", &registers);
-        println!("Executing instruction at 0x{:08x}: {:?}", *pc, self);
         let log = self.execute(*pc, registers, memory)?;
         *pc = log.next_pc;
         Ok(log)

--- a/executor/tests/asm.rs
+++ b/executor/tests/asm.rs
@@ -9,7 +9,7 @@ fn run_program_and_check_output(elf_path: &str, expected_output: i32) {
         println!("0x{:08x}: 0x{:08x}", addr, word);
     });
     let (results, _logs) =
-        run_program(program.image, program.entry_point).expect("Failed to run program");
+        run_program(program.image, program.entry_point, true).expect("Failed to run program");
 
     assert!(results.0 == expected_output);
 }

--- a/executor/tests/rust.rs
+++ b/executor/tests/rust.rs
@@ -10,7 +10,7 @@ fn run_program_and_check_output(elf_path: &str, expected_output: i32) {
     });
 
     let (results, _logs) =
-        run_program(program.image, program.entry_point).expect("Failed to run program");
+        run_program(program.image, program.entry_point, true).expect("Failed to run program");
 
     assert!(results.0 == expected_output);
 }


### PR DESCRIPTION
The benchmark workflow is currently taking a very long time (40minutes) to run on main branch as the constant printing makes it very slow. This PR aims to fix this by adding a `--verbose` flag so that we can choose if we want to see the prints or not.