### PR TITLE
spec: Fix cast operator precedence and allow description fields on any kind of constraint

### DIFF
--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -143,7 +143,7 @@
 
   // Whether constraint has a "desc" field we need to render separately
   let has_extra_description(constraint) = {
-    constraint.kind == "arith" and "desc" in constraint
+    "desc" in constraint
   }
 
   // Rendering polynomial constraints

--- a/spec/expr.typ
+++ b/spec/expr.typ
@@ -48,13 +48,13 @@
   "MIN": -1, // <the most secret heart of any expression>
   "pow": 0,  // ^
   "neg": 1,  // Unary -
-  "mul": 2,  // *
-  "div": 3,  // /
-  "not": 4,  // not
-  "add": 5,  // +
-  "sub": 6,  // -
-  "idx": 7,  // []
-  "cast": 8, // cast
+  "cast": 2, // cast
+  "mul": 3,  // *
+  "div": 4,  // /
+  "not": 5,  // not
+  "add": 6,  // +
+  "sub": 7,  // -
+  "idx": 8,  // []
   "eq": 9,   // =
   "MAX": 10, // <the void outside every expression>
 )


### PR DESCRIPTION
(I'll merge this manually to have these as separate commits on spec/main)