### PR TITLE
feat: Add mul/div instructions to CPU decoder

### DIFF
--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -101,7 +101,42 @@ impl CpuTableRow {
                         row.signed = FE::one();
                     }
                     ArithOp::SetLessThanU => row.slt = FE::one(),
-                    _ => todo!(),
+                    ArithOp::Mul => {
+                        row.mul = FE::one();
+                        row.mp_selector = FE::one();
+                        row.signed = FE::one();
+                    }
+                    ArithOp::MulHigh => {
+                        row.mul = FE::one();
+                        row.muldiv_selector = FE::one();
+                        row.signed = FE::one();
+                    }
+                    ArithOp::MulHighSignedUnsigned => {
+                        row.mul = FE::one();
+                        row.muldiv_selector = FE::one();
+                        row.mp_selector = FE::one();
+                        row.signed = FE::one();
+                    }
+                    ArithOp::MulHighUnsigned => {
+                        row.mul = FE::one();
+                        row.muldiv_selector = FE::one();
+                    }
+                    ArithOp::Div => {
+                        row.divrem = FE::one();
+                        row.signed = FE::one();
+                    }
+                    ArithOp::DivUnsigned => {
+                        row.divrem = FE::one();
+                    }
+                    ArithOp::Remainder => {
+                        row.divrem = FE::one();
+                        row.muldiv_selector = FE::one();
+                        row.signed = FE::one();
+                    }
+                    ArithOp::RemainderUnsigned => {
+                        row.divrem = FE::one();
+                        row.muldiv_selector = FE::one();
+                    }
                 }
             }
 

--- a/prover/src/tests/integration_tests.rs
+++ b/prover/src/tests/integration_tests.rs
@@ -53,10 +53,10 @@ mod tests {
         run_program_and_prover("../executor/program_artifacts/rust/if.elf");
     }
 
-    // #[test]
-    // fn test_fibonacci() {
-    //     run_program_and_prover("../executor/program_artifacts/rust/fibonacci.elf");
-    // }
+    #[test]
+    fn test_fibonacci() {
+        run_program_and_prover("../executor/program_artifacts/rust/fibonacci.elf");
+    }
 
     #[test]
     fn test_fibonacci_iterative() {
@@ -83,8 +83,8 @@ mod tests {
         run_program_and_prover("../executor/program_artifacts/rust/half_signed.elf");
     }
 
-    // #[test]
-    // fn test_rlp() {
-    //     run_program_and_prover("../executor/program_artifacts/rust/rlp.elf");
-    // }
+    #[test]
+    fn test_rlp() {
+        run_program_and_prover("../executor/program_artifacts/rust/rlp.elf");
+    }
 }


### PR DESCRIPTION
Add instruction AIR decoder for:

- Mul
- MulHigh
- MulHighSignedUnsigned
- MulHighUnsigned
- Div
- DivUnsigned
- Remainder
- RemainderUnsigned

Add integration tests for RLP and recursive Fibonacci.