### PR TITLE
spec: conditionally render constraint table headers

### DIFF
--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -160,6 +160,7 @@
     groups = (groups,)
   }
   assert(groups.all(group => group in all_groups), message: "unknown group")
+  let selected_constraints = chip.constraints.pairs().filter(p => p.first() in groups).map(p => p.last()).flatten();
 
   // Find the group definition in the constraint_groups
   let lookup_group(name) = chip.constraint_groups.filter((g) => g.name == name).at(0, default: (name: name))
@@ -220,13 +221,26 @@
     (table.cell(align: right, colspan: 2, [_description_]), eval(constraint.desc, mode: "markup"), [])
   }
 
+  // Whether there is at least one constraint with a range
+  // This can be used to see whether the "Range" label should be displayed
+  let do_display_range = selected_constraints.any(x => "range" in x)
+
+  // Whether there is at least one constraint with a multiplicity
+  // This can be used to see whether the "Multiplicity" label should be displayed
+  let do_display_multiplicity = selected_constraints.any(x => "multiplicity" in x)
+
   show figure: set block(breakable: true)
   figure(table(
     columns: (auto, auto, 1fr, auto),
     inset: 6pt,
     align: (top + left, top + left, top + left, top + center),
     stroke: none,
-    table.header([*Tag*], [*Range*], [*Description*], [*Multiplicity*]),
+    table.header(
+      [*Tag*], 
+      if do_display_range {[*Range*]} else {[]}, 
+      [*Description*], 
+      if do_display_multiplicity {[*Multiplicity*]} else {[]},
+    ),
     table.hline(stroke: stroke(thickness: 2pt)),
     ..for group in groups {
       for constraint in chip.constraints.at(group) {

--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -160,7 +160,7 @@
     groups = (groups,)
   }
   assert(groups.all(group => group in all_groups), message: "unknown group")
-  let selected_constraints = groups.map(g => chip.constraints.at(g)).flatten();
+  let selected_constraints = groups.map(g => (g: chip.constraints.at(g))).join()
 
   // Find the group definition in the constraint_groups
   let lookup_group(name) = chip.constraint_groups.filter((g) => g.name == name).at(0, default: (name: name))
@@ -223,11 +223,11 @@
 
   // Whether there is at least one constraint with a range
   // This can be used to see whether the "Range" label should be displayed
-  let do_display_range = selected_constraints.any(x => "range" in x)
+  let do_display_range = selected_constraints.values().flatten().any(x => "range" in x)
 
   // Whether there is at least one constraint with a multiplicity
   // This can be used to see whether the "Multiplicity" label should be displayed
-  let do_display_multiplicity = selected_constraints.any(x => "multiplicity" in x)
+  let do_display_multiplicity = selected_constraints.values().flatten().any(x => "multiplicity" in x)
 
   show figure: set block(breakable: true)
   figure(table(
@@ -242,8 +242,8 @@
       if do_display_multiplicity {[*Multiplicity*]} else {[]},
     ),
     table.hline(stroke: stroke(thickness: 2pt)),
-    ..for group in groups {
-      for constraint in chip.constraints.at(group) {
+    ..for (group, group_constraints) in selected_constraints.pairs() {
+      for constraint in group_constraints {
         (
           [#tag(constraint, lookup_group(group))],
           [#interval(constraint)],
@@ -257,6 +257,6 @@
           render_polynomial_constraints(constraint)
         }
       }
-    },
+    }
   ), caption: [Constraint overview of #chip.name chip.])
 }

--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -160,7 +160,7 @@
     groups = (groups,)
   }
   assert(groups.all(group => group in all_groups), message: "unknown group")
-  let selected_constraints = chip.constraints.pairs().filter(p => p.first() in groups).map(p => p.last()).flatten();
+  let selected_constraints = groups.map(g => chip.constraints.at(g)).flatten();
 
   // Find the group definition in the constraint_groups
   let lookup_group(name) = chip.constraint_groups.filter((g) => g.name == name).at(0, default: (name: name))


### PR DESCRIPTION
Only render the *range* and *multiplicity* headers when applicable:

Before:
<img width="597" height="216" alt="image" src="https://github.com/user-attachments/assets/3939b597-cb04-43ea-bf13-44079d6d50f7" />

After:
<img width="597" height="216" alt="image" src="https://github.com/user-attachments/assets/20c1736a-f49d-42cc-bdc8-4d40c57e82dc" />
