### PR TITLE
feat(crypto/stark): allow multi-proving and multi-verifying

### DIFF
--- a/crypto/crypto/src/commitments/README.md
+++ b/crypto/crypto/src/commitments/README.md
@@ -78,15 +78,15 @@ KZG commitments can be used to commit to polynomials and later prove evaluations
 First, you need to load or create a Structured Reference String (SRS) and initialize the KZG instance:
 
 ```rust
-use lambdaworks_crypto::commitments::kzg::{KateZaveruchaGoldberg, StructuredReferenceString};
-use lambdaworks_crypto::commitments::traits::IsCommitmentScheme;
-use lambdaworks_math::elliptic_curve::short_weierstrass::curves::bls12_381::{
+use crypto::commitments::kzg::{KateZaveruchaGoldberg, StructuredReferenceString};
+use crypto::commitments::traits::IsCommitmentScheme;
+use math::elliptic_curve::short_weierstrass::curves::bls12_381::{
     curve::BLS12381Curve,
     default_types::{FrElement, FrField},
     pairing::BLS12381AtePairing,
     twist::BLS12381TwistCurve,
 };
-use lambdaworks_math::elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint;
+use math::elliptic_curve::short_weierstrass::point::ShortWeierstrassProjectivePoint;
 
 // Load SRS from a file
 let srs_file = "path/to/srs.bin";
@@ -101,8 +101,8 @@ let kzg = KateZaveruchaGoldberg::<FrField, BLS12381AtePairing>::new(srs);
 To commit to a polynomial, you first create the polynomial and then use the `commit` method:
 
 ```rust
-use lambdaworks_math::field::element::FieldElement;
-use lambdaworks_math::polynomial::Polynomial;
+use math::field::element::FieldElement;
+use math::polynomial::Polynomial;
 
 // Create a polynomial p(x) = x + 1
 let p = Polynomial::<FrElement>::new(&[FieldElement::one(), FieldElement::one()]);

--- a/crypto/crypto/src/fiat_shamir/default_transcript.rs
+++ b/crypto/crypto/src/fiat_shamir/default_transcript.rs
@@ -1,7 +1,11 @@
-use super::is_transcript::IsTranscript;
+use crate::fiat_shamir::is_transcript::{IsStarkTranscript, IsTranscript};
+
 use core::marker::PhantomData;
 use math::{
-    field::{element::FieldElement, traits::HasDefaultTranscript},
+    field::{
+        element::FieldElement,
+        traits::{HasDefaultTranscript, IsField, IsSubFieldOf},
+    },
     traits::ByteConversion,
 };
 use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
@@ -70,6 +74,15 @@ where
     fn sample_u64(&mut self, upper_bound: u64) -> u64 {
         u64::from_be_bytes(self.state()[..8].try_into().unwrap()) % upper_bound
     }
+}
+
+impl<F, S> IsStarkTranscript<F, S> for DefaultTranscript<F>
+where
+    F: HasDefaultTranscript,
+    FieldElement<F>: ByteConversion,
+    S: IsField + IsSubFieldOf<F>,
+{
+    // nothing to implement: sample_z_ood uses the default body
 }
 
 #[cfg(test)]

--- a/crypto/crypto/src/fiat_shamir/is_transcript.rs
+++ b/crypto/crypto/src/fiat_shamir/is_transcript.rs
@@ -1,9 +1,6 @@
-use math::{
-    field::{
-        element::FieldElement,
-        traits::{IsField, IsSubFieldOf},
-    },
-    traits::AsBytes,
+use math::field::{
+    element::FieldElement,
+    traits::{IsField, IsSubFieldOf},
 };
 
 /// The functionality of a transcript to be used in the STARK Prove and Verify protocols.
@@ -18,15 +15,15 @@ pub trait IsTranscript<F: IsField> {
     fn sample_field_element(&mut self) -> FieldElement<F>;
     /// Returns a random index between 0 and `upper_bound`.
     fn sample_u64(&mut self, upper_bound: u64) -> u64;
+}
+
+pub trait IsStarkTranscript<F: IsField, S: IsField + IsSubFieldOf<F>>: IsTranscript<F> {
     /// Returns a field element not contained in `lde_roots_of_unity_coset` or `trace_roots_of_unity`.
-    fn sample_z_ood<S: IsSubFieldOf<F>>(
+    fn sample_z_ood(
         &mut self,
         lde_roots_of_unity_coset: &[FieldElement<S>],
         trace_roots_of_unity: &[FieldElement<S>],
-    ) -> FieldElement<F>
-    where
-        FieldElement<F>: AsBytes,
-    {
+    ) -> FieldElement<F> {
         loop {
             let value: FieldElement<F> = self.sample_field_element();
             if !lde_roots_of_unity_coset

--- a/crypto/crypto/src/merkle_tree/README.md
+++ b/crypto/crypto/src/merkle_tree/README.md
@@ -46,11 +46,11 @@ The implementation in this codebase includes:
 Here's a basic example of creating a Merkle tree with field elements:
 
 ```rust
-use lambdaworks_crypto::merkle_tree::{
+use crypto::merkle_tree::{
     merkle::MerkleTree,
     backends::field_element::FieldElementBackend,
 };
-use lambdaworks_math::field::{
+use math::field::{
     element::FieldElement,
     fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
 };
@@ -72,12 +72,12 @@ let merkle_tree = MerkleTree::<FieldElementBackend<F, Keccak256, 32>>::build(&va
 The `BatchPoseidonTree` backend is specifically designed for efficient batch hashing using the Poseidon hash function, which is particularly useful in zero-knowledge proof systems. This backend provides optimized performance for vectors of field elements.
 
 ```rust
-use lambdaworks_crypto::merkle_tree::{
+use crypto::merkle_tree::{
     merkle::MerkleTree,
     backends::field_element_vector::BatchPoseidonTree,
 };
-use lambdaworks_crypto::hash::poseidon::starknet::PoseidonCairoStark252;
-use lambdaworks_math::field::{
+use crypto::hash::poseidon::starknet::PoseidonCairoStark252;
+use math::field::{
     element::FieldElement,
     fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
 };
@@ -149,11 +149,11 @@ assert!(is_valid, "Proof verification failed");
 If you need to hash vectors of field elements:
 
 ```rust
-use lambdaworks_crypto::merkle_tree::{
+use crypto::merkle_tree::{
     merkle::MerkleTree,
     backends::field_element_vector::FieldElementVectorBackend,
 };
-use lambdaworks_math::field::{
+use math::field::{
     element::FieldElement,
     fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
 };
@@ -192,12 +192,12 @@ Proofs can be serialized and deserialized for storage or transmission. Note that
 
 ```rust
 // This requires the 'alloc' feature to be enabled
-use lambdaworks_crypto::merkle_tree::{
+use crypto::merkle_tree::{
     merkle::MerkleTree,
     proof::Proof,
     // For testing, you might use a simpler backend like TestBackend
 };
-use lambdaworks_math::traits::{Deserializable, Serializable};
+use math::traits::{Deserializable, Serializable};
 
 // Serialize the proof
 let serialized_proof = proof.serialize();

--- a/crypto/math/src/circle/README.md
+++ b/crypto/math/src/circle/README.md
@@ -57,9 +57,9 @@ The CFFT algorithm uses what we called a Standard Coset. A Standard Coset is a C
 In `coset.rs` you will find our implementation for the Circle Group over the Mersenne-31 Prime Field. You can use it in the following way:
 
 ```rust
-use lambdaworks_math::circle::cosets::Coset;
-use lambdaworks_math::circle::point::CirclePoint;
-use lambdaworks_math::field::fields::mersenne31::field::Mersenne31Field;
+use math::circle::cosets::Coset;
+use math::circle::point::CirclePoint;
+use math::field::fields::mersenne31::field::Mersenne31Field;
 
 // Create a standard coset of size 2^k
 let log_2_size = 3; // k = 3, for a coset of size 8.
@@ -112,11 +112,11 @@ After the FFT:
 ### Working with Circle group points
 
 ```rust
-use lambdaworks_math::field::{
+use math::field::{
     element::FieldElement,
     fields::mersenne31::field::Mersenne31Field,
 };
-use lambdaworks_math::circle::point::CirclePoint;
+use math::circle::point::CirclePoint;
 
 // Create a valid point in the Circle group, i.e a point (x, y) 
 // that satisfies x^2 + y^2 = 1
@@ -138,11 +138,11 @@ let point4 = point1 * 8; // Scalar multiplication
 ### Polynomial evaluation and interpolation using CFFT
 
 ```rust
-use lambdaworks_math::field::{
+use math::field::{
     element::FieldElement,
     fields::mersenne31::field::Mersenne31Field,
 };
-use lambdaworks_math::circle::polynomial::{evaluate_cfft, interpolate_cfft};
+use math::circle::polynomial::{evaluate_cfft, interpolate_cfft};
 
 // Define polynomial coefficients
 let coefficients: Vec<FieldElement<Mersenne31Field>> = (0..8)
@@ -159,16 +159,16 @@ let recovered_coefficients = interpolate_cfft(evaluations);
 ### Using CFFT directly
 
 ```rust
-use lambdaworks_math::field::{
+use math::field::{
     element::FieldElement,
     fields::mersenne31::field::Mersenne31Field,
 };
-use lambdaworks_math::circle::{
+use math::circle::{
     cfft::{cfft, icfft},
     cosets::Coset,
     twiddles::{get_twiddles, TwiddlesConfig},
 };
-use lambdaworks_math::fft::cpu::bit_reversing::in_place_bit_reverse_permute;
+use math::fft::cpu::bit_reversing::in_place_bit_reverse_permute;
 
 // Prepare data (must be a power of 2 in length)
 let mut data: Vec<FieldElement<Mersenne31Field>> = (0..8)
@@ -202,4 +202,3 @@ icfft(&mut data, inverse_twiddles);
 - [Circle FFT Paper](https://eprint.iacr.org/2024/278)
 - [Anatomy of a STARK](https://aszepieniec.github.io/stark-anatomy/) - Detailed explanation of STARKs
 - [STARKs, Part I: Proofs with Polynomials](https://vitalik.ca/general/2017/11/09/starks_part_1.html) - Vitalik Buterin's series on STARKs
-

--- a/crypto/math/src/field/fields/binary/README.md
+++ b/crypto/math/src/field/fields/binary/README.md
@@ -76,7 +76,7 @@ The method `new` handles possible overflows in this way:
 - If the value input doesn't fit in the level given, then we take just the less significant bits that fit in that level and set it as the element's `value`.
 
 ```rust
-use lambdaworks_math::field::fields::binary::field::TowerFieldElement;
+use math::field::fields::binary::field::TowerFieldElement;
 
 // Create elements at different tower levels
 let element_level_0 = TowerFieldElement::new(1, 0);  // Element '1' in GF(2)
@@ -96,7 +96,7 @@ let from_u64 = TowerFieldElement::from(42u64);
 ### Basic Operations
 
 ```rust
-use lambdaworks_math::field::fields::binary::field::TowerFieldElement;
+use math::field::fields::binary::field::TowerFieldElement;
 
 // Create two elements
 let a = TowerFieldElement::new(5, 2);  // '0101' in GF(2^4)
@@ -122,7 +122,7 @@ let a_cubed = a.pow(3);
 ### Working with Different Levels
 
 ```rust
-use lambdaworks_math::field::fields::binary::field::TowerFieldElement;
+use math::field::fields::binary::field::TowerFieldElement;
 
 // Elements at different levels
 let a = TowerFieldElement::new(3, 1);  // Level 1: GF(2^2)

--- a/crypto/math/src/field/traits.rs
+++ b/crypto/math/src/field/traits.rs
@@ -99,7 +99,7 @@ pub trait IsFFTField: IsField {
 pub trait IsField: Debug + Clone {
     /// The underlying base type for representing elements from the field.
     // TODO: Relax Unpin for non cuda usage
-    type BaseType: Clone + Debug + Unpin + ByteConversion + Default;
+    type BaseType: Clone + Debug + Unpin + ByteConversion + Default + Send + Sync;
 
     /// Returns the sum of `a` and `b`.
     fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType;

--- a/crypto/stark/src/constraints/evaluator.rs
+++ b/crypto/stark/src/constraints/evaluator.rs
@@ -6,7 +6,7 @@ use crate::trace::LDETraceTable;
 use crate::traits::{AIR, TransitionEvaluationContext};
 use crate::{frame::Frame, prover::evaluate_polynomial_on_lde_domain};
 use itertools::Itertools;
-use math::field::traits::{IsFFTField, IsSubFieldOf};
+use math::field::traits::{IsFFTField, IsField, IsSubFieldOf};
 #[cfg(not(feature = "parallel"))]
 use math::polynomial::Polynomial;
 use math::{fft::errors::FFTError, field::element::FieldElement};
@@ -22,7 +22,7 @@ use std::time::Instant;
 
 pub struct ConstraintEvaluator<
     Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsFFTField,
+    FieldExtension: Send + Sync + IsField,
     PI,
 > {
     boundary_constraints: BoundaryConstraints<FieldExtension>,
@@ -31,7 +31,7 @@ pub struct ConstraintEvaluator<
 impl<Field, FieldExtension, PI> ConstraintEvaluator<Field, FieldExtension, PI>
 where
     Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsFFTField,
+    FieldExtension: Send + Sync + IsField,
 {
     pub fn new(
         air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,

--- a/crypto/stark/src/constraints/evaluator.rs
+++ b/crypto/stark/src/constraints/evaluator.rs
@@ -6,47 +6,57 @@ use crate::trace::LDETraceTable;
 use crate::traits::{AIR, TransitionEvaluationContext};
 use crate::{frame::Frame, prover::evaluate_polynomial_on_lde_domain};
 use itertools::Itertools;
+use math::field::traits::{IsFFTField, IsSubFieldOf};
 #[cfg(not(feature = "parallel"))]
 use math::polynomial::Polynomial;
-use math::{fft::errors::FFTError, field::element::FieldElement, traits::AsBytes};
+use math::{fft::errors::FFTError, field::element::FieldElement};
 #[cfg(feature = "parallel")]
 use rayon::{
     iter::IndexedParallelIterator,
     prelude::{IntoParallelIterator, ParallelIterator},
 };
 
+use std::marker::PhantomData;
 #[cfg(feature = "instruments")]
 use std::time::Instant;
 
-pub struct ConstraintEvaluator<A: AIR> {
-    boundary_constraints: BoundaryConstraints<A::FieldExtension>,
+pub struct ConstraintEvaluator<
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
+    FieldExtension: Send + Sync + IsFFTField,
+    PI,
+> {
+    boundary_constraints: BoundaryConstraints<FieldExtension>,
+    phantom: PhantomData<(Field, PI)>,
 }
-impl<A: AIR> ConstraintEvaluator<A> {
-    pub fn new(air: &A, rap_challenges: &[FieldElement<A::FieldExtension>]) -> Self {
+impl<Field, FieldExtension, PI> ConstraintEvaluator<Field, FieldExtension, PI>
+where
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
+    FieldExtension: Send + Sync + IsFFTField,
+{
+    pub fn new(
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        rap_challenges: &[FieldElement<FieldExtension>],
+    ) -> Self {
         let boundary_constraints = air.boundary_constraints(rap_challenges);
 
         Self {
             boundary_constraints,
+            phantom: PhantomData::<(Field, PI)> {},
         }
     }
 
     pub(crate) fn evaluate(
         &self,
-        air: &A,
-        lde_trace: &LDETraceTable<A::Field, A::FieldExtension>,
-        domain: &Domain<A::Field>,
-        transition_coefficients: &[FieldElement<A::FieldExtension>],
-        boundary_coefficients: &[FieldElement<A::FieldExtension>],
-        rap_challenges: &[FieldElement<A::FieldExtension>],
-    ) -> Vec<FieldElement<A::FieldExtension>>
-    where
-        FieldElement<A::Field>: AsBytes + Send + Sync,
-        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
-        A: Send + Sync,
-    {
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        lde_trace: &LDETraceTable<Field, FieldExtension>,
+        domain: &Domain<Field>,
+        transition_coefficients: &[FieldElement<FieldExtension>],
+        boundary_coefficients: &[FieldElement<FieldExtension>],
+        rap_challenges: &[FieldElement<FieldExtension>],
+    ) -> Vec<FieldElement<FieldExtension>> {
         let boundary_constraints = &self.boundary_constraints;
         let number_of_b_constraints = boundary_constraints.constraints.len();
-        let boundary_zerofiers_inverse_evaluations: Vec<Vec<FieldElement<A::Field>>> =
+        let boundary_zerofiers_inverse_evaluations: Vec<Vec<FieldElement<Field>>> =
             boundary_constraints
                 .constraints
                 .iter()
@@ -56,14 +66,14 @@ impl<A: AIR> ConstraintEvaluator<A> {
                         .lde_roots_of_unity_coset
                         .iter()
                         .map(|v| v.clone() - point)
-                        .collect::<Vec<FieldElement<A::Field>>>();
+                        .collect::<Vec<FieldElement<Field>>>();
                     FieldElement::inplace_batch_inverse(&mut evals).unwrap();
                     evals
                 })
-                .collect::<Vec<Vec<FieldElement<A::Field>>>>();
+                .collect::<Vec<Vec<FieldElement<Field>>>>();
 
         #[cfg(all(debug_assertions, not(feature = "parallel")))]
-        let boundary_polys: Vec<Polynomial<FieldElement<A::Field>>> = Vec::new();
+        let boundary_polys: Vec<Polynomial<FieldElement<Field>>> = Vec::new();
 
         #[cfg(feature = "instruments")]
         let timer = Instant::now();
@@ -79,7 +89,7 @@ impl<A: AIR> ConstraintEvaluator<A> {
                     &domain.coset_offset,
                 )
             })
-            .collect::<Result<Vec<Vec<FieldElement<A::Field>>>, FFTError>>()
+            .collect::<Result<Vec<Vec<FieldElement<Field>>>, FFTError>>()
             .unwrap();
 
         #[cfg(feature = "instruments")]

--- a/crypto/stark/src/debug.rs
+++ b/crypto/stark/src/debug.rs
@@ -2,6 +2,7 @@ use super::domain::Domain;
 use super::traits::{AIR, TransitionEvaluationContext};
 use crate::{frame::Frame, trace::LDETraceTable};
 use log::{error, info};
+use math::field::traits::IsSubFieldOf;
 use math::{
     field::{
         element::FieldElement,
@@ -11,12 +12,16 @@ use math::{
 };
 
 /// Validates that the trace is valid with respect to the supplied AIR constraints
-pub fn validate_trace<A: AIR>(
-    air: &A,
-    main_trace_polys: &[Polynomial<FieldElement<A::Field>>],
-    aux_trace_polys: &[Polynomial<FieldElement<A::FieldExtension>>],
-    domain: &Domain<A::Field>,
-    rap_challenges: &[FieldElement<A::FieldExtension>],
+pub fn validate_trace<
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
+    FieldExtension: Send + Sync + IsFFTField,
+    PI,
+>(
+    air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+    main_trace_polys: &[Polynomial<FieldElement<Field>>],
+    aux_trace_polys: &[Polynomial<FieldElement<FieldExtension>>],
+    domain: &Domain<Field>,
+    rap_challenges: &[FieldElement<FieldExtension>],
 ) -> bool {
     info!("Starting constraints validation over trace...");
     let mut ret = true;
@@ -24,7 +29,7 @@ pub fn validate_trace<A: AIR>(
     let main_trace_columns: Vec<_> = main_trace_polys
         .iter()
         .map(|poly| {
-            Polynomial::<FieldElement<A::Field>>::evaluate_fft::<A::Field>(
+            Polynomial::<FieldElement<Field>>::evaluate_fft::<Field>(
                 poly,
                 1,
                 Some(domain.interpolation_domain_size),
@@ -36,19 +41,19 @@ pub fn validate_trace<A: AIR>(
     let aux_trace_columns: Vec<_> = aux_trace_polys
         .iter()
         .map(|poly| {
-            Polynomial::evaluate_fft::<A::Field>(poly, 1, Some(domain.interpolation_domain_size))
+            Polynomial::evaluate_fft::<Field>(poly, 1, Some(domain.interpolation_domain_size))
                 .unwrap()
         })
         .collect();
 
     let lde_trace =
-        LDETraceTable::from_columns(main_trace_columns, aux_trace_columns, A::STEP_SIZE, 1);
+        LDETraceTable::from_columns(main_trace_columns, aux_trace_columns, air.step_size(), 1);
 
     let periodic_columns: Vec<_> = air
         .get_periodic_column_polynomials()
         .iter()
         .map(|poly| {
-            Polynomial::<FieldElement<A::Field>>::evaluate_fft::<A::Field>(
+            Polynomial::<FieldElement<Field>>::evaluate_fft::<Field>(
                 poly,
                 1,
                 Some(domain.interpolation_domain_size),

--- a/crypto/stark/src/debug.rs
+++ b/crypto/stark/src/debug.rs
@@ -14,7 +14,7 @@ use math::{
 /// Validates that the trace is valid with respect to the supplied AIR constraints
 pub fn validate_trace<
     Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsFFTField,
+    FieldExtension: Send + Sync + IsField,
     PI,
 >(
     air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,

--- a/crypto/stark/src/domain.rs
+++ b/crypto/stark/src/domain.rs
@@ -2,7 +2,7 @@ use math::{
     fft::cpu::roots_of_unity::get_powers_of_primitive_root_coset,
     field::{
         element::FieldElement,
-        traits::{IsFFTField, IsSubFieldOf},
+        traits::{IsFFTField, IsField, IsSubFieldOf},
     },
 };
 
@@ -62,7 +62,7 @@ pub fn new_domain<Field, FieldExtension, PI>(
 ) -> Domain<Field>
 where
     Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsFFTField,
+    FieldExtension: Send + Sync + IsField,
 {
     // Initial definitions
     let blowup_factor = air.options().blowup_factor as usize;

--- a/crypto/stark/src/domain.rs
+++ b/crypto/stark/src/domain.rs
@@ -1,6 +1,9 @@
 use math::{
     fft::cpu::roots_of_unity::get_powers_of_primitive_root_coset,
-    field::{element::FieldElement, traits::IsFFTField},
+    field::{
+        element::FieldElement,
+        traits::{IsFFTField, IsSubFieldOf},
+    },
 };
 
 use super::traits::AIR;
@@ -51,5 +54,45 @@ impl<F: IsFFTField> Domain<F> {
             coset_offset,
             interpolation_domain_size,
         }
+    }
+}
+
+pub fn new_domain<Field, FieldExtension, PI>(
+    air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+) -> Domain<Field>
+where
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
+    FieldExtension: Send + Sync + IsFFTField,
+{
+    // Initial definitions
+    let blowup_factor = air.options().blowup_factor as usize;
+    let coset_offset = FieldElement::from(air.options().coset_offset);
+    let interpolation_domain_size = air.trace_length();
+    let root_order = air.trace_length().trailing_zeros();
+    // * Generate Coset
+    let trace_primitive_root = Field::get_primitive_root_of_unity(root_order as u64).unwrap();
+    let trace_roots_of_unity = get_powers_of_primitive_root_coset(
+        root_order as u64,
+        interpolation_domain_size,
+        &FieldElement::one(),
+    )
+    .unwrap();
+
+    let lde_root_order = (air.trace_length() * blowup_factor).trailing_zeros();
+    let lde_roots_of_unity_coset = get_powers_of_primitive_root_coset(
+        lde_root_order as u64,
+        air.trace_length() * blowup_factor,
+        &coset_offset,
+    )
+    .unwrap();
+
+    Domain {
+        root_order,
+        lde_roots_of_unity_coset,
+        trace_primitive_root,
+        trace_roots_of_unity,
+        blowup_factor,
+        coset_offset,
+        interpolation_domain_size,
     }
 }

--- a/crypto/stark/src/examples/bit_flags.rs
+++ b/crypto/stark/src/examples/bit_flags.rs
@@ -9,7 +9,6 @@ use crate::{
 use math::field::{
     element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
 };
-use std::iter;
 
 type StarkField = Stark252PrimeField;
 
@@ -136,7 +135,9 @@ impl AIR for BitFlagsAIR {
     type FieldExtension = StarkField;
     type PublicInputs = ();
 
-    const STEP_SIZE: usize = 16;
+    fn step_size(&self) -> usize {
+        16
+    }
 
     fn new(
         trace_length: usize,
@@ -207,10 +208,12 @@ pub fn bit_prefix_flag_trace(num_steps: usize) -> TraceTable<StarkField, StarkFi
     .map(|t| Felt252::from(*t))
     .collect();
 
-    let mut data: Vec<Felt252> = iter::repeat_n(step, num_steps).flatten().collect();
+    let mut data: Vec<Felt252> = std::iter::repeat_n(step, num_steps).flatten().collect();
     data[0] = Felt252::from(1030);
 
     let mut dummy_column = (0..16).map(Felt252::from).collect();
-    dummy_column = iter::repeat_n(dummy_column, num_steps).flatten().collect();
+    dummy_column = std::iter::repeat_n(dummy_column, num_steps)
+        .flatten()
+        .collect();
     TraceTable::from_columns_main(vec![data, dummy_column], 16)
 }

--- a/crypto/stark/src/examples/dummy_air.rs
+++ b/crypto/stark/src/examples/dummy_air.rs
@@ -144,7 +144,9 @@ impl AIR for DummyAIR {
     type FieldExtension = StarkField;
     type PublicInputs = ();
 
-    const STEP_SIZE: usize = 1;
+    fn step_size(&self) -> usize {
+        1
+    }
 
     fn new(
         trace_length: usize,

--- a/crypto/stark/src/examples/fibonacci_2_cols_shifted.rs
+++ b/crypto/stark/src/examples/fibonacci_2_cols_shifted.rs
@@ -176,7 +176,9 @@ where
     type FieldExtension = F;
     type PublicInputs = PublicInputs<Self::Field>;
 
-    const STEP_SIZE: usize = 1;
+    fn step_size(&self) -> usize {
+        1
+    }
 
     fn new(
         trace_length: usize,

--- a/crypto/stark/src/examples/fibonacci_2_columns.rs
+++ b/crypto/stark/src/examples/fibonacci_2_columns.rs
@@ -155,7 +155,9 @@ where
     type FieldExtension = F;
     type PublicInputs = FibonacciPublicInputs<Self::Field>;
 
-    const STEP_SIZE: usize = 1;
+    fn step_size(&self) -> usize {
+        1
+    }
 
     fn new(
         trace_length: usize,

--- a/crypto/stark/src/examples/fibonacci_rap.rs
+++ b/crypto/stark/src/examples/fibonacci_rap.rs
@@ -10,7 +10,7 @@ use crate::{
     trace::TraceTable,
     traits::{AIR, TransitionEvaluationContext},
 };
-use crypto::fiat_shamir::is_transcript::IsTranscript;
+use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
 use math::{
     field::{element::FieldElement, traits::IsFFTField},
     helpers::resize_to_next_power_of_two,
@@ -173,7 +173,9 @@ where
     type FieldExtension = F;
     type PublicInputs = FibonacciRAPPublicInputs<Self::Field>;
 
-    const STEP_SIZE: usize = 1;
+    fn step_size(&self) -> usize {
+        1
+    }
 
     fn new(
         trace_length: usize,
@@ -235,7 +237,7 @@ where
 
     fn build_rap_challenges(
         &self,
-        transcript: &mut impl IsTranscript<Self::Field>,
+        transcript: &mut dyn IsStarkTranscript<Self::Field, Self::Field>,
     ) -> Vec<FieldElement<Self::FieldExtension>> {
         vec![transcript.sample_field_element()]
     }

--- a/crypto/stark/src/examples/quadratic_air.rs
+++ b/crypto/stark/src/examples/quadratic_air.rs
@@ -97,7 +97,9 @@ where
     type FieldExtension = F;
     type PublicInputs = QuadraticPublicInputs<Self::Field>;
 
-    const STEP_SIZE: usize = 1;
+    fn step_size(&self) -> usize {
+        1
+    }
 
     fn new(
         trace_length: usize,

--- a/crypto/stark/src/examples/read_only_memory.rs
+++ b/crypto/stark/src/examples/read_only_memory.rs
@@ -10,7 +10,7 @@ use crate::{
     trace::TraceTable,
     traits::{AIR, TransitionEvaluationContext},
 };
-use crypto::fiat_shamir::is_transcript::IsTranscript;
+use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
 use math::field::traits::IsPrimeField;
 use math::{
     field::{element::FieldElement, traits::IsFFTField},
@@ -248,7 +248,9 @@ where
     type FieldExtension = F;
     type PublicInputs = ReadOnlyPublicInputs<F>;
 
-    const STEP_SIZE: usize = 1;
+    fn step_size(&self) -> usize {
+        1
+    }
 
     fn new(
         trace_length: usize,
@@ -313,7 +315,7 @@ where
 
     fn build_rap_challenges(
         &self,
-        transcript: &mut impl IsTranscript<Self::Field>,
+        transcript: &mut dyn IsStarkTranscript<Self::Field, Self::Field>,
     ) -> Vec<FieldElement<Self::FieldExtension>> {
         vec![
             transcript.sample_field_element(),

--- a/crypto/stark/src/examples/read_only_memory_logup.rs
+++ b/crypto/stark/src/examples/read_only_memory_logup.rs
@@ -415,9 +415,7 @@ where
         &self,
         trace: &mut TraceTable<Self::Field, Self::FieldExtension>,
         challenges: &[FieldElement<E>],
-    ) where
-        Self::FieldExtension: IsFFTField,
-    {
+    ) {
         // Main table
         let main_segment_cols = trace.columns_main();
         let a = &main_segment_cols[0];

--- a/crypto/stark/src/examples/read_only_memory_logup.rs
+++ b/crypto/stark/src/examples/read_only_memory_logup.rs
@@ -14,7 +14,7 @@ use crate::{
     trace::TraceTable,
     traits::{AIR, TransitionEvaluationContext},
 };
-use crypto::fiat_shamir::is_transcript::IsTranscript;
+use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
 use itertools::Itertools;
 use math::{
     field::{
@@ -379,7 +379,9 @@ where
     type FieldExtension = E;
     type PublicInputs = LogReadOnlyPublicInputs<F>;
 
-    const STEP_SIZE: usize = 1;
+    fn step_size(&self) -> usize {
+        1
+    }
 
     fn new(
         trace_length: usize,
@@ -453,7 +455,7 @@ where
 
     fn build_rap_challenges(
         &self,
-        transcript: &mut impl IsTranscript<Self::FieldExtension>,
+        transcript: &mut dyn IsStarkTranscript<Self::FieldExtension, Self::Field>,
     ) -> Vec<FieldElement<Self::FieldExtension>> {
         vec![
             transcript.sample_field_element(),

--- a/crypto/stark/src/examples/simple_fibonacci.rs
+++ b/crypto/stark/src/examples/simple_fibonacci.rs
@@ -99,7 +99,9 @@ where
     type FieldExtension = F;
     type PublicInputs = FibonacciPublicInputs<Self::Field>;
 
-    const STEP_SIZE: usize = 1;
+    fn step_size(&self) -> usize {
+        1
+    }
 
     fn new(
         trace_length: usize,

--- a/crypto/stark/src/examples/simple_periodic_cols.rs
+++ b/crypto/stark/src/examples/simple_periodic_cols.rs
@@ -117,7 +117,9 @@ where
     type FieldExtension = F;
     type PublicInputs = SimplePeriodicPublicInputs<Self::Field>;
 
-    const STEP_SIZE: usize = 1;
+    fn step_size(&self) -> usize {
+        1
+    }
 
     fn new(
         trace_length: usize,

--- a/crypto/stark/src/fri/mod.rs
+++ b/crypto/stark/src/fri/mod.rs
@@ -2,7 +2,7 @@ pub mod fri_commitment;
 pub mod fri_decommit;
 mod fri_functions;
 
-use crypto::fiat_shamir::is_transcript::IsTranscript;
+use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
 use math::field::traits::{IsFFTField, IsField};
 use math::traits::AsBytes;
 use math::{fft::cpu::bit_reversing::in_place_bit_reverse_permute, field::traits::IsSubFieldOf};
@@ -20,7 +20,7 @@ use self::fri_functions::fold_polynomial;
 pub fn commit_phase<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
     number_layers: usize,
     p_0: Polynomial<FieldElement<E>>,
-    transcript: &mut impl IsTranscript<E>,
+    transcript: &mut impl IsStarkTranscript<E, F>,
     coset_offset: &FieldElement<F>,
     domain_size: usize,
 ) -> (

--- a/crypto/stark/src/lib.rs
+++ b/crypto/stark/src/lib.rs
@@ -10,6 +10,7 @@ pub mod examples;
 pub mod frame;
 pub mod fri;
 pub mod grinding;
+pub mod multi_table_prover;
 pub mod proof;
 pub mod prover;
 pub mod table;

--- a/crypto/stark/src/lib.rs
+++ b/crypto/stark/src/lib.rs
@@ -11,6 +11,7 @@ pub mod frame;
 pub mod fri;
 pub mod grinding;
 pub mod multi_table_prover;
+pub mod multi_table_verifier;
 pub mod proof;
 pub mod prover;
 pub mod table;

--- a/crypto/stark/src/multi_table_prover.rs
+++ b/crypto/stark/src/multi_table_prover.rs
@@ -19,6 +19,7 @@ type Airs<'a, F, E, PI> = Vec<(
     &'a dyn AIR<Field = F, FieldExtension = E, PublicInputs = PI>,
     &'a mut TraceTable<F, E>,
 )>;
+
 pub fn multi_prove<F: IsSubFieldOf<E> + IsFFTField + Send + Sync, E: Send + Sync + IsFFTField, PI>(
     airs: Airs<F, E, PI>,
     transcript: &mut impl IsStarkTranscript<E, F>,

--- a/crypto/stark/src/multi_table_prover.rs
+++ b/crypto/stark/src/multi_table_prover.rs
@@ -1,0 +1,35 @@
+use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
+use math::{
+    field::{
+        element::FieldElement,
+        traits::{IsFFTField, IsSubFieldOf},
+    },
+    traits::AsBytes,
+};
+
+use crate::{
+    proof::stark::StarkProof,
+    prover::{IsStarkProver, Prover, ProvingError},
+    trace::TraceTable,
+    traits::AIR,
+};
+
+// List of airs and their associated table
+type Airs<'a, F, E, PI> = Vec<(
+    &'a dyn AIR<Field = F, FieldExtension = E, PublicInputs = PI>,
+    &'a mut TraceTable<F, E>,
+)>;
+pub fn multi_prove<F: IsSubFieldOf<E> + IsFFTField + Send + Sync, E: Send + Sync + IsFFTField, PI>(
+    airs: Airs<F, E, PI>,
+    transcript: &mut impl IsStarkTranscript<E, F>,
+) -> Result<StarkProof<F, E>, ProvingError>
+where
+    FieldElement<F>: AsBytes,
+    FieldElement<E>: AsBytes,
+{
+    let mut proof = None;
+    for (air, table) in airs {
+        let _ = proof.insert(Prover::<F, E, PI>::prove(air, table, transcript)?);
+    }
+    Ok(proof.unwrap())
+}

--- a/crypto/stark/src/multi_table_verifier.rs
+++ b/crypto/stark/src/multi_table_verifier.rs
@@ -1,0 +1,42 @@
+use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
+use math::{
+    field::{
+        element::FieldElement,
+        traits::{IsFFTField, IsSubFieldOf},
+    },
+    traits::AsBytes,
+};
+
+use crate::{
+    proof::stark::StarkProof,
+    traits::AIR,
+    verifier::{IsStarkVerifier, Verifier},
+};
+
+// List of airs and their associated proof
+type AirsAndProofs<'a, F, E, PI> = Vec<(
+    &'a dyn AIR<Field = F, FieldExtension = E, PublicInputs = PI>,
+    &'a StarkProof<F, E>,
+)>;
+
+/// Verifies multiple STARK proofs with their corresponding airs `airs_and_proofs`.
+/// Warning: the transcript must be safely initializated before passing it to this method.
+pub fn multi_verify<
+    F: IsSubFieldOf<E> + IsFFTField + Send + Sync,
+    E: Send + Sync + IsFFTField,
+    PI,
+>(
+    airs_and_proofs: AirsAndProofs<F, E, PI>,
+    transcript: &mut impl IsStarkTranscript<E, F>,
+) -> bool
+where
+    FieldElement<F>: AsBytes,
+    FieldElement<E>: AsBytes,
+{
+    for (air, proof) in airs_and_proofs {
+        if !Verifier::verify(proof, air, transcript) {
+            return false;
+        }
+    }
+    true
+}

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 #[cfg(feature = "instruments")]
 use std::time::Instant;
 
-use crypto::fiat_shamir::is_transcript::IsTranscript;
+use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
 use math::fft::cpu::bit_reversing::{in_place_bit_reverse_permute, reverse_index};
 use math::fft::errors::FFTError;
 
@@ -19,6 +19,7 @@ use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelI
 
 #[cfg(debug_assertions)]
 use crate::debug::validate_trace;
+use crate::domain::new_domain;
 use crate::fri;
 use crate::proof::stark::{DeepPolynomialOpenings, PolynomialOpenings};
 use crate::table::Table;
@@ -29,17 +30,26 @@ use super::constraints::evaluator::ConstraintEvaluator;
 use super::domain::Domain;
 use super::fri::fri_decommit::FriDecommitment;
 use super::grinding;
-use super::proof::options::ProofOptions;
 use super::proof::stark::{DeepPolynomialOpening, StarkProof};
 use super::trace::TraceTable;
 use super::traits::AIR;
 
 /// A default STARK prover implementing `IsStarkProver`.
-pub struct Prover<A: AIR> {
-    phantom: PhantomData<A>,
+pub struct Prover<
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
+    FieldExtension: Send + Sync + IsFFTField,
+    PI,
+> {
+    p: PhantomData<(Field, FieldExtension, PI)>,
 }
 
-impl<A: AIR> IsStarkProver<A> for Prover<A> {}
+impl<
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
+    FieldExtension: Send + Sync + IsFFTField,
+    PI,
+> IsStarkProver<Field, FieldExtension, PI> for Prover<Field, FieldExtension, PI>
+{
+}
 
 #[derive(Debug)]
 pub enum ProvingError {
@@ -52,7 +62,7 @@ pub enum ProvingError {
 pub struct Round1CommitmentData<F>
 where
     F: IsField,
-    FieldElement<F>: AsBytes + Send + Sync,
+    FieldElement<F>: AsBytes,
 {
     /// The result of the interpolation of the columns of the trace table.
     pub(crate) trace_polys: Vec<Polynomial<FieldElement<F>>>,
@@ -63,32 +73,34 @@ where
 }
 
 /// A container for the results of the first round of the STARK Prove protocol.
-pub struct Round1<A>
+pub struct Round1<Field, FieldExtension>
 where
-    A: AIR,
-    FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
-    FieldElement<A::Field>: AsBytes + Sync + Send,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField,
+    FieldExtension: IsFFTField,
+    FieldElement<Field>: AsBytes,
+    FieldElement<FieldExtension>: AsBytes,
 {
     /// The table of evaluations over the LDE of the main and auxiliary trace tables.
-    pub(crate) lde_trace: LDETraceTable<A::Field, A::FieldExtension>,
+    pub(crate) lde_trace: LDETraceTable<Field, FieldExtension>,
     /// The intermediate results of the commitment to the main trace table.
-    pub(crate) main: Round1CommitmentData<A::Field>,
+    pub(crate) main: Round1CommitmentData<Field>,
     /// The intermediate results of the commitment to the auxiliary trace table in case of RAP.
-    pub(crate) aux: Option<Round1CommitmentData<A::FieldExtension>>,
+    pub(crate) aux: Option<Round1CommitmentData<FieldExtension>>,
     /// The challenges of the RAP round.
-    pub(crate) rap_challenges: Vec<FieldElement<A::FieldExtension>>,
+    pub(crate) rap_challenges: Vec<FieldElement<FieldExtension>>,
 }
 
-impl<A> Round1<A>
+impl<Field, FieldExtension> Round1<Field, FieldExtension>
 where
-    A: AIR,
-    FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
-    FieldElement<A::Field>: AsBytes + Sync + Send,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField,
+    FieldExtension: IsFFTField,
+    FieldElement<Field>: AsBytes,
+    FieldElement<FieldExtension>: AsBytes,
 {
     /// Returns the full list of the polynomials interpolating the trace. It includes both
     /// main and auxiliary trace polynomials. The main trace polynomials are casted to
     /// polynomials with coefficients over `Self::FieldExtension`.
-    fn all_trace_polys(&self) -> Vec<Polynomial<FieldElement<A::FieldExtension>>> {
+    fn all_trace_polys(&self) -> Vec<Polynomial<FieldElement<FieldExtension>>> {
         let mut trace_polys: Vec<_> = self
             .main
             .trace_polys
@@ -108,7 +120,7 @@ where
 pub struct Round2<F>
 where
     F: IsField,
-    FieldElement<F>: AsBytes + Sync + Send,
+    FieldElement<F>: AsBytes,
 {
     /// The list of polynomials `H₀, ..., Hₙ` such that `H = ∑ᵢXⁱH(Xⁿ)`, where H is the composition polynomial.
     pub(crate) composition_poly_parts: Vec<Polynomial<FieldElement<F>>>,
@@ -169,13 +181,18 @@ where
 /// https://lambdaclass.github.io/lambdaworks/starks/protocol.html
 /// The default implementation is complete and is compatible with Stone prover
 /// https://github.com/starkware-libs/stone-prover
-pub trait IsStarkProver<A: AIR> {
+pub trait IsStarkProver<
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
+    FieldExtension: Send + Sync + IsFFTField,
+    PI,
+>
+{
     /// Returns the Merkle tree and the commitment to the vectors `vectors`.
     fn batch_commit_main(
-        vectors: &[Vec<FieldElement<A::Field>>],
-    ) -> Option<(BatchedMerkleTree<A::Field>, Commitment)>
+        vectors: &[Vec<FieldElement<Field>>],
+    ) -> Option<(BatchedMerkleTree<Field>, Commitment)>
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
     {
         let tree = BatchedMerkleTree::build(vectors)?;
 
@@ -185,11 +202,11 @@ pub trait IsStarkProver<A: AIR> {
 
     /// Returns the Merkle tree and the commitment to the vectors `vectors`.
     fn batch_commit_extension(
-        vectors: &[Vec<FieldElement<A::FieldExtension>>],
-    ) -> Option<(BatchedMerkleTree<A::FieldExtension>, Commitment)>
+        vectors: &[Vec<FieldElement<FieldExtension>>],
+    ) -> Option<(BatchedMerkleTree<FieldExtension>, Commitment)>
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         let tree = BatchedMerkleTree::build(vectors)?;
 
@@ -206,27 +223,26 @@ pub trait IsStarkProver<A: AIR> {
     /// • The roots of the above Merkle trees.
     #[allow(clippy::type_complexity)]
     fn interpolate_and_commit_main(
-        trace: &TraceTable<A::Field, A::FieldExtension>,
-        domain: &Domain<A::Field>,
-        transcript: &mut impl IsTranscript<A::FieldExtension>,
+        trace: &TraceTable<Field, FieldExtension>,
+        domain: &Domain<Field>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
     ) -> Option<(
-        Vec<Polynomial<FieldElement<A::Field>>>,
-        Vec<Vec<FieldElement<A::Field>>>,
-        BatchedMerkleTree<A::Field>,
+        Vec<Polynomial<FieldElement<Field>>>,
+        Vec<Vec<FieldElement<Field>>>,
+        BatchedMerkleTree<Field>,
         Commitment,
     )>
     where
-        FieldElement<A::Field>: AsBytes + Send + Sync,
-        // FieldElement<E>: AsBytes + Send + Sync,
-        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
-        A::Field: IsSubFieldOf<A::FieldExtension>,
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
+        Field: IsSubFieldOf<FieldExtension>,
     {
         // Interpolate columns of `trace`.
-        let trace_polys = trace.compute_trace_polys_main::<A::Field>();
+        let trace_polys = trace.compute_trace_polys_main::<Field>();
 
         // Evaluate those polynomials t_j on the large domain D_LDE.
         let lde_trace_evaluations =
-            Self::compute_lde_trace_evaluations::<A::Field>(&trace_polys, domain);
+            Self::compute_lde_trace_evaluations::<Field>(&trace_polys, domain);
 
         let mut lde_trace_permuted = lde_trace_evaluations.clone();
         for col in lde_trace_permuted.iter_mut() {
@@ -259,22 +275,22 @@ pub trait IsStarkProver<A: AIR> {
     /// • The roots of the above Merkle trees.
     #[allow(clippy::type_complexity)]
     fn interpolate_and_commit_aux(
-        trace: &TraceTable<A::Field, A::FieldExtension>,
-        domain: &Domain<A::Field>,
-        transcript: &mut impl IsTranscript<A::FieldExtension>,
+        trace: &TraceTable<Field, FieldExtension>,
+        domain: &Domain<Field>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
     ) -> Option<(
-        Vec<Polynomial<FieldElement<A::FieldExtension>>>,
-        Vec<Vec<FieldElement<A::FieldExtension>>>,
-        BatchedMerkleTree<A::FieldExtension>,
+        Vec<Polynomial<FieldElement<FieldExtension>>>,
+        Vec<Vec<FieldElement<FieldExtension>>>,
+        BatchedMerkleTree<FieldExtension>,
         Commitment,
     )>
     where
-        FieldElement<A::Field>: AsBytes + Send + Sync,
-        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
-        A::Field: IsSubFieldOf<A::FieldExtension> + IsFFTField,
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
+        Field: IsSubFieldOf<FieldExtension> + IsFFTField,
     {
         // Interpolate columns of `trace`.
-        let trace_polys = trace.compute_trace_polys_aux::<A::Field>();
+        let trace_polys = trace.compute_trace_polys_aux::<Field>();
 
         // Evaluate those polynomials t_j on the large domain D_LDE.
         let lde_trace_evaluations = Self::compute_lde_trace_evaluations(&trace_polys, domain);
@@ -305,13 +321,11 @@ pub trait IsStarkProver<A: AIR> {
     /// The i-th entry of the returned vector contains the evaluations of the i-th polynomial in `trace_polys`.
     fn compute_lde_trace_evaluations<E>(
         trace_polys: &[Polynomial<FieldElement<E>>],
-        domain: &Domain<A::Field>,
+        domain: &Domain<Field>,
     ) -> Vec<Vec<FieldElement<E>>>
     where
-        FieldElement<E>: Send + Sync,
-        FieldElement<A::Field>: Send + Sync,
-        E: IsSubFieldOf<A::FieldExtension>,
-        A::Field: IsSubFieldOf<E>,
+        E: IsSubFieldOf<FieldExtension>,
+        Field: IsSubFieldOf<E>,
     {
         #[cfg(not(feature = "parallel"))]
         let trace_polys_iter = trace_polys.iter();
@@ -333,15 +347,14 @@ pub trait IsStarkProver<A: AIR> {
 
     /// Returns the result of the first round of the STARK Prove protocol.
     fn round_1_randomized_air_with_preprocessing(
-        air: &A,
-        trace: &mut TraceTable<A::Field, A::FieldExtension>,
-        domain: &Domain<A::Field>,
-        transcript: &mut impl IsTranscript<A::FieldExtension>,
-    ) -> Result<Round1<A>, ProvingError>
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        trace: &mut TraceTable<Field, FieldExtension>,
+        domain: &Domain<Field>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
+    ) -> Result<Round1<Field, FieldExtension>, ProvingError>
     where
-        FieldElement<A::Field>: AsBytes + Send + Sync,
-        A::FieldExtension: IsFFTField,
-        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
     {
         let Some((trace_polys, evaluations, main_merkle_tree, main_merkle_root)) =
             Self::interpolate_and_commit_main(trace, domain, transcript)
@@ -349,7 +362,7 @@ pub trait IsStarkProver<A: AIR> {
             return Err(ProvingError::EmptyCommitment);
         };
 
-        let main = Round1CommitmentData::<A::Field> {
+        let main = Round1CommitmentData::<Field> {
             trace_polys,
             lde_trace_merkle_tree: main_merkle_tree,
             lde_trace_merkle_root: main_merkle_root,
@@ -368,7 +381,7 @@ pub trait IsStarkProver<A: AIR> {
                 return Err(ProvingError::EmptyCommitment);
             };
             let aux_evaluations = aux_trace_polys_evaluations;
-            let aux = Some(Round1CommitmentData::<A::FieldExtension> {
+            let aux = Some(Round1CommitmentData::<FieldExtension> {
                 trace_polys: aux_trace_polys,
                 lde_trace_merkle_tree: aux_merkle_tree,
                 lde_trace_merkle_root: aux_merkle_root,
@@ -381,7 +394,7 @@ pub trait IsStarkProver<A: AIR> {
         let lde_trace = LDETraceTable::from_columns(
             evaluations,
             aux_evaluations,
-            A::STEP_SIZE,
+            air.step_size(),
             domain.blowup_factor,
         );
 
@@ -396,11 +409,11 @@ pub trait IsStarkProver<A: AIR> {
     /// Returns the Merkle tree and the commitment to the evaluations of the parts of the
     /// composition polynomial.
     fn commit_composition_polynomial(
-        lde_composition_poly_parts_evaluations: &[Vec<FieldElement<A::FieldExtension>>],
-    ) -> Option<(BatchedMerkleTree<A::FieldExtension>, Commitment)>
+        lde_composition_poly_parts_evaluations: &[Vec<FieldElement<FieldExtension>>],
+    ) -> Option<(BatchedMerkleTree<FieldExtension>, Commitment)>
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         // TODO: Remove clones
         let mut lde_composition_poly_evaluations = Vec::new();
@@ -426,16 +439,15 @@ pub trait IsStarkProver<A: AIR> {
 
     /// Returns the result of the second round of the STARK Prove protocol.
     fn round_2_compute_composition_polynomial(
-        air: &A,
-        domain: &Domain<A::Field>,
-        round_1_result: &Round1<A>,
-        transition_coefficients: &[FieldElement<A::FieldExtension>],
-        boundary_coefficients: &[FieldElement<A::FieldExtension>],
-    ) -> Result<Round2<A::FieldExtension>, ProvingError>
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        domain: &Domain<Field>,
+        round_1_result: &Round1<Field, FieldExtension>,
+        transition_coefficients: &[FieldElement<FieldExtension>],
+        boundary_coefficients: &[FieldElement<FieldExtension>],
+    ) -> Result<Round2<FieldExtension>, ProvingError>
     where
-        A: Send + Sync,
-        FieldElement<A::Field>: AsBytes + Send + Sync,
-        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
     {
         // Compute the evaluations of the composition polynomial on the LDE domain.
         let evaluator = ConstraintEvaluator::new(air, &round_1_result.rap_challenges);
@@ -485,15 +497,15 @@ pub trait IsStarkProver<A: AIR> {
 
     /// Returns the result of the third round of the STARK Prove protocol.
     fn round_3_evaluate_polynomials_in_out_of_domain_element(
-        air: &A,
-        domain: &Domain<A::Field>,
-        round_1_result: &Round1<A>,
-        round_2_result: &Round2<A::FieldExtension>,
-        z: &FieldElement<A::FieldExtension>,
-    ) -> Round3<A::FieldExtension>
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        domain: &Domain<Field>,
+        round_1_result: &Round1<Field, FieldExtension>,
+        round_2_result: &Round2<FieldExtension>,
+        z: &FieldElement<FieldExtension>,
+    ) -> Round3<FieldExtension>
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
     {
         let z_power = z.pow(round_2_result.composition_poly_parts.len());
 
@@ -512,19 +524,18 @@ pub trait IsStarkProver<A: AIR> {
         //
         // In the fibonacci example, the ood frame is simply the evaluations `[t(z), t(z * g), t(z * g^2)]`, where `t` is the trace
         // polynomial and `g` is the primitive root of unity used when interpolating `t`.
-        let trace_ood_evaluations =
-            crate::trace::get_trace_evaluations::<A::Field, A::FieldExtension>(
-                &round_1_result.main.trace_polys,
-                round_1_result
-                    .aux
-                    .as_ref()
-                    .map(|aux| &aux.trace_polys)
-                    .unwrap_or(&vec![]),
-                z,
-                &air.context().transition_offsets,
-                &domain.trace_primitive_root,
-                A::STEP_SIZE,
-            );
+        let trace_ood_evaluations = crate::trace::get_trace_evaluations::<Field, FieldExtension>(
+            &round_1_result.main.trace_polys,
+            round_1_result
+                .aux
+                .as_ref()
+                .map(|aux| &aux.trace_polys)
+                .unwrap_or(&vec![]),
+            z,
+            &air.context().transition_offsets,
+            &domain.trace_primitive_root,
+            air.step_size(),
+        );
 
         Round3 {
             trace_ood_evaluations,
@@ -534,26 +545,26 @@ pub trait IsStarkProver<A: AIR> {
 
     /// Returns the result of the fourth round of the STARK Prove protocol.
     fn round_4_compute_and_run_fri_on_the_deep_composition_polynomial(
-        air: &A,
-        domain: &Domain<A::Field>,
-        round_1_result: &Round1<A>,
-        round_2_result: &Round2<A::FieldExtension>,
-        round_3_result: &Round3<A::FieldExtension>,
-        z: &FieldElement<A::FieldExtension>,
-        transcript: &mut impl IsTranscript<A::FieldExtension>,
-    ) -> Round4<A::Field, A::FieldExtension>
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        domain: &Domain<Field>,
+        round_1_result: &Round1<Field, FieldExtension>,
+        round_2_result: &Round2<FieldExtension>,
+        round_3_result: &Round3<FieldExtension>,
+        z: &FieldElement<FieldExtension>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
+    ) -> Round4<Field, FieldExtension>
     where
-        FieldElement<A::Field>: AsBytes + Send + Sync,
-        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
+        FieldElement<FieldExtension>: AsBytes,
+        FieldElement<Field>: AsBytes,
     {
         let coset_offset_u64 = air.context().proof_options.coset_offset;
-        let coset_offset = FieldElement::<A::Field>::from(coset_offset_u64);
+        let coset_offset = FieldElement::<Field>::from(coset_offset_u64);
 
         let gamma = transcript.sample_field_element();
 
         let n_terms_composition_poly = round_2_result.lde_composition_poly_evaluations.len();
         let num_terms_trace =
-            air.context().transition_offsets.len() * A::STEP_SIZE * air.context().trace_columns;
+            air.context().transition_offsets.len() * air.step_size() * air.context().trace_columns;
 
         // <<<< Receive challenges: 𝛾, 𝛾'
         let mut deep_composition_coefficients: Vec<_> =
@@ -564,7 +575,7 @@ pub trait IsStarkProver<A: AIR> {
         let trace_term_coeffs: Vec<_> = deep_composition_coefficients
             .drain(..num_terms_trace)
             .collect::<Vec<_>>()
-            .chunks(air.context().transition_offsets.len() * A::STEP_SIZE)
+            .chunks(air.context().transition_offsets.len() * air.step_size())
             .map(|chunk| chunk.to_vec())
             .collect();
 
@@ -585,7 +596,7 @@ pub trait IsStarkProver<A: AIR> {
         let domain_size = domain.lde_roots_of_unity_coset.len();
 
         // FRI commit and query phases
-        let (fri_last_value, fri_layers) = fri::commit_phase::<A::Field, A::FieldExtension>(
+        let (fri_last_value, fri_layers) = fri::commit_phase::<Field, FieldExtension>(
             domain.root_order as usize,
             deep_composition_poly,
             transcript,
@@ -627,8 +638,8 @@ pub trait IsStarkProver<A: AIR> {
 
     fn sample_query_indexes(
         number_of_queries: usize,
-        domain: &Domain<A::Field>,
-        transcript: &mut impl IsTranscript<A::FieldExtension>,
+        domain: &Domain<Field>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
     ) -> Vec<usize> {
         let domain_size = domain.lde_roots_of_unity_coset.len() as u64;
         (0..number_of_queries)
@@ -641,17 +652,17 @@ pub trait IsStarkProver<A: AIR> {
     /// composition polynomial, with coefficients sampled by the verifier (i.e. using Fiat-Shamir).
     #[allow(clippy::too_many_arguments)]
     fn compute_deep_composition_poly(
-        trace_polys: &[Polynomial<FieldElement<A::FieldExtension>>],
-        round_2_result: &Round2<A::FieldExtension>,
-        round_3_result: &Round3<A::FieldExtension>,
-        z: &FieldElement<A::FieldExtension>,
-        primitive_root: &FieldElement<A::Field>,
-        composition_poly_gammas: &[FieldElement<A::FieldExtension>],
-        trace_terms_gammas: &[Vec<FieldElement<A::FieldExtension>>],
-    ) -> Polynomial<FieldElement<A::FieldExtension>>
+        trace_polys: &[Polynomial<FieldElement<FieldExtension>>],
+        round_2_result: &Round2<FieldExtension>,
+        round_3_result: &Round3<FieldExtension>,
+        z: &FieldElement<FieldExtension>,
+        primitive_root: &FieldElement<Field>,
+        composition_poly_gammas: &[FieldElement<FieldExtension>],
+        trace_terms_gammas: &[Vec<FieldElement<FieldExtension>>],
+    ) -> Polynomial<FieldElement<FieldExtension>>
     where
-        FieldElement<A::Field>: AsBytes + Send + Sync,
-        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
     {
         let z_power = z.pow(round_2_result.composition_poly_parts.len());
 
@@ -718,15 +729,15 @@ pub trait IsStarkProver<A: AIR> {
     /// composition polynomial. That is, returns `accumulator + \sum_i \gamma_i \frac{ t_j - t_j(zg^i) }{ X - zg^i }`,
     /// where `i` ranges from `T * j` to `T * j + T - 1`, where `T` is the number of offsets in every frame.
     fn compute_trace_term(
-        accumulator: &Polynomial<FieldElement<A::FieldExtension>>,
-        trace_term_poly: &Polynomial<FieldElement<A::FieldExtension>>,
-        trace_terms_gammas: &[FieldElement<A::FieldExtension>],
-        trace_frame_evaluations: &[FieldElement<A::FieldExtension>],
-        (z, primitive_root): (&FieldElement<A::FieldExtension>, &FieldElement<A::Field>),
-    ) -> Polynomial<FieldElement<A::FieldExtension>>
+        accumulator: &Polynomial<FieldElement<FieldExtension>>,
+        trace_term_poly: &Polynomial<FieldElement<FieldExtension>>,
+        trace_terms_gammas: &[FieldElement<FieldExtension>],
+        trace_frame_evaluations: &[FieldElement<FieldExtension>],
+        (z, primitive_root): (&FieldElement<FieldExtension>, &FieldElement<Field>),
+    ) -> Polynomial<FieldElement<FieldExtension>>
     where
-        FieldElement<A::Field>: AsBytes + Send + Sync,
-        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
     {
         let trace_int = trace_frame_evaluations
             .iter()
@@ -750,13 +761,13 @@ pub trait IsStarkProver<A: AIR> {
     /// at the domain value corresponding to the FRI query challenge `index` and its symmetric
     /// element.
     fn open_composition_poly(
-        composition_poly_merkle_tree: &BatchedMerkleTree<A::FieldExtension>,
-        lde_composition_poly_evaluations: &[Vec<FieldElement<A::FieldExtension>>],
+        composition_poly_merkle_tree: &BatchedMerkleTree<FieldExtension>,
+        lde_composition_poly_evaluations: &[Vec<FieldElement<FieldExtension>>],
         index: usize,
-    ) -> PolynomialOpenings<A::FieldExtension>
+    ) -> PolynomialOpenings<FieldExtension>
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         let proof = composition_poly_merkle_tree
             .get_proof_by_pos(index)
@@ -792,15 +803,15 @@ pub trait IsStarkProver<A: AIR> {
     /// at the domain value corresponding to the FRI query challenge `index` and its symmetric
     /// element.
     fn open_trace_polys<E>(
-        domain: &Domain<A::Field>,
+        domain: &Domain<Field>,
         tree: &BatchedMerkleTree<E>,
         lde_trace: &Table<E>,
         challenge: usize,
     ) -> PolynomialOpenings<E>
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
         FieldElement<E>: AsBytes + Sync + Send,
-        A::Field: IsSubFieldOf<E>,
+        Field: IsSubFieldOf<E>,
         E: IsField,
     {
         let domain_size = domain.lde_roots_of_unity_coset.len();
@@ -821,19 +832,19 @@ pub trait IsStarkProver<A: AIR> {
 
     /// Open the deep composition polynomial on a list of indexes and their symmetric elements.
     fn open_deep_composition_poly(
-        domain: &Domain<A::Field>,
-        round_1_result: &Round1<A>,
-        round_2_result: &Round2<A::FieldExtension>,
+        domain: &Domain<Field>,
+        round_1_result: &Round1<Field, FieldExtension>,
+        round_2_result: &Round2<FieldExtension>,
         indexes_to_open: &[usize],
-    ) -> DeepPolynomialOpenings<A::Field, A::FieldExtension>
+    ) -> DeepPolynomialOpenings<Field, FieldExtension>
     where
-        FieldElement<A::Field>: AsBytes + Send + Sync,
-        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
     {
         let mut openings = Vec::new();
 
         for index in indexes_to_open.iter() {
-            let main_trace_opening = Self::open_trace_polys::<A::Field>(
+            let main_trace_opening = Self::open_trace_polys::<Field>(
                 domain,
                 &round_1_result.main.lde_trace_merkle_tree,
                 &round_1_result.lde_trace.main_table,
@@ -847,7 +858,7 @@ pub trait IsStarkProver<A: AIR> {
             );
 
             let aux_trace_polys = round_1_result.aux.as_ref().map(|aux| {
-                Self::open_trace_polys::<A::FieldExtension>(
+                Self::open_trace_polys::<FieldExtension>(
                     domain,
                     &aux.lde_trace_merkle_tree,
                     &round_1_result.lde_trace.aux_table,
@@ -869,16 +880,14 @@ pub trait IsStarkProver<A: AIR> {
     /// Generates a STARK proof for the trace `main_trace` with public inputs `pub_inputs`.
     /// Warning: the transcript must be safely initializated before passing it to this method.
     fn prove(
-        trace: &mut TraceTable<A::Field, A::FieldExtension>,
-        pub_inputs: &A::PublicInputs,
-        proof_options: &ProofOptions,
-        mut transcript: impl IsTranscript<A::FieldExtension>,
-    ) -> Result<StarkProof<A::Field, A::FieldExtension>, ProvingError>
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        trace: &mut TraceTable<Field, FieldExtension>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
+    ) -> Result<StarkProof<Field, FieldExtension>, ProvingError>
     where
-        A: Send + Sync,
-        FieldElement<A::Field>: AsBytes + Send + Sync,
-        A::FieldExtension: IsFFTField,
-        FieldElement<A::FieldExtension>: AsBytes + Send + Sync,
+        FieldElement<Field>: AsBytes,
+        FieldExtension: IsFFTField,
+        FieldElement<FieldExtension>: AsBytes,
     {
         info!("Started proof generation...");
         #[cfg(feature = "instruments")]
@@ -886,8 +895,7 @@ pub trait IsStarkProver<A: AIR> {
         #[cfg(feature = "instruments")]
         let timer0 = Instant::now();
 
-        let air = A::new(trace.num_rows(), pub_inputs, proof_options);
-        let domain = Domain::new(&air);
+        let domain = new_domain(air);
 
         #[cfg(feature = "instruments")]
         let elapsed0 = timer0.elapsed();
@@ -904,11 +912,11 @@ pub trait IsStarkProver<A: AIR> {
         let timer1 = Instant::now();
 
         let round_1_result =
-            Self::round_1_randomized_air_with_preprocessing(&air, trace, &domain, &mut transcript)?;
+            Self::round_1_randomized_air_with_preprocessing(air, trace, &domain, transcript)?;
 
         #[cfg(debug_assertions)]
         validate_trace(
-            &air,
+            air,
             &round_1_result.main.trace_polys,
             round_1_result
                 .aux
@@ -918,7 +926,6 @@ pub trait IsStarkProver<A: AIR> {
             &domain,
             &round_1_result.rap_challenges,
         );
-
         #[cfg(feature = "instruments")]
         let elapsed1 = timer1.elapsed();
         #[cfg(feature = "instruments")]
@@ -952,7 +959,7 @@ pub trait IsStarkProver<A: AIR> {
         let boundary_coefficients = coefficients;
 
         let round_2_result = Self::round_2_compute_composition_polynomial(
-            &air,
+            air,
             &domain,
             &round_1_result,
             &transition_coefficients,
@@ -983,7 +990,7 @@ pub trait IsStarkProver<A: AIR> {
         );
 
         let round_3_result = Self::round_3_evaluate_polynomials_in_out_of_domain_element(
-            &air,
+            air,
             &domain,
             &round_1_result,
             &round_2_result,
@@ -1021,13 +1028,13 @@ pub trait IsStarkProver<A: AIR> {
         // protocol on its own. Therefore we pass it the transcript
         // to simulate the interactions with the verifier.
         let round_4_result = Self::round_4_compute_and_run_fri_on_the_deep_composition_polynomial(
-            &air,
+            air,
             &domain,
             &round_1_result,
             &round_2_result,
             &round_3_result,
             &z,
-            &mut transcript,
+            transcript,
         );
 
         #[cfg(feature = "instruments")]
@@ -1050,7 +1057,7 @@ pub trait IsStarkProver<A: AIR> {
 
         info!("End proof generation");
 
-        Ok(StarkProof::<A::Field, A::FieldExtension> {
+        Ok(StarkProof::<Field, FieldExtension> {
             // [t]
             lde_trace_main_merkle_root: round_1_result.main.lde_trace_merkle_root,
             // [t]
@@ -1229,11 +1236,16 @@ mod tests {
 
         let transcript_init_seed = [0xca, 0xfe, 0xca, 0xfe];
 
-        let proof = Prover::<Fibonacci2ColsShifted<_>>::prove(
-            &mut trace,
+        let air = Fibonacci2ColsShifted::<Stark252PrimeField>::new(
+            trace.num_rows(),
             &pub_inputs,
             &proof_options,
-            StoneProverTranscript::new(&transcript_init_seed),
+        );
+
+        let proof = Prover::prove(
+            &air,
+            &mut trace,
+            &mut StoneProverTranscript::new(&transcript_init_seed),
         )
         .unwrap();
         (proof, pub_inputs, proof_options, transcript_init_seed)
@@ -1626,11 +1638,16 @@ mod tests {
 
         let transcript_init_seed = [0xfa, 0xfa, 0xfa, 0xee];
 
-        let proof = Prover::<Fibonacci2ColsShifted<_>>::prove(
-            &mut trace,
+        let air = Fibonacci2ColsShifted::<Stark252PrimeField>::new(
+            trace.num_rows(),
             &pub_inputs,
             &proof_options,
-            StoneProverTranscript::new(&transcript_init_seed),
+        );
+
+        let proof = Prover::prove(
+            &air,
+            &mut trace,
+            &mut StoneProverTranscript::new(&transcript_init_seed),
         )
         .unwrap();
         (proof, pub_inputs, proof_options, transcript_init_seed)

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -37,7 +37,7 @@ use super::traits::AIR;
 /// A default STARK prover implementing `IsStarkProver`.
 pub struct Prover<
     Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsFFTField,
+    FieldExtension: Send + Sync + IsField,
     PI,
 > {
     p: PhantomData<(Field, FieldExtension, PI)>,
@@ -45,7 +45,7 @@ pub struct Prover<
 
 impl<
     Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsFFTField,
+    FieldExtension: Send + Sync + IsField,
     PI,
 > IsStarkProver<Field, FieldExtension, PI> for Prover<Field, FieldExtension, PI>
 {
@@ -76,7 +76,7 @@ where
 pub struct Round1<Field, FieldExtension>
 where
     Field: IsSubFieldOf<FieldExtension> + IsFFTField,
-    FieldExtension: IsFFTField,
+    FieldExtension: IsField,
     FieldElement<Field>: AsBytes,
     FieldElement<FieldExtension>: AsBytes,
 {
@@ -93,7 +93,7 @@ where
 impl<Field, FieldExtension> Round1<Field, FieldExtension>
 where
     Field: IsSubFieldOf<FieldExtension> + IsFFTField,
-    FieldExtension: IsFFTField,
+    FieldExtension: IsField,
     FieldElement<Field>: AsBytes,
     FieldElement<FieldExtension>: AsBytes,
 {
@@ -183,7 +183,7 @@ where
 /// https://github.com/starkware-libs/stone-prover
 pub trait IsStarkProver<
     Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsFFTField,
+    FieldExtension: Send + Sync + IsField,
     PI,
 >
 {
@@ -886,8 +886,8 @@ pub trait IsStarkProver<
     ) -> Result<StarkProof<Field, FieldExtension>, ProvingError>
     where
         FieldElement<Field>: AsBytes,
-        FieldExtension: IsFFTField,
         FieldElement<FieldExtension>: AsBytes,
+        FieldExtension: IsField,
     {
         info!("Started proof generation...");
         #[cfg(feature = "instruments")]
@@ -1214,7 +1214,7 @@ mod tests {
 
     fn proof_parts_stone_compatibility_case_1() -> (
         StarkProof<Stark252PrimeField, Stark252PrimeField>,
-        fibonacci_2_cols_shifted::PublicInputs<Stark252PrimeField>,
+        Fibonacci2ColsShifted<Stark252PrimeField>,
         ProofOptions,
         [u8; 4],
     ) {
@@ -1248,7 +1248,7 @@ mod tests {
             &mut StoneProverTranscript::new(&transcript_init_seed),
         )
         .unwrap();
-        (proof, pub_inputs, proof_options, transcript_init_seed)
+        (proof, air, proof_options, transcript_init_seed)
     }
 
     fn stone_compatibility_case_1_proof() -> StarkProof<Stark252PrimeField, Stark252PrimeField> {
@@ -1256,11 +1256,9 @@ mod tests {
         proof
     }
 
-    fn stone_compatibility_case_1_challenges()
-    -> Challenges<Fibonacci2ColsShifted<Stark252PrimeField>> {
-        let (proof, public_inputs, options, seed) = proof_parts_stone_compatibility_case_1();
+    fn stone_compatibility_case_1_challenges() -> Challenges<Stark252PrimeField> {
+        let (proof, air, _, seed) = proof_parts_stone_compatibility_case_1();
 
-        let air = Fibonacci2ColsShifted::new(proof.trace_length, &public_inputs, &options);
         let domain = Domain::new(&air);
         Verifier::step_1_replay_rounds_and_recover_challenges(
             &air,
@@ -1272,12 +1270,11 @@ mod tests {
 
     #[test]
     fn stone_compatibility_case_1_proof_is_valid() {
-        let (proof, public_inputs, options, seed) = proof_parts_stone_compatibility_case_1();
-        assert!(Verifier::<Fibonacci2ColsShifted<_>>::verify(
+        let (proof, air, _options, seed) = proof_parts_stone_compatibility_case_1();
+        assert!(Verifier::verify(
             &proof,
-            &public_inputs,
-            &options,
-            StoneProverTranscript::new(&seed)
+            &air,
+            &mut StoneProverTranscript::new(&seed)
         ));
     }
 
@@ -1658,8 +1655,7 @@ mod tests {
         proof
     }
 
-    fn stone_compatibility_case_2_challenges()
-    -> Challenges<Fibonacci2ColsShifted<Stark252PrimeField>> {
+    fn stone_compatibility_case_2_challenges() -> Challenges<Stark252PrimeField> {
         let (proof, public_inputs, options, seed) = proof_parts_stone_compatibility_case_2();
 
         let air = Fibonacci2ColsShifted::new(proof.trace_length, &public_inputs, &options);

--- a/crypto/stark/src/tests/integration_tests.rs
+++ b/crypto/stark/src/tests/integration_tests.rs
@@ -46,11 +46,10 @@ fn test_prove_fib() {
         FibonacciAIR::<Stark252PrimeField>::new(trace.num_rows(), &pub_inputs, &proof_options);
 
     let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
-    assert!(Verifier::<FibonacciAIR<Stark252PrimeField>>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[]),
+        &air,
+        &mut StoneProverTranscript::new(&[]),
     ));
 }
 
@@ -69,11 +68,10 @@ fn test_prove_simple_periodic_8() {
         SimplePeriodicAIR::<Stark252PrimeField>::new(trace.num_rows(), &pub_inputs, &proof_options);
 
     let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
-    assert!(Verifier::<SimplePeriodicAIR<Stark252PrimeField>>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[]),
+        &air,
+        &mut StoneProverTranscript::new(&[]),
     ));
 }
 
@@ -93,11 +91,10 @@ fn test_prove_simple_periodic_32() {
 
     let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
 
-    assert!(Verifier::<SimplePeriodicAIR<Stark252PrimeField>>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[]),
+        &air,
+        &mut StoneProverTranscript::new(&[]),
     ));
 }
 
@@ -116,11 +113,10 @@ fn test_prove_fib_2_cols() {
 
     let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
 
-    assert!(Verifier::<Fibonacci2ColsAIR<Stark252PrimeField>>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[])
+        &air,
+        &mut StoneProverTranscript::new(&[])
     ));
 }
 
@@ -145,11 +141,10 @@ fn test_prove_fib_2_cols_shifted() {
 
     let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
 
-    assert!(Verifier::<Fibonacci2ColsShifted<_>>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[])
+        &air,
+        &mut StoneProverTranscript::new(&[])
     ));
 }
 
@@ -168,11 +163,10 @@ fn test_prove_quadratic() {
 
     let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
 
-    assert!(Verifier::<QuadraticAIR<Stark252PrimeField>>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[])
+        &air,
+        &mut StoneProverTranscript::new(&[])
     ));
 }
 
@@ -194,11 +188,10 @@ fn test_prove_rap_fib() {
 
     let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
 
-    assert!(Verifier::<FibonacciRAP<Stark252PrimeField>>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[])
+        &air,
+        &mut StoneProverTranscript::new(&[])
     ));
 }
 
@@ -213,11 +206,10 @@ fn test_prove_dummy() {
 
     let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
 
-    assert!(Verifier::<DummyAIR>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &(),
-        &proof_options,
-        StoneProverTranscript::new(&[])
+        &air,
+        &mut StoneProverTranscript::new(&[])
     ));
 }
 
@@ -230,11 +222,10 @@ fn test_prove_bit_flags() {
 
     let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
 
-    assert!(Verifier::<BitFlagsAIR>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &(),
-        &proof_options,
-        StoneProverTranscript::new(&[]),
+        &air,
+        &mut StoneProverTranscript::new(&[]),
     ));
 }
 
@@ -274,11 +265,10 @@ fn test_prove_read_only_memory() {
 
     let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
 
-    assert!(Verifier::<ReadOnlyRAP<Stark252PrimeField>>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[])
+        &air,
+        &mut StoneProverTranscript::new(&[])
     ));
 }
 
@@ -328,12 +318,9 @@ fn test_prove_log_read_only_memory() {
     )
     .unwrap();
 
-    assert!(Verifier::<
-        LogReadOnlyRAP<Babybear31PrimeField, Degree4BabyBearExtensionField>,
-    >::verify(
+    assert!(Verifier::verify(
         &proof,
-        &pub_inputs,
-        &proof_options,
-        DefaultTranscript::<Degree4BabyBearExtensionField>::new(&[]),
+        &air,
+        &mut DefaultTranscript::<Degree4BabyBearExtensionField>::new(&[]),
     ));
 }

--- a/crypto/stark/src/tests/integration_tests.rs
+++ b/crypto/stark/src/tests/integration_tests.rs
@@ -7,6 +7,7 @@ use math::field::fields::fft_friendly::{
     babybear::Babybear31PrimeField, quartic_babybear::Degree4BabyBearExtensionField,
 };
 
+use crate::traits::AIR;
 use crate::{
     Felt252,
     examples::{
@@ -41,13 +42,10 @@ fn test_prove_fib() {
         a1: Felt252::one(),
     };
 
-    let proof = Prover::<FibonacciAIR<Stark252PrimeField>>::prove(
-        &mut trace,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[]),
-    )
-    .unwrap();
+    let air =
+        FibonacciAIR::<Stark252PrimeField>::new(trace.num_rows(), &pub_inputs, &proof_options);
+
+    let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
     assert!(Verifier::<FibonacciAIR<Stark252PrimeField>>::verify(
         &proof,
         &pub_inputs,
@@ -67,13 +65,10 @@ fn test_prove_simple_periodic_8() {
         a1: Felt252::from(8),
     };
 
-    let proof = Prover::<SimplePeriodicAIR<Stark252PrimeField>>::prove(
-        &mut trace,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[]),
-    )
-    .unwrap();
+    let air =
+        SimplePeriodicAIR::<Stark252PrimeField>::new(trace.num_rows(), &pub_inputs, &proof_options);
+
+    let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
     assert!(Verifier::<SimplePeriodicAIR<Stark252PrimeField>>::verify(
         &proof,
         &pub_inputs,
@@ -93,13 +88,11 @@ fn test_prove_simple_periodic_32() {
         a1: Felt252::from(32768),
     };
 
-    let proof = Prover::<SimplePeriodicAIR<Stark252PrimeField>>::prove(
-        &mut trace,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[]),
-    )
-    .unwrap();
+    let air =
+        SimplePeriodicAIR::<Stark252PrimeField>::new(trace.num_rows(), &pub_inputs, &proof_options);
+
+    let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
+
     assert!(Verifier::<SimplePeriodicAIR<Stark252PrimeField>>::verify(
         &proof,
         &pub_inputs,
@@ -118,13 +111,10 @@ fn test_prove_fib_2_cols() {
         a1: Felt252::one(),
     };
 
-    let proof = Prover::<Fibonacci2ColsAIR<Stark252PrimeField>>::prove(
-        &mut trace,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[]),
-    )
-    .unwrap();
+    let air =
+        Fibonacci2ColsAIR::<Stark252PrimeField>::new(trace.num_rows(), &pub_inputs, &proof_options);
+
+    let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
 
     assert!(Verifier::<Fibonacci2ColsAIR<Stark252PrimeField>>::verify(
         &proof,
@@ -147,13 +137,14 @@ fn test_prove_fib_2_cols_shifted() {
         claimed_index,
     };
 
-    let proof = Prover::<Fibonacci2ColsShifted<_>>::prove(
-        &mut trace,
+    let air = Fibonacci2ColsShifted::<Stark252PrimeField>::new(
+        trace.num_rows(),
         &pub_inputs,
         &proof_options,
-        StoneProverTranscript::new(&[]),
-    )
-    .unwrap();
+    );
+
+    let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
+
     assert!(Verifier::<Fibonacci2ColsShifted<_>>::verify(
         &proof,
         &pub_inputs,
@@ -172,13 +163,11 @@ fn test_prove_quadratic() {
         a0: Felt252::from(3),
     };
 
-    let proof = Prover::<QuadraticAIR<Stark252PrimeField>>::prove(
-        &mut trace,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[]),
-    )
-    .unwrap();
+    let air =
+        QuadraticAIR::<Stark252PrimeField>::new(trace.num_rows(), &pub_inputs, &proof_options);
+
+    let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
+
     assert!(Verifier::<QuadraticAIR<Stark252PrimeField>>::verify(
         &proof,
         &pub_inputs,
@@ -200,13 +189,11 @@ fn test_prove_rap_fib() {
         a1: Felt252::one(),
     };
 
-    let proof = Prover::<FibonacciRAP<Stark252PrimeField>>::prove(
-        &mut trace,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[]),
-    )
-    .unwrap();
+    let air =
+        FibonacciRAP::<Stark252PrimeField>::new(trace.num_rows(), &pub_inputs, &proof_options);
+
+    let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
+
     assert!(Verifier::<FibonacciRAP<Stark252PrimeField>>::verify(
         &proof,
         &pub_inputs,
@@ -222,13 +209,10 @@ fn test_prove_dummy() {
 
     let proof_options = ProofOptions::default_test_options();
 
-    let proof = Prover::<DummyAIR>::prove(
-        &mut trace,
-        &(),
-        &proof_options,
-        StoneProverTranscript::new(&[]),
-    )
-    .unwrap();
+    let air = DummyAIR::new(trace.num_rows(), &(), &proof_options);
+
+    let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
+
     assert!(Verifier::<DummyAIR>::verify(
         &proof,
         &(),
@@ -242,13 +226,9 @@ fn test_prove_bit_flags() {
     let mut trace = bit_flags::bit_prefix_flag_trace(32);
     let proof_options = ProofOptions::default_test_options();
 
-    let proof = Prover::<BitFlagsAIR>::prove(
-        &mut trace,
-        &(),
-        &proof_options,
-        StoneProverTranscript::new(&[]),
-    )
-    .unwrap();
+    let air = BitFlagsAIR::new(trace.num_rows(), &(), &proof_options);
+
+    let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
 
     assert!(Verifier::<BitFlagsAIR>::verify(
         &proof,
@@ -289,13 +269,11 @@ fn test_prove_read_only_memory() {
     };
     let mut trace = sort_rap_trace(address_col, value_col);
     let proof_options = ProofOptions::default_test_options();
-    let proof = Prover::<ReadOnlyRAP<Stark252PrimeField>>::prove(
-        &mut trace,
-        &pub_inputs,
-        &proof_options,
-        StoneProverTranscript::new(&[]),
-    )
-    .unwrap();
+
+    let air = ReadOnlyRAP::<Stark252PrimeField>::new(trace.num_rows(), &pub_inputs, &proof_options);
+
+    let proof = Prover::prove(&air, &mut trace, &mut StoneProverTranscript::new(&[])).unwrap();
+
     assert!(Verifier::<ReadOnlyRAP<Stark252PrimeField>>::verify(
         &proof,
         &pub_inputs,
@@ -336,14 +314,20 @@ fn test_prove_log_read_only_memory() {
     };
     let mut trace = read_only_logup_trace(address_col, value_col);
     let proof_options = ProofOptions::default_test_options();
-    let proof =
-        Prover::<LogReadOnlyRAP<Babybear31PrimeField, Degree4BabyBearExtensionField>>::prove(
-            &mut trace,
-            &pub_inputs,
-            &proof_options,
-            DefaultTranscript::<Degree4BabyBearExtensionField>::new(&[]),
-        )
-        .unwrap();
+
+    let air = LogReadOnlyRAP::<Babybear31PrimeField, Degree4BabyBearExtensionField>::new(
+        trace.num_rows(),
+        &pub_inputs,
+        &proof_options,
+    );
+
+    let proof = Prover::prove(
+        &air,
+        &mut trace,
+        &mut DefaultTranscript::<Degree4BabyBearExtensionField>::new(&[]),
+    )
+    .unwrap();
+
     assert!(Verifier::<
         LogReadOnlyRAP<Babybear31PrimeField, Degree4BabyBearExtensionField>,
     >::verify(

--- a/crypto/stark/src/traits.rs
+++ b/crypto/stark/src/traits.rs
@@ -91,9 +91,7 @@ pub trait AIR: Send + Sync {
         &self,
         _main_trace: &mut TraceTable<Self::Field, Self::FieldExtension>,
         _rap_challenges: &[FieldElement<Self::FieldExtension>],
-    ) where
-        Self::FieldExtension: IsFFTField,
-    {
+    ) {
     }
 
     fn build_rap_challenges(

--- a/crypto/stark/src/traits.rs
+++ b/crypto/stark/src/traits.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crypto::fiat_shamir::is_transcript::IsTranscript;
+use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
 use math::{
     field::{
         element::FieldElement,
@@ -72,18 +72,20 @@ where
 }
 
 /// AIR is a representation of the Constraints
-pub trait AIR {
+pub trait AIR: Send + Sync {
     type Field: IsFFTField + IsSubFieldOf<Self::FieldExtension> + Send + Sync;
     type FieldExtension: IsField + Send + Sync;
     type PublicInputs;
 
-    const STEP_SIZE: usize;
+    fn step_size(&self) -> usize;
 
     fn new(
         trace_length: usize,
         pub_inputs: &Self::PublicInputs,
         proof_options: &ProofOptions,
-    ) -> Self;
+    ) -> Self
+    where
+        Self: Sized;
 
     fn build_auxiliary_trace(
         &self,
@@ -96,7 +98,7 @@ pub trait AIR {
 
     fn build_rap_challenges(
         &self,
-        _transcript: &mut impl IsTranscript<Self::FieldExtension>,
+        _transcript: &mut dyn IsStarkTranscript<Self::FieldExtension, Self::Field>,
     ) -> Vec<FieldElement<Self::FieldExtension>> {
         Vec::new()
     }

--- a/crypto/stark/src/transcript.rs
+++ b/crypto/stark/src/transcript.rs
@@ -1,4 +1,4 @@
-use crypto::fiat_shamir::is_transcript::IsTranscript;
+use crypto::fiat_shamir::is_transcript::{IsStarkTranscript, IsTranscript};
 use math::{
     field::{
         element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
@@ -129,6 +129,10 @@ impl IsTranscript<Stark252PrimeField> for StoneProverTranscript {
         let u64_val: u64 = u64::from_be_bytes(bytes);
         u64_val % upper_bound
     }
+}
+
+impl IsStarkTranscript<Stark252PrimeField, Stark252PrimeField> for StoneProverTranscript {
+    // nothing to implement: sample_z_ood uses the default body
 }
 
 /// Returns a batch of size `size` of field elements sampled from the transcript `transcript`.

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -3,10 +3,10 @@ use super::{
     domain::Domain,
     fri::fri_decommit::FriDecommitment,
     grinding,
-    proof::{options::ProofOptions, stark::StarkProof},
+    proof::stark::StarkProof,
     traits::{AIR, TransitionEvaluationContext},
 };
-use crate::{config::Commitment, proof::stark::DeepPolynomialOpening};
+use crate::{config::Commitment, domain::new_domain, proof::stark::DeepPolynomialOpening};
 use crypto::{fiat_shamir::is_transcript::IsStarkTranscript, merkle_tree::proof::Proof};
 #[cfg(not(feature = "test_fiat_shamir"))]
 use log::error;
@@ -23,34 +23,44 @@ use std::marker::PhantomData;
 use std::time::Instant;
 
 /// A default STARK verifier implementing `IsStarkVerifier`.
-pub struct Verifier<A: AIR> {
-    phantom: PhantomData<A>,
+pub struct Verifier<
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
+    FieldExtension: Send + Sync + IsField,
+    PI,
+> {
+    phantom: PhantomData<(Field, FieldExtension, PI)>,
 }
 
-impl<A: AIR> IsStarkVerifier<A> for Verifier<A> {}
+impl<
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
+    FieldExtension: Send + Sync + IsFFTField,
+    PI,
+> IsStarkVerifier<Field, FieldExtension, PI> for Verifier<Field, FieldExtension, PI>
+{
+}
 
 /// A container holding the complete list of challenges sent to the prover along with the seed used
 /// to validate the proof-of-work nonce.
-pub struct Challenges<A>
+pub struct Challenges<FieldExtension>
 where
-    A: AIR,
+    FieldExtension: Send + Sync + IsField,
 {
     /// The out-of-domain challenge.
-    pub z: FieldElement<A::FieldExtension>,
+    pub z: FieldElement<FieldExtension>,
     /// The composition polynomial coefficients corresponding to the boundary constraints terms.
-    pub boundary_coeffs: Vec<FieldElement<A::FieldExtension>>,
+    pub boundary_coeffs: Vec<FieldElement<FieldExtension>>,
     /// The composition polynomial coefficients corresponding to the transition constraints terms.
-    pub transition_coeffs: Vec<FieldElement<A::FieldExtension>>,
+    pub transition_coeffs: Vec<FieldElement<FieldExtension>>,
     /// The deep composition polynomial coefficients corresponding to the trace polynomial terms.
-    pub trace_term_coeffs: Vec<Vec<FieldElement<A::FieldExtension>>>,
+    pub trace_term_coeffs: Vec<Vec<FieldElement<FieldExtension>>>,
     /// The deep composition polynomial coefficients corresponding to the composition polynomial parts terms.
-    pub gammas: Vec<FieldElement<A::FieldExtension>>,
+    pub gammas: Vec<FieldElement<FieldExtension>>,
     /// The list of FRI commit phase folding challenges.
-    pub zetas: Vec<FieldElement<A::FieldExtension>>,
+    pub zetas: Vec<FieldElement<FieldExtension>>,
     /// The list of FRI query phase index challenges.
     pub iotas: Vec<usize>,
     /// The challenges used to build the auxiliary trace.
-    pub rap_challenges: Vec<FieldElement<A::FieldExtension>>,
+    pub rap_challenges: Vec<FieldElement<FieldExtension>>,
     /// The seed used to verify the proof-of-work nonce.
     pub grinding_seed: [u8; 32],
 }
@@ -59,11 +69,16 @@ pub type DeepPolynomialEvaluations<F> = (Vec<FieldElement<F>>, Vec<FieldElement<
 
 /// The functionality of a STARK verifier providing methods to run the STARK Verify protocol
 /// https://lambdaclass.github.io/lambdaworks/starks/protocol.html
-pub trait IsStarkVerifier<A: AIR> {
+pub trait IsStarkVerifier<
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
+    FieldExtension: Send + Sync + IsField,
+    PI,
+>
+{
     fn sample_query_indexes(
         number_of_queries: usize,
-        domain: &Domain<A::Field>,
-        transcript: &mut impl IsStarkTranscript<A::FieldExtension, A::Field>,
+        domain: &Domain<Field>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
     ) -> Vec<usize> {
         let domain_size = domain.lde_roots_of_unity_coset.len() as u64;
         (0..number_of_queries)
@@ -73,14 +88,14 @@ pub trait IsStarkVerifier<A: AIR> {
 
     /// Returns the list of challenges sent to the prover.
     fn step_1_replay_rounds_and_recover_challenges(
-        air: &A,
-        proof: &StarkProof<A::Field, A::FieldExtension>,
-        domain: &Domain<A::Field>,
-        transcript: &mut impl IsStarkTranscript<A::FieldExtension, A::Field>,
-    ) -> Challenges<A>
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        proof: &StarkProof<Field, FieldExtension>,
+        domain: &Domain<Field>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
+    ) -> Challenges<FieldExtension>
     where
-        FieldElement<A::Field>: AsBytes,
-        FieldElement<A::FieldExtension>: AsBytes,
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
     {
         // ===================================
         // ==========|   Round 1   |==========
@@ -173,7 +188,7 @@ pub trait IsStarkVerifier<A: AIR> {
                 transcript.append_bytes(root);
                 element
             })
-            .collect::<Vec<FieldElement<A::FieldExtension>>>();
+            .collect::<Vec<FieldElement<FieldExtension>>>();
 
         // >>>> Send challenge 𝜁ₙ₋₁
         zetas.push(transcript.sample_field_element());
@@ -213,10 +228,10 @@ pub trait IsStarkVerifier<A: AIR> {
     /// polynomials at the out-of-domain challenge are consistent.
     /// See https://lambdaclass.github.io/lambdaworks/starks/protocol.html#step-2-verify-claimed-composition-polynomial
     fn step_2_verify_claimed_composition_polynomial(
-        air: &A,
-        proof: &StarkProof<A::Field, A::FieldExtension>,
-        domain: &Domain<A::Field>,
-        challenges: &Challenges<A>,
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        proof: &StarkProof<Field, FieldExtension>,
+        domain: &Domain<Field>,
+        challenges: &Challenges<FieldExtension>,
     ) -> bool {
         let boundary_constraints = air.boundary_constraints(&challenges.rap_challenges);
 
@@ -225,8 +240,8 @@ pub trait IsStarkVerifier<A: AIR> {
 
         #[allow(clippy::type_complexity)]
         let (boundary_c_i_evaluations_num, mut boundary_c_i_evaluations_den): (
-            Vec<FieldElement<A::FieldExtension>>,
-            Vec<FieldElement<A::FieldExtension>>,
+            Vec<FieldElement<FieldExtension>>,
+            Vec<FieldElement<FieldExtension>>,
         ) = (0..number_of_b_constraints)
             .map(|index| {
                 let step = boundary_constraints.constraints[index].step;
@@ -255,19 +270,19 @@ pub trait IsStarkVerifier<A: AIR> {
 
         FieldElement::inplace_batch_inverse(&mut boundary_c_i_evaluations_den).unwrap();
 
-        let boundary_quotient_ood_evaluation: FieldElement<A::FieldExtension> =
+        let boundary_quotient_ood_evaluation: FieldElement<FieldExtension> =
             boundary_c_i_evaluations_num
                 .iter()
                 .zip(&boundary_c_i_evaluations_den)
                 .zip(&challenges.boundary_coeffs)
                 .map(|((num, den), beta)| num * den * beta)
-                .fold(FieldElement::<A::FieldExtension>::zero(), |acc, x| acc + x);
+                .fold(FieldElement::<FieldExtension>::zero(), |acc, x| acc + x);
 
         let periodic_values = air
             .get_periodic_column_polynomials()
             .iter()
             .map(|poly| poly.evaluate(&challenges.z))
-            .collect::<Vec<FieldElement<A::FieldExtension>>>();
+            .collect::<Vec<FieldElement<FieldExtension>>>();
 
         let num_main_trace_columns =
             proof.trace_ood_evaluations.width - air.num_auxiliary_rap_columns();
@@ -283,7 +298,7 @@ pub trait IsStarkVerifier<A: AIR> {
             air.compute_transition(&transition_evaluation_context);
 
         let mut denominators =
-            vec![FieldElement::<A::FieldExtension>::zero(); air.num_transition_constraints()];
+            vec![FieldElement::<FieldExtension>::zero(); air.num_transition_constraints()];
         air.transition_constraints().iter().for_each(|c| {
             denominators[c.constraint_idx()] =
                 c.evaluate_zerofier(&challenges.z, &domain.trace_primitive_root, trace_length);
@@ -316,13 +331,13 @@ pub trait IsStarkVerifier<A: AIR> {
     /// openings of the trace polynomials and the composition polynomial parts. It then uses these to verify that the
     /// FRI decommitments are valid and correspond to the Deep composition polynomial.
     fn step_3_verify_fri(
-        proof: &StarkProof<A::Field, A::FieldExtension>,
-        domain: &Domain<A::Field>,
-        challenges: &Challenges<A>,
+        proof: &StarkProof<Field, FieldExtension>,
+        domain: &Domain<Field>,
+        challenges: &Challenges<FieldExtension>,
     ) -> bool
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         let (deep_poly_evaluations, deep_poly_evaluations_sym) =
             Self::reconstruct_deep_composition_poly_evaluations_for_all_queries(
@@ -334,7 +349,7 @@ pub trait IsStarkVerifier<A: AIR> {
             .iotas
             .iter()
             .map(|iota| Self::query_challenge_to_evaluation_point(*iota, domain))
-            .collect::<Vec<FieldElement<A::Field>>>();
+            .collect::<Vec<FieldElement<Field>>>();
         FieldElement::inplace_batch_inverse(&mut evaluation_point_inverse).unwrap();
 
         proof
@@ -360,8 +375,8 @@ pub trait IsStarkVerifier<A: AIR> {
     /// Returns the field element element of the domain `domain` corresponding to the given FRI query index challenge `iota`.
     fn query_challenge_to_evaluation_point(
         iota: usize,
-        domain: &Domain<A::Field>,
-    ) -> FieldElement<A::Field> {
+        domain: &Domain<Field>,
+    ) -> FieldElement<Field> {
         domain.lde_roots_of_unity_coset
             [reverse_index(iota * 2, domain.lde_roots_of_unity_coset.len() as u64)]
         .clone()
@@ -370,8 +385,8 @@ pub trait IsStarkVerifier<A: AIR> {
     /// Returns the symmetric field element element of the domain `domain` corresponding to the given FRI query index challenge `iota`.
     fn query_challenge_to_evaluation_point_sym(
         iota: usize,
-        domain: &Domain<A::Field>,
-    ) -> FieldElement<A::Field> {
+        domain: &Domain<Field>,
+    ) -> FieldElement<Field> {
         domain.lde_roots_of_unity_coset
             [reverse_index(iota * 2 + 1, domain.lde_roots_of_unity_coset.len() as u64)]
         .clone()
@@ -385,10 +400,10 @@ pub trait IsStarkVerifier<A: AIR> {
         value: &[FieldElement<E>],
     ) -> bool
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
         FieldElement<E>: AsBytes + Sync + Send,
         E: IsField,
-        A::Field: IsSubFieldOf<E>,
+        Field: IsSubFieldOf<E>,
     {
         proof.verify::<BatchedMerkleTreeBackend<E>>(root, index, &value.to_owned())
     }
@@ -396,25 +411,25 @@ pub trait IsStarkVerifier<A: AIR> {
     /// Verify opening Open(tⱼ(D_LDE), 𝜐) and Open(tⱼ(D_LDE), -𝜐) for all trace polynomials tⱼ,
     /// where 𝜐 and -𝜐 are the elements corresponding to the index challenge `iota`.
     fn verify_trace_openings(
-        proof: &StarkProof<A::Field, A::FieldExtension>,
-        deep_poly_openings: &DeepPolynomialOpening<A::Field, A::FieldExtension>,
+        proof: &StarkProof<Field, FieldExtension>,
+        deep_poly_openings: &DeepPolynomialOpening<Field, FieldExtension>,
         iota: usize,
     ) -> bool
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         let index = iota * 2;
         let index_sym = iota * 2 + 1;
         let mut result = true;
 
-        result &= Self::verify_opening::<A::Field>(
+        result &= Self::verify_opening::<Field>(
             &deep_poly_openings.main_trace_polys.proof,
             &proof.lde_trace_main_merkle_root,
             index,
             &deep_poly_openings.main_trace_polys.evaluations,
         );
-        result &= Self::verify_opening::<A::Field>(
+        result &= Self::verify_opening::<Field>(
             &deep_poly_openings.main_trace_polys.proof_sym,
             &proof.lde_trace_main_merkle_root,
             index_sym,
@@ -428,13 +443,13 @@ pub trait IsStarkVerifier<A: AIR> {
             (None, Some(_)) => result = false,
             (Some(_), None) => result = false,
             (Some(aux_root), Some(aux_trace_polys_opening)) => {
-                result &= Self::verify_opening::<A::FieldExtension>(
+                result &= Self::verify_opening::<FieldExtension>(
                     &aux_trace_polys_opening.proof,
                     &aux_root,
                     index,
                     &aux_trace_polys_opening.evaluations,
                 );
-                result &= Self::verify_opening::<A::FieldExtension>(
+                result &= Self::verify_opening::<FieldExtension>(
                     &aux_trace_polys_opening.proof_sym,
                     &aux_root,
                     index_sym,
@@ -450,13 +465,13 @@ pub trait IsStarkVerifier<A: AIR> {
     /// Verify opening Open(Hᵢ(D_LDE), 𝜐) and Open(Hᵢ(D_LDE), -𝜐) for all parts Hᵢof the composition
     /// polynomial, where 𝜐 and -𝜐 are the elements corresponding to the index challenge `iota`.
     fn verify_composition_poly_opening(
-        deep_poly_openings: &DeepPolynomialOpening<A::Field, A::FieldExtension>,
+        deep_poly_openings: &DeepPolynomialOpening<Field, FieldExtension>,
         composition_poly_merkle_root: &Commitment,
         iota: &usize,
     ) -> bool
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         let mut value = deep_poly_openings.composition_poly.evaluations.clone();
         value.extend_from_slice(&deep_poly_openings.composition_poly.evaluations_sym);
@@ -464,7 +479,7 @@ pub trait IsStarkVerifier<A: AIR> {
         deep_poly_openings
             .composition_poly
             .proof
-            .verify::<BatchedMerkleTreeBackend<A::FieldExtension>>(
+            .verify::<BatchedMerkleTreeBackend<FieldExtension>>(
                 composition_poly_merkle_root,
                 *iota,
                 &value,
@@ -475,12 +490,12 @@ pub trait IsStarkVerifier<A: AIR> {
     /// parts at the domain elements and their symmetric counterparts corresponding to all the FRI query
     /// index challenges.
     fn step_4_verify_trace_and_composition_openings(
-        proof: &StarkProof<A::Field, A::FieldExtension>,
-        challenges: &Challenges<A>,
+        proof: &StarkProof<Field, FieldExtension>,
+        challenges: &Challenges<FieldExtension>,
     ) -> bool
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         challenges.iotas.iter().zip(&proof.deep_poly_openings).fold(
             true,
@@ -501,13 +516,13 @@ pub trait IsStarkVerifier<A: AIR> {
     fn verify_fri_layer_openings(
         merkle_root: &Commitment,
         auth_path_sym: &Proof<Commitment>,
-        evaluation: &FieldElement<A::FieldExtension>,
-        evaluation_sym: &FieldElement<A::FieldExtension>,
+        evaluation: &FieldElement<FieldExtension>,
+        evaluation_sym: &FieldElement<FieldExtension>,
         iota: usize,
     ) -> bool
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         let evaluations = if iota % 2 == 1 {
             vec![evaluation_sym.clone(), evaluation.clone()]
@@ -515,7 +530,7 @@ pub trait IsStarkVerifier<A: AIR> {
             vec![evaluation.clone(), evaluation_sym.clone()]
         };
 
-        auth_path_sym.verify::<BatchedMerkleTreeBackend<A::FieldExtension>>(
+        auth_path_sym.verify::<BatchedMerkleTreeBackend<FieldExtension>>(
             merkle_root,
             iota >> 1,
             &evaluations,
@@ -531,20 +546,20 @@ pub trait IsStarkVerifier<A: AIR> {
     /// `deep_composition_evaluation`: precomputed value of p₀(𝜐), where p₀ is the deep composition polynomial.
     /// `deep_composition_evaluation_sym`: precomputed value of p₀(-𝜐), where p₀ is the deep composition polynomial.
     fn verify_query_and_sym_openings(
-        proof: &StarkProof<A::Field, A::FieldExtension>,
-        zetas: &[FieldElement<A::FieldExtension>],
+        proof: &StarkProof<Field, FieldExtension>,
+        zetas: &[FieldElement<FieldExtension>],
         iota: usize,
-        fri_decommitment: &FriDecommitment<A::FieldExtension>,
-        evaluation_point_inv: FieldElement<A::Field>,
-        deep_composition_evaluation: &FieldElement<A::FieldExtension>,
-        deep_composition_evaluation_sym: &FieldElement<A::FieldExtension>,
+        fri_decommitment: &FriDecommitment<FieldExtension>,
+        evaluation_point_inv: FieldElement<Field>,
+        deep_composition_evaluation: &FieldElement<FieldExtension>,
+        deep_composition_evaluation_sym: &FieldElement<FieldExtension>,
     ) -> bool
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         let fri_layers_merkle_roots = &proof.fri_layers_merkle_roots;
-        let evaluation_point_vec: Vec<FieldElement<A::Field>> =
+        let evaluation_point_vec: Vec<FieldElement<Field>> =
             core::iter::successors(Some(evaluation_point_inv.square()), |evaluation_point| {
                 Some(evaluation_point.square())
             })
@@ -605,17 +620,17 @@ pub trait IsStarkVerifier<A: AIR> {
     }
 
     fn reconstruct_deep_composition_poly_evaluations_for_all_queries(
-        challenges: &Challenges<A>,
-        domain: &Domain<A::Field>,
-        proof: &StarkProof<A::Field, A::FieldExtension>,
-    ) -> DeepPolynomialEvaluations<A::FieldExtension> {
+        challenges: &Challenges<FieldExtension>,
+        domain: &Domain<Field>,
+        proof: &StarkProof<Field, FieldExtension>,
+    ) -> DeepPolynomialEvaluations<FieldExtension> {
         let mut deep_poly_evaluations = Vec::new();
         let mut deep_poly_evaluations_sym = Vec::new();
         for (i, iota) in challenges.iotas.iter().enumerate() {
             let primitive_root =
-                &A::Field::get_primitive_root_of_unity(domain.root_order as u64).unwrap();
+                &Field::get_primitive_root_of_unity(domain.root_order as u64).unwrap();
 
-            let mut evaluations: Vec<FieldElement<A::FieldExtension>> = proof.deep_poly_openings[i]
+            let mut evaluations: Vec<FieldElement<FieldExtension>> = proof.deep_poly_openings[i]
                 .main_trace_polys
                 .evaluations
                 .clone()
@@ -636,8 +651,8 @@ pub trait IsStarkVerifier<A: AIR> {
                 &proof.deep_poly_openings[i].composition_poly.evaluations,
             ));
 
-            let mut evaluations_sym: Vec<FieldElement<A::FieldExtension>> = proof
-                .deep_poly_openings[i]
+            let mut evaluations_sym: Vec<FieldElement<FieldExtension>> = proof.deep_poly_openings
+                [i]
                 .main_trace_polys
                 .evaluations_sym
                 .clone()
@@ -662,13 +677,13 @@ pub trait IsStarkVerifier<A: AIR> {
     }
 
     fn reconstruct_deep_composition_poly_evaluation(
-        proof: &StarkProof<A::Field, A::FieldExtension>,
-        evaluation_point: &FieldElement<A::Field>,
-        primitive_root: &FieldElement<A::Field>,
-        challenges: &Challenges<A>,
-        lde_trace_evaluations: &[FieldElement<A::FieldExtension>],
-        lde_composition_poly_parts_evaluation: &[FieldElement<A::FieldExtension>],
-    ) -> FieldElement<A::FieldExtension> {
+        proof: &StarkProof<Field, FieldExtension>,
+        evaluation_point: &FieldElement<Field>,
+        primitive_root: &FieldElement<Field>,
+        challenges: &Challenges<FieldExtension>,
+        lde_trace_evaluations: &[FieldElement<FieldExtension>],
+        lde_composition_poly_parts_evaluation: &[FieldElement<FieldExtension>],
+    ) -> FieldElement<FieldExtension> {
         let ood_evaluations_table_height = proof.trace_ood_evaluations.height;
         let ood_evaluations_table_width = proof.trace_ood_evaluations.width;
         let trace_term_coeffs = &challenges.trace_term_coeffs;
@@ -679,7 +694,7 @@ pub trait IsStarkVerifier<A: AIR> {
 
         let mut denoms_trace = (0..ood_evaluations_table_height)
             .map(|row_idx| evaluation_point - primitive_root.pow(row_idx as u64) * &challenges.z)
-            .collect::<Vec<FieldElement<A::FieldExtension>>>();
+            .collect::<Vec<FieldElement<FieldExtension>>>();
         FieldElement::inplace_batch_inverse(&mut denoms_trace).unwrap();
 
         let trace_term = (0..ood_evaluations_table_width)
@@ -715,17 +730,16 @@ pub trait IsStarkVerifier<A: AIR> {
     /// Verifies a STARK proof with public inputs `pub_inputs`.
     /// Warning: the transcript must be safely initializated before passing it to this method.
     fn verify(
-        proof: &StarkProof<A::Field, A::FieldExtension>,
-        pub_input: &A::PublicInputs,
-        proof_options: &ProofOptions,
-        mut transcript: impl IsStarkTranscript<A::FieldExtension, A::Field>,
+        proof: &StarkProof<Field, FieldExtension>,
+        air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
     ) -> bool
     where
-        FieldElement<A::Field>: AsBytes + Sync + Send,
-        FieldElement<A::FieldExtension>: AsBytes + Sync + Send,
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
         // Verify there are enough queries
-        if proof.query_list.len() < proof_options.fri_number_of_queries {
+        if proof.query_list.len() < air.context().proof_options.fri_number_of_queries {
             return false;
         }
 
@@ -734,15 +748,10 @@ pub trait IsStarkVerifier<A: AIR> {
         #[cfg(feature = "instruments")]
         let timer1 = Instant::now();
 
-        let air = A::new(proof.trace_length, pub_input, proof_options);
-        let domain = Domain::new(&air);
+        let domain = new_domain(air);
 
-        let challenges = Self::step_1_replay_rounds_and_recover_challenges(
-            &air,
-            proof,
-            &domain,
-            &mut transcript,
-        );
+        let challenges =
+            Self::step_1_replay_rounds_and_recover_challenges(air, proof, &domain, transcript);
 
         // verify grinding
         let security_bits = air.context().proof_options.grinding_factor;
@@ -767,7 +776,7 @@ pub trait IsStarkVerifier<A: AIR> {
         #[cfg(feature = "instruments")]
         let timer2 = Instant::now();
 
-        if !Self::step_2_verify_claimed_composition_polynomial(&air, proof, &domain, &challenges) {
+        if !Self::step_2_verify_claimed_composition_polynomial(air, proof, &domain, &challenges) {
             error!("Composition Polynomial verification failed");
             return false;
         }

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -7,7 +7,7 @@ use super::{
     traits::{AIR, TransitionEvaluationContext},
 };
 use crate::{config::Commitment, proof::stark::DeepPolynomialOpening};
-use crypto::{fiat_shamir::is_transcript::IsTranscript, merkle_tree::proof::Proof};
+use crypto::{fiat_shamir::is_transcript::IsStarkTranscript, merkle_tree::proof::Proof};
 #[cfg(not(feature = "test_fiat_shamir"))]
 use log::error;
 use math::{
@@ -63,7 +63,7 @@ pub trait IsStarkVerifier<A: AIR> {
     fn sample_query_indexes(
         number_of_queries: usize,
         domain: &Domain<A::Field>,
-        transcript: &mut impl IsTranscript<A::FieldExtension>,
+        transcript: &mut impl IsStarkTranscript<A::FieldExtension, A::Field>,
     ) -> Vec<usize> {
         let domain_size = domain.lde_roots_of_unity_coset.len() as u64;
         (0..number_of_queries)
@@ -76,7 +76,7 @@ pub trait IsStarkVerifier<A: AIR> {
         air: &A,
         proof: &StarkProof<A::Field, A::FieldExtension>,
         domain: &Domain<A::Field>,
-        transcript: &mut impl IsTranscript<A::FieldExtension>,
+        transcript: &mut impl IsStarkTranscript<A::FieldExtension, A::Field>,
     ) -> Challenges<A>
     where
         FieldElement<A::Field>: AsBytes,
@@ -143,7 +143,7 @@ pub trait IsStarkVerifier<A: AIR> {
 
         let num_terms_composition_poly = proof.composition_poly_parts_ood_evaluation.len();
         let num_terms_trace =
-            air.context().transition_offsets.len() * A::STEP_SIZE * air.context().trace_columns;
+            air.context().transition_offsets.len() * air.step_size() * air.context().trace_columns;
         let gamma = transcript.sample_field_element();
 
         // <<<< Receive challenges: 𝛾, 𝛾'
@@ -155,7 +155,7 @@ pub trait IsStarkVerifier<A: AIR> {
         let trace_term_coeffs: Vec<_> = deep_composition_coefficients
             .drain(..num_terms_trace)
             .collect::<Vec<_>>()
-            .chunks(air.context().transition_offsets.len() * A::STEP_SIZE)
+            .chunks(air.context().transition_offsets.len() * air.step_size())
             .map(|chunk| chunk.to_vec())
             .collect();
 
@@ -273,7 +273,7 @@ pub trait IsStarkVerifier<A: AIR> {
             proof.trace_ood_evaluations.width - air.num_auxiliary_rap_columns();
 
         let ood_frame =
-            (proof.trace_ood_evaluations).into_frame(num_main_trace_columns, A::STEP_SIZE);
+            (proof.trace_ood_evaluations).into_frame(num_main_trace_columns, air.step_size());
         let transition_evaluation_context = TransitionEvaluationContext::new_verifier(
             &ood_frame,
             &periodic_values,
@@ -718,7 +718,7 @@ pub trait IsStarkVerifier<A: AIR> {
         proof: &StarkProof<A::Field, A::FieldExtension>,
         pub_input: &A::PublicInputs,
         proof_options: &ProofOptions,
-        mut transcript: impl IsTranscript<A::FieldExtension>,
+        mut transcript: impl IsStarkTranscript<A::FieldExtension, A::Field>,
     ) -> bool
     where
         FieldElement<A::Field>: AsBytes + Sync + Send,

--- a/prover/src/constraints/cpu_air.rs
+++ b/prover/src/constraints/cpu_air.rs
@@ -77,8 +77,6 @@ impl AIR for CPUTableAIR {
     type FieldExtension = Degree4BabyBearU32ExtensionField;
     type PublicInputs = ();
 
-    const STEP_SIZE: usize = 1;
-
     fn new(
         trace_length: usize,
         _pub_inputs: &Self::PublicInputs,
@@ -213,6 +211,10 @@ impl AIR for CPUTableAIR {
 
     fn pub_inputs(&self) -> &Self::PublicInputs {
         &()
+    }
+
+    fn step_size(&self) -> usize {
+        1
     }
 }
 

--- a/prover/src/tests/cpu_table.rs
+++ b/prover/src/tests/cpu_table.rs
@@ -647,11 +647,10 @@ mod tests {
         )
         .unwrap();
 
-        assert!(Verifier::<CPUTableAIR>::verify(
+        assert!(Verifier::verify(
             &proof,
-            &(),
-            &proof_options,
-            DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
+            &air,
+            &mut DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
         ));
     }
 
@@ -671,11 +670,10 @@ mod tests {
         )
         .unwrap();
 
-        assert!(Verifier::<CPUTableAIR>::verify(
+        assert!(Verifier::verify(
             &proof,
-            &(),
-            &proof_options,
-            DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
+            &air,
+            &mut DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
         ));
     }
 }

--- a/prover/src/tests/cpu_table.rs
+++ b/prover/src/tests/cpu_table.rs
@@ -626,6 +626,7 @@ mod tests {
     use crate::tables::cpu::cpu_trace_from_logs;
     use crypto::fiat_shamir::default_transcript::DefaultTranscript;
     use math::field::fields::fft_friendly::quartic_babybear_u32::Degree4BabyBearU32ExtensionField;
+    use stark::traits::AIR;
     use stark::{
         proof::options::ProofOptions,
         prover::{IsStarkProver, Prover},
@@ -637,11 +638,12 @@ mod tests {
         let mut trace = build_cpu_trace(columns);
         let proof_options = ProofOptions::default_test_options();
 
-        let proof = Prover::<CPUTableAIR>::prove(
+        let air = CPUTableAIR::new(trace.num_rows(), &(), &proof_options);
+
+        let proof = Prover::<Babybear31PrimeField, Degree4BabyBearU32ExtensionField, _>::prove(
+            &air,
             &mut trace,
-            &(),
-            &proof_options,
-            DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
+            &mut DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
         )
         .unwrap();
 
@@ -660,11 +662,12 @@ mod tests {
 
         let proof_options = ProofOptions::default_test_options();
 
-        let proof = Prover::<CPUTableAIR>::prove(
+        let air = CPUTableAIR::new(trace.num_rows(), &(), &proof_options);
+
+        let proof = Prover::<Babybear31PrimeField, Degree4BabyBearU32ExtensionField, _>::prove(
+            &air,
             &mut trace,
-            &(),
-            &proof_options,
-            DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
+            &mut DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
         )
         .unwrap();
 

--- a/prover/src/tests/integration_tests.rs
+++ b/prover/src/tests/integration_tests.rs
@@ -31,11 +31,10 @@ pub fn run_program_and_prover(elf_path: &str) {
     )
     .unwrap();
 
-    assert!(Verifier::<CPUTableAIR>::verify(
+    assert!(Verifier::verify(
         &proof,
-        &(),
-        &proof_options,
-        DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
+        &air,
+        &mut DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
     ));
 }
 

--- a/prover/src/tests/integration_tests.rs
+++ b/prover/src/tests/integration_tests.rs
@@ -1,10 +1,13 @@
 use crate::{constraints::cpu_air::CPUTableAIR, tables::cpu::cpu_trace_from_logs};
 use crypto::fiat_shamir::default_transcript::DefaultTranscript;
 use executor::{elf::Elf, vm::execution::run_program};
-use math::field::fields::fft_friendly::quartic_babybear_u32::Degree4BabyBearU32ExtensionField;
+use math::field::fields::fft_friendly::{
+    babybear_u32::Babybear31PrimeField, quartic_babybear_u32::Degree4BabyBearU32ExtensionField,
+};
 use stark::{
     proof::options::ProofOptions,
     prover::{IsStarkProver, Prover},
+    traits::AIR,
     verifier::{IsStarkVerifier, Verifier},
 };
 
@@ -19,11 +22,12 @@ pub fn run_program_and_prover(elf_path: &str) {
 
     let proof_options = ProofOptions::default_test_options();
 
-    let proof = Prover::<CPUTableAIR>::prove(
+    let air = CPUTableAIR::new(trace.num_rows(), &(), &proof_options);
+
+    let proof = Prover::<Babybear31PrimeField, Degree4BabyBearU32ExtensionField, _>::prove(
+        &air,
         &mut trace,
-        &(),
-        &proof_options,
-        DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
+        &mut DefaultTranscript::<Degree4BabyBearU32ExtensionField>::new(&[]),
     )
     .unwrap();
 


### PR DESCRIPTION
Includes changes from https://github.com/lambdaclass/lambdaworks/pull/1059 (up to commit [08e0707](https://github.com/lambdaclass/lambdaworks/pull/1059/commits/08e070772ba6081eb84cc166dacc8fcb8f155472))
* Add `multi_prove` & `multi_verify` functions to prove and verify multiple AIRs at once (basic skeleton)
* Refactor multiple apis to allow this change