### PR TITLE
spec: do not print index in assumption/constraint ref

### DIFF
--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -134,7 +134,7 @@
     let index = if "range" in assumption { "." + assumption.range.at(0) } else { "" }
     let lbl = [#chip.name\-A]
     show figure: (it) => align(left, block[#lbl#context it.counter.display()#index])
-    cref(assumption)[#figure(kind: "assumption", numbering: (i) => [#lbl#i#index], supplement: [], [])]
+    cref(assumption)[#figure(kind: "assumption", numbering: (i) => [#lbl#i], supplement: [], [])]
   }
 
   figure(table(
@@ -170,7 +170,7 @@
     let prefix = if "prefix" in group { group.prefix }
     let lbl = [#chip.name\-C#prefix]
     show figure: (it) => align(left, block[#lbl#context it.counter.display()#index])
-    cref(constraint)[#figure(kind: "constraint", numbering: (i) => [#lbl#i#index], supplement: [], [])]
+    cref(constraint)[#figure(kind: "constraint", numbering: (i) => [#lbl#i], supplement: [], [])]
   }
 
   /// Generates a representation of `constraint`


### PR DESCRIPTION
Exclude the index from an assumption/constraints reference label, allowing for more natural referencing:

Before:
<img width="602" height="128" alt="image" src="https://github.com/user-attachments/assets/b5954bdd-d532-494c-8d23-839dacd7bb14" />

After:
<img width="602" height="128" alt="image" src="https://github.com/user-attachments/assets/9ddae2a4-c2b2-4d32-9e02-11ace2580668" />