### PR TITLE
spec: improve definitions

### DIFF
--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -31,12 +31,11 @@
   let render_def_range(idx, range) = {
     if type(range) == array {
       if range.len() == 1 {
-      [#raw(idx) `=` #range.at(0)]
-      }
-      if range.len() == 2 {
+        [#raw(idx) `=` #range.at(0)]
+      } else if range.len() == 2 {
         [#raw(idx) #sym.in `[`#range.at(0)`,`#range.at(1)`]`]
       } else {
-        assert(false, message: "invalid range: " + repr(range))
+        assert(false, message: "invalid range: " + repr(range) + repr(range.len()))
       }
     } else {
       [#raw(idx) `=` #range]

--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -44,12 +44,12 @@
   }
 
   // Render definition `def`
-  let render_definition(def) = {
+  let render_definition(def, var_name) = {
     if type(def) == dictionary {
       (
         [],
         table.cell(align: right, emph[definition]), 
-        expr_to_math((":=", ("idx", var.name, def.idx), def.poly)),
+        expr_to_math((":=", ("idx", var_name, def.idx), def.poly)),
         render_def_range(def.idx, def.range)
       )
     } else {
@@ -63,7 +63,7 @@
 
   // Render definition `defs`
   // It is assumed that `defs` has several entries.
-  let render_indexed_definitions(var_name, defs) = {
+  let render_indexed_definitions(defs, var_name) = {
     (
       [],
       table.cell(align: right, emph[definition]), 
@@ -97,13 +97,13 @@
           table.cell(colspan: 2, [#eval(var.desc, mode: "markup")])
         )
         if "polys" in var {
-          render_indexed_definitions(var.polys)
+          render_indexed_definitions(var.polys, var.name)
         }
         if "poly" in var {
-          render_definition(var.poly)
+          render_definition(var.poly, var.name)
         }
       }
-      (table.cell(colspan: 4, []))
+      (table.cell(colspan: 4, []), )
     },
   ), caption: [Column overview of #chip.name chip.])
 }

--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -44,37 +44,39 @@
 
   // Render definition `def`
   let render_definition(def, var_name) = {
-    if type(def) == dictionary {
+    if type(def) in (array, str) {
+      return (
+        [],
+        table.cell(align: right, emph[definition]), 
+        table.cell(colspan: 2, expr_to_math(def))
+      )
+    }
+
+    assert(type(def) == dictionary, message: "invalid definition: " + repr(def))
+
+    if "poly" in def {
       (
         [],
         table.cell(align: right, emph[definition]), 
         expr_to_math((":=", ("idx", var_name, def.idx), def.poly)),
         render_def_range(def.idx, def.range)
       )
-    } else {
+    } else if "polys" in def {
       (
         [],
         table.cell(align: right, emph[definition]), 
-        table.cell(colspan: 2, expr_to_math(def))
+        table.cell(colspan: 2, expr_to_math(("idx", var_name, def.idx)))
       )
-    }
-  }
-
-  // Render definition `defs`
-  // It is assumed that `defs` has several entries.
-  let render_indexed_definitions(defs, var_name) = {
-    (
-      [],
-      table.cell(align: right, emph[definition]), 
-      table.cell(colspan: 2, expr_to_math(("idx", var_name, defs.idx)))
-    )
-    for (i, def) in defs.polys.enumerate() {
-      (
-        [],
-        [],              
-        [#expr_to_math((":=", "  ", def.poly))],
-        [#render_def_range(defs.idx, def.range)], 
-      )
+      for (i, poly) in def.polys.enumerate() {
+        (
+          [],
+          [],              
+          expr_to_math((":=", "  ", poly.poly)),
+          render_def_range(def.idx, poly.range), 
+        )
+      }
+    } else {
+      assert(false, message: "invalid definition: " + repr(def))
     }
   }
 
@@ -95,9 +97,6 @@
           [#type_to_code(var.type)], 
           table.cell(colspan: 2, [#eval(var.desc, mode: "markup")])
         )
-        if "defs" in var {
-          render_indexed_definitions(var.defs, var.name)
-        }
         if "def" in var {
           render_definition(var.def, var.name)
         }

--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -26,27 +26,84 @@
 
 /// Generates a table listing `chip`'s columns.
 #let render_chip_column_table(chip, config) = {
+
+  // Render a definition's range
+  let render_def_range(idx, range) = {
+    if type(range) == array {
+      if range.len() == 1 {
+      [#raw(idx) `=` #range.at(0)]
+      }
+      if range.len() == 2 {
+        [#raw(idx) #sym.in `[`#range.at(0)`,`#range.at(1)`]`]
+      } else {
+        assert(false, message: "invalid range: " + repr(range))
+      }
+    } else {
+      [#raw(idx) `=` #range]
+    }
+  }
+
+  // Render definition `def`
+  let render_definition(def) = {
+    if type(def) == dictionary {
+      (
+        [],
+        table.cell(align: right, emph[definition]), 
+        expr_to_math((":=", ("idx", var.name, def.idx), def.poly)),
+        render_def_range(def.idx, def.range)
+      )
+    } else {
+      (
+        [],
+        table.cell(align: right, emph[definition]), 
+        table.cell(colspan: 2, expr_to_math(def))
+      )
+    }
+  }
+
+  // Render definition `defs`
+  // It is assumed that `defs` has several entries.
+  let render_indexed_definitions(var_name, defs) = {
+    (
+      [],
+      table.cell(align: right, emph[definition]), 
+      table.cell(colspan: 2, expr_to_math(("idx", var_name, defs.idx)))
+    )
+    for (i, def) in defs.entries.enumerate() {
+      (
+        [],
+        [],              
+        [#expr_to_math((":=", "  ", def.poly))],
+        [#render_def_range(defs.idx, def.range)], 
+      )
+    }
+  }
+
   // Group variables by category
   show figure: set block(breakable: true)
   figure(table(
-    columns: (auto, auto, 1fr),
+    columns: (auto, auto, 1fr, auto),
     inset: 6pt,
     align: left + top,
     stroke: none,
-    table.header([*Label*], [*Type*], [*Description*]),
+    table.header([*Label*], [*Type*], table.cell(colspan: 2, [*Description*])),
     table.hline(stroke: stroke(thickness: 2pt)),
     ..for (cat, vars) in chip.variables.pairs() {
-      ([#emph(cat)], [], [], table.hline(stroke: .6pt))
+      (table.cell(colspan: 4, emph(cat)), table.hline(stroke: .6pt))
       for var in vars {
-        ([#raw(var.name)], [#type_to_code(var.type)], [#eval(var.desc, mode: "markup")])
-        for (i, poly) in var.at("polys", default: ()).enumerate() {
-          (if i == 0 { emph[def] }, [], expr_to_math(("=", ("idx", var.name, i), poly)))
+        (
+          [#raw(var.name)], 
+          [#type_to_code(var.type)], 
+          table.cell(colspan: 2, [#eval(var.desc, mode: "markup")])
+        )
+        if "polys" in var {
+          render_indexed_definitions(var.polys)
         }
         if "poly" in var {
-          (emph[def], [], expr_to_math(var.poly))
+          render_definition(var.poly)
         }
       }
-      ([], [], [])
+      (table.cell(colspan: 4, []))
     },
   ), caption: [Column overview of #chip.name chip.])
 }

--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -68,7 +68,7 @@
       table.cell(align: right, emph[definition]), 
       table.cell(colspan: 2, expr_to_math(("idx", var_name, defs.idx)))
     )
-    for (i, def) in defs.entries.enumerate() {
+    for (i, def) in defs.polys.enumerate() {
       (
         [],
         [],              
@@ -95,11 +95,11 @@
           [#type_to_code(var.type)], 
           table.cell(colspan: 2, [#eval(var.desc, mode: "markup")])
         )
-        if "polys" in var {
-          render_indexed_definitions(var.polys, var.name)
+        if "defs" in var {
+          render_indexed_definitions(var.defs, var.name)
         }
-        if "poly" in var {
-          render_definition(var.poly, var.name)
+        if "def" in var {
+          render_definition(var.def, var.name)
         }
       }
       (table.cell(colspan: 4, []), )

--- a/spec/expr.typ
+++ b/spec/expr.typ
@@ -55,7 +55,7 @@
   "add": 6,  // +
   "sub": 7,  // -
   "idx": 8,  // []
-  "eq": 9,   // = and :-
+  "eq": 9,   // = and :=
   "MAX": 10, // <the void outside every expression>
 )
 

--- a/spec/expr.typ
+++ b/spec/expr.typ
@@ -55,7 +55,7 @@
   "sub": 6,  // -
   "idx": 7,  // []
   "cast": 8, // cast
-  "eq": 9,   // =
+  "eq": 9,   // = and :=
   "MAX": 10, // <the void outside every expression>
 )
 
@@ -100,6 +100,7 @@
       rec(PREC.pow, e.at(1)) + `^` + rec(PREC.pow, e.at(2))
     },
     "=": (pp, rec, e) => rec(PREC.eq, e.at(1)) + ` = ` + rec(PREC.eq, e.at(2)),
+    ":=": (pp, rec, e) => rec(PREC.eq, e.at(1)) + ` := ` + rec(PREC.eq, e.at(2)),
     "-": (pp, rec, e) => {
       if e.len() == 2 {
         // Negation
@@ -138,6 +139,7 @@
       $#e.at(1)^#e.at(2)$
     },
     "=": (pp, rec, e) => $#rec(PREC.eq, e.at(1)) = #rec(PREC.eq, e.at(2))$,
+    ":=": (pp, rec, e) => $#rec(PREC.eq, e.at(1)) := #rec(PREC.eq, e.at(2))$,
     "-": (pp, rec, e) => {
       if e.len() == 2 {
         // Negation

--- a/spec/src.typ
+++ b/spec/src.typ
@@ -38,15 +38,16 @@
     assert(category in config.variables.categories.all)
   }
 
-  // Check that either `poly` or `polys` is set, but not both
-  let all_vars = chip.variables.values().flatten()
-  for var in all_vars {
+  // Check that `def` is only contained in `virtual` variables
+  let non_virtual_vars = chip.variables.pairs().filter(x => x.first() != "virtual").map(x => x.last()).flatten();
+  for var in non_virtual_vars {
     assert(
-      "poly" not in var or "polys" not in var, 
-      message: "both 'poly' and 'polys' defined defined for " + repr(var.name)
+      "def" not in var,
+      message: "illegal `def` in non-virtual var: " + repr(var.name)
     )
   }
 
+  let all_vars = chip.variables.values().flatten()
   let all_labels = config.variables.types.map(type => type.label);
   for var in all_vars {
     let type_label = if type(var.type) == array {

--- a/spec/src.typ
+++ b/spec/src.typ
@@ -38,8 +38,17 @@
     assert(category in config.variables.categories.all)
   }
 
+  // Check that either `poly` or `polys` is set, but not both
+  let all_vars = chip.variables.values().flatten()
+  for var in all_vars {
+    assert(
+      "poly" not in var or "polys" not in var, 
+      message: "both 'poly' and 'polys' defined defined for " + repr(var.name)
+    )
+  }
+
   let all_labels = config.variables.types.map(type => type.label);
-  for var in chip.variables.values().flatten() {
+  for var in all_vars {
     let type_label = if type(var.type) == array {
       var.type.at(0)
     } else {


### PR DESCRIPTION
This
```
name = "TEST"

[[variables.auxiliary]]
name = "a"
type = "Bit"
desc = "hello"
poly = "hello"

[[variables.auxiliary]]
name = "b"
type = "Bit"
desc = "hello"
poly = ["*", "hello", 5]

[[variables.auxiliary]]
name = "c"
type = ["Byte", 4]
desc = "hello"
poly = {idx="i", range=[0, 4], poly="hello"}

[[variables.auxiliary]]
name = "d"
type = ["Half", 8]
desc = "nothing"
poly = {idx="k", range=[0, 7], poly=["*", "hello", "k"]}

[[variables.auxiliary]]
name = "eeby_deeby"
type = ["Half", 8]
desc = "nothing"
polys = {idx="j", entries=[
    {range=[0, 3], poly=["idx", "d", "j"]},
    {range=[4, 7], poly=["*", "a", ["idx", "c", ["-", "j", 4]]]},
    {range=[8], poly=["^", 2, 32]},
]}
```
now renders into this
<img width="707" height="521" alt="image" src="https://github.com/user-attachments/assets/665a8ec9-9e9d-4ec8-943b-8e0ab665620e" />
