### PR TITLE
spec: Fix some chip rendering pain points

### DIFF
--- a/spec/book.typ
+++ b/spec/book.typ
@@ -19,3 +19,4 @@
   *TODO #if name != none { [(#name)] }*: #body
 ]
 #let rj = todo.with(background: teal, name: "Robin")
+#let et = todo.with(background: rgb("d4aa3a"), name: "Erik")

--- a/spec/book.typ
+++ b/spec/book.typ
@@ -13,3 +13,9 @@
 // re-export page template
 #import "/templates/page.typ": project
 #let book-page = project
+
+#let todo(background: white, foreground: black, name: none, body) = block(fill: background, outset: 0.5em, radius: 20%, stroke: black)[
+  #set text(fill: foreground)
+  *TODO #if name != none { [(#name)] }*: #body
+]
+#let rj = todo.with(background: teal, name: "Robin")

--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -43,9 +43,11 @@
   ), caption: [Column overview of #chip.name chip.])
 }
 
-#let cref(constraint) = {
+#let cref(constraint, body) = {
   if "ref" in constraint {
-    label(constraint.ref)
+    [#body#label(constraint.ref)]
+  } else {
+    body
   }
 }
 
@@ -69,7 +71,7 @@
     let index = if "range" in assumption { "." + assumption.range.at(0) } else { "" }
     let lbl = [#chip.name\-A]
     show figure: (it) => align(left, block[#lbl#context it.counter.display()#index])
-    [#figure(kind: "assumption", numbering: (i) => [#lbl#i#index], supplement: [], [])#cref(assumption)]
+    cref(assumption)[#figure(kind: "assumption", numbering: (i) => [#lbl#i#index], supplement: [], [])]
   }
 
   figure(table(
@@ -102,7 +104,7 @@
     let prefix = if "prefix" in group { group.prefix }
     let lbl = [#chip.name\-C#prefix]
     show figure: (it) => align(left, block[#lbl#context it.counter.display()#index])
-    [#figure(kind: "constraint", numbering: (i) => [#lbl#i#index], supplement: [], [])#cref(constraint)]
+    cref(constraint)[#figure(kind: "constraint", numbering: (i) => [#lbl#i#index], supplement: [], [])]
   }
 
   /// Generates a representation of `constraint`
@@ -112,7 +114,7 @@
     if kind == "interaction" {
       raw(constraint.tag) + `[` + args_interaction_like(constraint.input, constraint.at("output", default: none)) + `]`
     } else if kind == "arith" {
-      [#eval(constraint.constraint)]
+      [#eval(constraint.constraint, mode: "markup")]
     } else if kind == "template" {
       raw(constraint.tag) + `<` + args_interaction_like(constraint.input, constraint.at("output", default: none)) + `>`
     } else {
@@ -120,9 +122,14 @@
     }
   }
 
-  // Whether constraints has polynomial constraints
+  // Whether constraint has polynomial constraints
   let has_polynomial_constraints(constraint) = {
-    constraint.at("kind") == "arith" and ("poly" in constraint or "polys" in constraint)
+    constraint.kind == "arith" and ("poly" in constraint or "polys" in constraint)
+  }
+
+  // Whether constraint has a "desc" field we need to render separately
+  let has_extra_description(constraint) = {
+    constraint.kind == "arith" and "desc" in constraint
   }
 
   // Rendering polynomial constraints
@@ -137,6 +144,11 @@
     (..for poly in polys {
       ([_polynomial constraint_], [], $#expr_to_math(poly) = 0$, [])
     },)
+  }
+
+  // Rendering the additional "desc" field for arith constraints
+  let render_extra_description(constraint) = {
+    ([_description_], [], eval(constraint.desc, mode: "markup"), [])
   }
 
   figure(table(
@@ -154,6 +166,9 @@
           [#repr_constraint(constraint)],
           [#expr_to_math(constraint.at("multiplicity", default: ""))],
         )
+        if has_extra_description(constraint) {
+          render_extra_description(constraint)
+        }
         if has_polynomial_constraints(constraint) {
           render_polynomial_constraints(constraint)
         }

--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -20,6 +20,7 @@
 /// Generates a table listing `chip`'s columns.
 #let render_chip_column_table(chip, config) = {
   // Group variables by category
+  show figure: set block(breakable: true)
   figure(table(
     columns: (auto, auto, 1fr),
     inset: 6pt,
@@ -98,6 +99,9 @@
   }
   assert(groups.all(group => group in all_groups), message: "unknown group")
 
+  // Find the group definition in the constraint_groups
+  let lookup_group(name) = chip.constraint_groups.filter((g) => g.name == name).at(0, default: (name: name))
+
   /// Render the contraint's tag.
   let tag(constraint, group) = {
     let index = if "range" in constraint { "." + constraint.range.at(0) } else { "" }
@@ -116,7 +120,10 @@
     } else if kind == "arith" {
       [#eval(constraint.constraint, mode: "markup")]
     } else if kind == "template" {
-      raw(constraint.tag) + `<` + args_interaction_like(constraint.input, constraint.at("output", default: none)) + `>`
+      let cond = if "cond" in constraint {
+        $#expr_to_math(constraint.cond) arrow.r.double$ + " "
+      }
+      cond + raw(constraint.tag) + `<` + args_interaction_like(constraint.input, constraint.at("output", default: none)) + `>`
     } else {
       assert(false, message: "illegal constraint format: " + kind)
     }
@@ -151,6 +158,7 @@
     ([_description_], [], eval(constraint.desc, mode: "markup"), [])
   }
 
+  show figure: set block(breakable: true)
   figure(table(
     columns: (auto, auto, 1fr, auto),
     inset: 6pt,
@@ -161,7 +169,7 @@
     ..for group in groups {
       for constraint in chip.constraints.at(group) {
         (
-          [#tag(constraint, group)],
+          [#tag(constraint, lookup_group(group))],
           [#interval(constraint)],
           [#repr_constraint(constraint)],
           [#expr_to_math(constraint.at("multiplicity", default: ""))],

--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -44,9 +44,9 @@
   ), caption: [Column overview of #chip.name chip.])
 }
 
-#let cref(constraint, body) = {
-  if "ref" in constraint {
-    [#body#label(constraint.ref)]
+#let cref(obj, body) = {
+  if "ref" in obj {
+    [#body#label(obj.ref)]
   } else {
     body
   }

--- a/spec/expr.typ
+++ b/spec/expr.typ
@@ -40,8 +40,8 @@
     } else if type(expr) == int {
       num(expr)
     } else if type(expr) == array {
-      (dict.at(expr.at(0), default: (e) => {
-        assert(false, "Invalid expression: " + repr(e))
+      (dict.at(expr.at(0), default: (pp, rec, e) => {
+        assert(false, message: "Invalid expression: " + repr(e))
       }))(pp, res, expr)
     }
   }


### PR DESCRIPTION
This fixes the following pain points:
- Assumptions and constraints requiring a `ref` for rendering to succeed
- The `desc` field of `arith` constraints not being rendered
- The `constraint` field of an `arith` constraint using eval in code mode
- Long tables (columns and constraints) didn't break across pages
- Template constraints did not have conditions rendered
- Constraint groups didn't get the proper prefix if specified
- The default branch of expression rendering has missing arguments

It also introduces a nice visual todo macro