### PR TITLE
feat(crypto/math): add quadratic and cubic extensions for Goldilocks

### DIFF
--- a/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
@@ -162,9 +162,7 @@ impl IsSubFieldOf<Degree2GoldilocksExtensionField> for U64GoldilocksPrimeField {
         b: &<Degree2GoldilocksExtensionField as IsField>::BaseType,
     ) -> Result<<Degree2GoldilocksExtensionField as IsField>::BaseType, FieldError> {
         let b_inv = Degree2GoldilocksExtensionField::inv(b)?;
-        Ok(<Self as IsSubFieldOf<Degree2GoldilocksExtensionField>>::mul(
-            a, &b_inv,
-        ))
+        Ok(<Self as IsSubFieldOf<Degree2GoldilocksExtensionField>>::mul(a, &b_inv))
     }
 
     fn sub(
@@ -391,9 +389,7 @@ impl IsSubFieldOf<Degree3GoldilocksExtensionField> for U64GoldilocksPrimeField {
         b: &<Degree3GoldilocksExtensionField as IsField>::BaseType,
     ) -> Result<<Degree3GoldilocksExtensionField as IsField>::BaseType, FieldError> {
         let b_inv = Degree3GoldilocksExtensionField::inv(b)?;
-        Ok(<Self as IsSubFieldOf<Degree3GoldilocksExtensionField>>::mul(
-            a, &b_inv,
-        ))
+        Ok(<Self as IsSubFieldOf<Degree3GoldilocksExtensionField>>::mul(a, &b_inv))
     }
 
     fn sub(
@@ -420,7 +416,6 @@ impl IsSubFieldOf<Degree3GoldilocksExtensionField> for U64GoldilocksPrimeField {
 
 /// Field element type for the cubic extension of Goldilocks
 pub type Fp3E = FieldElement<Degree3GoldilocksExtensionField>;
-
 
 #[cfg(test)]
 mod tests {
@@ -733,5 +728,4 @@ mod tests {
         let result = (a / b).unwrap();
         assert_eq!(result * b, a);
     }
-
 }

--- a/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
@@ -29,8 +29,7 @@ impl HasQuadraticNonResidue<U64GoldilocksPrimeField> for U64GoldilocksPrimeField
 }
 
 /// Field element type for the quadratic extension of Goldilocks
-pub type Degree2GoldilocksExtensionFieldElement =
-    FieldElement<Degree2GoldilocksExtensionField>;
+pub type Degree2GoldilocksExtensionFieldElement = FieldElement<Degree2GoldilocksExtensionField>;
 
 // =====================================================
 // CUBIC EXTENSION (Fp3)
@@ -56,8 +55,7 @@ pub type Degree3GoldilocksExtensionField =
     CubicExtensionField<U64GoldilocksPrimeField, GoldilocksCubicNonResidue>;
 
 /// Field element type for the cubic extension of Goldilocks
-pub type Degree3GoldilocksExtensionFieldElement =
-    FieldElement<Degree3GoldilocksExtensionField>;
+pub type Degree3GoldilocksExtensionFieldElement = FieldElement<Degree3GoldilocksExtensionField>;
 
 #[cfg(test)]
 mod tests {
@@ -328,8 +326,14 @@ mod tests {
 
     #[test]
     fn test_fp2_large_values() {
-        let a = Fp2E::new([FpE::from(18446744069414584300u64), FpE::from(12345678901234567u64)]);
-        let b = Fp2E::new([FpE::from(9876543210987654u64), FpE::from(11111111111111111u64)]);
+        let a = Fp2E::new([
+            FpE::from(18446744069414584300u64),
+            FpE::from(12345678901234567u64),
+        ]);
+        let b = Fp2E::new([
+            FpE::from(9876543210987654u64),
+            FpE::from(11111111111111111u64),
+        ]);
 
         // Test that a * a^-1 = 1
         let a_inv = a.inv().unwrap();

--- a/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
@@ -1,10 +1,8 @@
 use crate::field::{
     element::FieldElement,
-    extensions::{
-        cubic::{CubicExtensionField, HasCubicNonResidue},
-        quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
-    },
+    errors::FieldError,
     fields::fft_friendly::u64_goldilocks::U64GoldilocksPrimeField,
+    traits::{IsField, IsSubFieldOf},
 };
 
 // =====================================================
@@ -14,22 +12,191 @@ use crate::field::{
 // The quadratic extension is constructed using x^2 - 7,
 // where 7 is a quadratic non-residue in the Goldilocks field.
 // This means Fp2 = Fp[x] / (x^2 - 7)
+// Elements are represented as a0 + a1*w where w^2 = 7
 
-/// Quadratic field extension of Goldilocks (degree 2)
-/// Elements are represented as a + b*w where w^2 = 7
-pub type Degree2GoldilocksExtensionField =
-    QuadraticExtensionField<U64GoldilocksPrimeField, U64GoldilocksPrimeField>;
+type FpE = FieldElement<U64GoldilocksPrimeField>;
 
-impl HasQuadraticNonResidue<U64GoldilocksPrimeField> for U64GoldilocksPrimeField {
-    /// Returns the quadratic non-residue used for the extension.
-    /// We use 7, which is verified to be a quadratic non-residue in the Goldilocks field.
-    fn residue() -> FieldElement<U64GoldilocksPrimeField> {
-        FieldElement::from(7u64)
+/// The quadratic non-residue W = 7 for the quadratic extension.
+/// Fp2 is constructed as Fp[x] / (x^2 - 7)
+pub const QUADRATIC_NON_RESIDUE: FpE = FpE::from_hex_unchecked("7");
+
+/// Degree 2 extension field of Goldilocks
+#[derive(Copy, Clone, Debug)]
+pub struct Degree2GoldilocksExtensionField;
+
+impl IsField for Degree2GoldilocksExtensionField {
+    type BaseType = [FpE; 2];
+
+    /// Returns the component-wise addition of `a` and `b`
+    fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        [a[0] + b[0], a[1] + b[1]]
+    }
+
+    /// Returns the multiplication of `a` and `b`:
+    /// (a0 + a1*w) * (b0 + b1*w) = (a0*b0 + W*a1*b1) + (a0*b1 + a1*b0)*w
+    /// where w^2 = W = 7
+    fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        let a0b0 = a[0] * b[0];
+        let a1b1 = a[1] * b[1];
+        let z = (a[0] + a[1]) * (b[0] + b[1]);
+        [a0b0 + QUADRATIC_NON_RESIDUE * a1b1, z - a0b0 - a1b1]
+    }
+
+    /// Returns the square of `a`:
+    /// (a0 + a1*w)^2 = (a0^2 + W*a1^2) + 2*a0*a1*w
+    fn square(a: &Self::BaseType) -> Self::BaseType {
+        let a0_sq = a[0].square();
+        let a1_sq = a[1].square();
+        let a0a1 = a[0] * a[1];
+        [a0_sq + QUADRATIC_NON_RESIDUE * a1_sq, a0a1.double()]
+    }
+
+    /// Returns the component-wise subtraction of `a` and `b`
+    fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        [a[0] - b[0], a[1] - b[1]]
+    }
+
+    /// Returns the component-wise negation of `a`
+    fn neg(a: &Self::BaseType) -> Self::BaseType {
+        [-a[0], -a[1]]
+    }
+
+    /// Returns the multiplicative inverse of `a`:
+    /// (a0 + a1*w)^-1 = (a0 - a1*w) / (a0^2 - W*a1^2)
+    /// The norm is a0^2 - W*a1^2. This is never zero for non-zero elements
+    /// because W=7 is a quadratic non-residue (no x exists where x^2 = 7).
+    fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
+        let norm = a[0].square() - QUADRATIC_NON_RESIDUE * a[1].square();
+        let norm_inv = norm.inv()?;
+        Ok([a[0] * norm_inv, -a[1] * norm_inv])
+    }
+
+    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
+        let b_inv = Self::inv(b)?;
+        Ok(<Self as IsField>::mul(a, &b_inv))
+    }
+
+    fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool {
+        a[0] == b[0] && a[1] == b[1]
+    }
+
+    fn zero() -> Self::BaseType {
+        [FpE::zero(), FpE::zero()]
+    }
+
+    fn one() -> Self::BaseType {
+        [FpE::one(), FpE::zero()]
+    }
+
+    fn from_u64(x: u64) -> Self::BaseType {
+        [FpE::from(x), FpE::zero()]
+    }
+
+    fn from_base_type(x: Self::BaseType) -> Self::BaseType {
+        x
+    }
+
+    fn double(a: &Self::BaseType) -> Self::BaseType {
+        [a[0].double(), a[1].double()]
+    }
+
+    fn pow<T>(a: &Self::BaseType, mut exponent: T) -> Self::BaseType
+    where
+        T: crate::unsigned_integer::traits::IsUnsignedInteger,
+    {
+        let zero = T::from(0);
+        let one = T::from(1);
+
+        if exponent == zero {
+            return Self::one();
+        }
+        if exponent == one {
+            return *a;
+        }
+
+        let mut result = *a;
+
+        while exponent & one == zero {
+            result = Self::square(&result);
+            exponent >>= 1;
+            if exponent == zero {
+                return result;
+            }
+        }
+
+        let mut base = result;
+        exponent >>= 1;
+
+        while exponent != zero {
+            base = Self::square(&base);
+            if exponent & one == one {
+                result = <Self as IsField>::mul(&result, &base);
+            }
+            exponent >>= 1;
+        }
+
+        result
+    }
+}
+
+impl IsSubFieldOf<Degree2GoldilocksExtensionField> for U64GoldilocksPrimeField {
+    fn mul(
+        a: &Self::BaseType,
+        b: &<Degree2GoldilocksExtensionField as IsField>::BaseType,
+    ) -> <Degree2GoldilocksExtensionField as IsField>::BaseType {
+        let c0 = FpE::from_raw(<Self as IsField>::mul(a, b[0].value()));
+        let c1 = FpE::from_raw(<Self as IsField>::mul(a, b[1].value()));
+        [c0, c1]
+    }
+
+    fn add(
+        a: &Self::BaseType,
+        b: &<Degree2GoldilocksExtensionField as IsField>::BaseType,
+    ) -> <Degree2GoldilocksExtensionField as IsField>::BaseType {
+        let c0 = FpE::from_raw(<Self as IsField>::add(a, b[0].value()));
+        [c0, b[1]]
+    }
+
+    fn div(
+        a: &Self::BaseType,
+        b: &<Degree2GoldilocksExtensionField as IsField>::BaseType,
+    ) -> Result<<Degree2GoldilocksExtensionField as IsField>::BaseType, FieldError> {
+        let b_inv = Degree2GoldilocksExtensionField::inv(b)?;
+        Ok(<Self as IsSubFieldOf<Degree2GoldilocksExtensionField>>::mul(
+            a, &b_inv,
+        ))
+    }
+
+    fn sub(
+        a: &Self::BaseType,
+        b: &<Degree2GoldilocksExtensionField as IsField>::BaseType,
+    ) -> <Degree2GoldilocksExtensionField as IsField>::BaseType {
+        let c0 = FpE::from_raw(<Self as IsField>::sub(a, b[0].value()));
+        let c1 = FpE::from_raw(<Self as IsField>::neg(b[1].value()));
+        [c0, c1]
+    }
+
+    fn embed(a: Self::BaseType) -> <Degree2GoldilocksExtensionField as IsField>::BaseType {
+        [FpE::from_raw(a), FpE::zero()]
+    }
+
+    #[cfg(feature = "alloc")]
+    fn to_subfield_vec(
+        b: <Degree2GoldilocksExtensionField as IsField>::BaseType,
+    ) -> alloc::vec::Vec<Self::BaseType> {
+        b.into_iter().map(|x| x.to_raw()).collect()
     }
 }
 
 /// Field element type for the quadratic extension of Goldilocks
-pub type Degree2GoldilocksExtensionFieldElement = FieldElement<Degree2GoldilocksExtensionField>;
+pub type Fp2E = FieldElement<Degree2GoldilocksExtensionField>;
+
+impl Fp2E {
+    /// Returns the conjugate of self: conjugate(a0 + a1*w) = a0 - a1*w
+    pub fn conjugate(&self) -> Self {
+        Self::new([self.value()[0], -self.value()[1]])
+    }
+}
 
 // =====================================================
 // CUBIC EXTENSION (Fp3)
@@ -37,33 +204,227 @@ pub type Degree2GoldilocksExtensionFieldElement = FieldElement<Degree2Goldilocks
 // The cubic extension is constructed using x^3 - 2,
 // where 2 is a cubic non-residue in the Goldilocks field.
 // This means Fp3 = Fp[x] / (x^3 - 2)
+// Elements are represented as a0 + a1*w + a2*w^2 where w^3 = 2
+//
+// Since the non-residue is 2, we use .double() for efficiency
+// instead of multiplying by the non-residue constant.
 
-#[derive(Debug, Clone)]
-pub struct GoldilocksCubicNonResidue;
+/// Degree 3 extension field of Goldilocks
+#[derive(Copy, Clone, Debug)]
+pub struct Degree3GoldilocksExtensionField;
 
-impl HasCubicNonResidue<U64GoldilocksPrimeField> for GoldilocksCubicNonResidue {
-    /// Returns the cubic non-residue used for the extension.
-    /// We use 2, which is a cubic non-residue in the Goldilocks field.
-    fn residue() -> FieldElement<U64GoldilocksPrimeField> {
-        FieldElement::from(2u64)
+impl IsField for Degree3GoldilocksExtensionField {
+    type BaseType = [FpE; 3];
+
+    /// Returns the component-wise addition of `a` and `b`
+    fn add(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+    }
+
+    /// Returns the multiplication of `a` and `b`:
+    /// (a0 + a1*w + a2*w^2) * (b0 + b1*w + b2*w^2) mod (w^3 - 2)
+    /// Using Karatsuba-like optimization with W=2 replaced by .double()
+    fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        let v0 = a[0] * b[0];
+        let v1 = a[1] * b[1];
+        let v2 = a[2] * b[2];
+
+        // c0 = v0 + 2 * ((a1 + a2)(b1 + b2) - v1 - v2)
+        // c1 = (a0 + a1)(b0 + b1) - v0 - v1 + 2 * v2
+        // c2 = (a0 + a2)(b0 + b2) - v0 + v1 - v2
+        [
+            v0 + ((a[1] + a[2]) * (b[1] + b[2]) - v1 - v2).double(),
+            (a[0] + a[1]) * (b[0] + b[1]) - v0 - v1 + v2.double(),
+            (a[0] + a[2]) * (b[0] + b[2]) - v0 + v1 - v2,
+        ]
+    }
+
+    /// Returns the square of `a`
+    fn square(a: &Self::BaseType) -> Self::BaseType {
+        let s0 = a[0].square();
+        let s1 = a[1].square();
+        let s2 = a[2].square();
+        let a01 = a[0] * a[1];
+        let a02 = a[0] * a[2];
+        let a12 = a[1] * a[2];
+
+        // c0 = s0 + 2 * 2 * a12 = s0 + 4 * a12
+        // c1 = 2 * a01 + 2 * s2
+        // c2 = 2 * a02 + s1
+        [
+            s0 + a12.double().double(),
+            a01.double() + s2.double(),
+            a02.double() + s1,
+        ]
+    }
+
+    /// Returns the component-wise subtraction of `a` and `b`
+    fn sub(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
+        [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+    }
+
+    /// Returns the component-wise negation of `a`
+    fn neg(a: &Self::BaseType) -> Self::BaseType {
+        [-a[0], -a[1], -a[2]]
+    }
+
+    /// Returns the multiplicative inverse of `a`
+    /// Using the formula for cubic extension inverse with W=2
+    fn inv(a: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
+        let a0_sq = a[0].square();
+        let a1_sq = a[1].square();
+        let a2_sq = a[2].square();
+
+        // W = 2, W^2 = 4
+        // Compute the norm: N = a0^3 + 2*a1^3 + 4*a2^3 - 6*a0*a1*a2
+        let a0_cubed = a0_sq * a[0];
+        let a1_cubed = a1_sq * a[1];
+        let a2_cubed = a2_sq * a[2];
+        let a0a1a2 = a[0] * a[1] * a[2];
+
+        // N = a0^3 + 2*a1^3 + 4*a2^3 - 6*a0*a1*a2
+        let norm = a0_cubed + a1_cubed.double() + a2_cubed.double().double()
+            - (a0a1a2.double() + a0a1a2).double();
+
+        let norm_inv = norm.inv()?;
+
+        // Compute inverse components:
+        // inv[0] = (a0^2 - 2*a1*a2) / N
+        // inv[1] = (2*a2^2 - a0*a1) / N
+        // inv[2] = (a1^2 - a0*a2) / N
+        Ok([
+            (a0_sq - (a[1] * a[2]).double()) * norm_inv,
+            (a2_sq.double() - a[0] * a[1]) * norm_inv,
+            (a1_sq - a[0] * a[2]) * norm_inv,
+        ])
+    }
+
+    fn div(a: &Self::BaseType, b: &Self::BaseType) -> Result<Self::BaseType, FieldError> {
+        let b_inv = Self::inv(b)?;
+        Ok(<Self as IsField>::mul(a, &b_inv))
+    }
+
+    fn eq(a: &Self::BaseType, b: &Self::BaseType) -> bool {
+        a[0] == b[0] && a[1] == b[1] && a[2] == b[2]
+    }
+
+    fn zero() -> Self::BaseType {
+        [FpE::zero(), FpE::zero(), FpE::zero()]
+    }
+
+    fn one() -> Self::BaseType {
+        [FpE::one(), FpE::zero(), FpE::zero()]
+    }
+
+    fn from_u64(x: u64) -> Self::BaseType {
+        [FpE::from(x), FpE::zero(), FpE::zero()]
+    }
+
+    fn from_base_type(x: Self::BaseType) -> Self::BaseType {
+        x
+    }
+
+    fn double(a: &Self::BaseType) -> Self::BaseType {
+        [a[0].double(), a[1].double(), a[2].double()]
+    }
+
+    fn pow<T>(a: &Self::BaseType, mut exponent: T) -> Self::BaseType
+    where
+        T: crate::unsigned_integer::traits::IsUnsignedInteger,
+    {
+        let zero = T::from(0);
+        let one = T::from(1);
+
+        if exponent == zero {
+            return Self::one();
+        }
+        if exponent == one {
+            return *a;
+        }
+
+        let mut result = *a;
+
+        while exponent & one == zero {
+            result = Self::square(&result);
+            exponent >>= 1;
+            if exponent == zero {
+                return result;
+            }
+        }
+
+        let mut base = result;
+        exponent >>= 1;
+
+        while exponent != zero {
+            base = Self::square(&base);
+            if exponent & one == one {
+                result = <Self as IsField>::mul(&result, &base);
+            }
+            exponent >>= 1;
+        }
+
+        result
     }
 }
 
-/// Cubic field extension of Goldilocks (degree 3)
-/// Elements are represented as a + b*w + c*w^2 where w^3 = 2
-pub type Degree3GoldilocksExtensionField =
-    CubicExtensionField<U64GoldilocksPrimeField, GoldilocksCubicNonResidue>;
+impl IsSubFieldOf<Degree3GoldilocksExtensionField> for U64GoldilocksPrimeField {
+    fn mul(
+        a: &Self::BaseType,
+        b: &<Degree3GoldilocksExtensionField as IsField>::BaseType,
+    ) -> <Degree3GoldilocksExtensionField as IsField>::BaseType {
+        let c0 = FpE::from_raw(<Self as IsField>::mul(a, b[0].value()));
+        let c1 = FpE::from_raw(<Self as IsField>::mul(a, b[1].value()));
+        let c2 = FpE::from_raw(<Self as IsField>::mul(a, b[2].value()));
+        [c0, c1, c2]
+    }
+
+    fn add(
+        a: &Self::BaseType,
+        b: &<Degree3GoldilocksExtensionField as IsField>::BaseType,
+    ) -> <Degree3GoldilocksExtensionField as IsField>::BaseType {
+        let c0 = FpE::from_raw(<Self as IsField>::add(a, b[0].value()));
+        [c0, b[1], b[2]]
+    }
+
+    fn div(
+        a: &Self::BaseType,
+        b: &<Degree3GoldilocksExtensionField as IsField>::BaseType,
+    ) -> Result<<Degree3GoldilocksExtensionField as IsField>::BaseType, FieldError> {
+        let b_inv = Degree3GoldilocksExtensionField::inv(b)?;
+        Ok(<Self as IsSubFieldOf<Degree3GoldilocksExtensionField>>::mul(
+            a, &b_inv,
+        ))
+    }
+
+    fn sub(
+        a: &Self::BaseType,
+        b: &<Degree3GoldilocksExtensionField as IsField>::BaseType,
+    ) -> <Degree3GoldilocksExtensionField as IsField>::BaseType {
+        let c0 = FpE::from_raw(<Self as IsField>::sub(a, b[0].value()));
+        let c1 = FpE::from_raw(<Self as IsField>::neg(b[1].value()));
+        let c2 = FpE::from_raw(<Self as IsField>::neg(b[2].value()));
+        [c0, c1, c2]
+    }
+
+    fn embed(a: Self::BaseType) -> <Degree3GoldilocksExtensionField as IsField>::BaseType {
+        [FpE::from_raw(a), FpE::zero(), FpE::zero()]
+    }
+
+    #[cfg(feature = "alloc")]
+    fn to_subfield_vec(
+        b: <Degree3GoldilocksExtensionField as IsField>::BaseType,
+    ) -> alloc::vec::Vec<Self::BaseType> {
+        b.into_iter().map(|x| x.to_raw()).collect()
+    }
+}
 
 /// Field element type for the cubic extension of Goldilocks
-pub type Degree3GoldilocksExtensionFieldElement = FieldElement<Degree3GoldilocksExtensionField>;
+pub type Fp3E = FieldElement<Degree3GoldilocksExtensionField>;
+
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    type FpE = FieldElement<U64GoldilocksPrimeField>;
-    type Fp2E = Degree2GoldilocksExtensionFieldElement;
-    type Fp3E = Degree3GoldilocksExtensionFieldElement;
 
     // =====================================================
     // QUADRATIC EXTENSION TESTS
@@ -100,21 +461,21 @@ mod tests {
     fn test_fp2_mul_by_one() {
         let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
         let one = Fp2E::one();
-        assert_eq!(&a * &one, a);
+        assert_eq!(a * one, a);
     }
 
     #[test]
     fn test_fp2_mul_by_zero() {
         let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
         let zero = Fp2E::zero();
-        assert_eq!(&a * &zero, zero);
+        assert_eq!(a * zero, zero);
     }
 
     #[test]
     fn test_fp2_inv() {
         let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
         let a_inv = a.inv().unwrap();
-        assert_eq!(&a * &a_inv, Fp2E::one());
+        assert_eq!(a * a_inv, Fp2E::one());
     }
 
     #[test]
@@ -127,16 +488,15 @@ mod tests {
     fn test_fp2_div() {
         let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
         let b = Fp2E::new([FpE::from(4u64), FpE::from(2u64)]);
-        let result = (&a / &b).unwrap();
-        // Verify: result * b = a
-        assert_eq!(&result * &b, a);
+        let result = (a / b).unwrap();
+        assert_eq!(result * b, a);
     }
 
     #[test]
     fn test_fp2_pow() {
         let a = Fp2E::new([FpE::from(2u64), FpE::from(3u64)]);
-        let a_squared = &a * &a;
-        let a_cubed = &a_squared * &a;
+        let a_squared = a * a;
+        let a_cubed = a_squared * a;
         assert_eq!(a.pow(2u64), a_squared);
         assert_eq!(a.pow(3u64), a_cubed);
     }
@@ -151,14 +511,20 @@ mod tests {
     #[test]
     fn test_fp2_neg() {
         let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
-        let neg_a = -&a;
-        assert_eq!(&a + &neg_a, Fp2E::zero());
+        let neg_a = -a;
+        assert_eq!(a + neg_a, Fp2E::zero());
     }
 
     #[test]
     fn test_fp2_square_equals_mul() {
         let a = Fp2E::new([FpE::from(7u64), FpE::from(11u64)]);
-        assert_eq!(a.square(), &a * &a);
+        assert_eq!(a.square(), a * a);
+    }
+
+    #[test]
+    fn test_fp2_double() {
+        let a = Fp2E::new([FpE::from(7u64), FpE::from(11u64)]);
+        assert_eq!(a.double(), a + a);
     }
 
     // =====================================================
@@ -185,29 +551,28 @@ mod tests {
     fn test_fp3_mul_by_one() {
         let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
         let one = Fp3E::one();
-        assert_eq!(&a * &one, a);
+        assert_eq!(a * one, a);
     }
 
     #[test]
     fn test_fp3_mul_by_zero() {
         let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
         let zero = Fp3E::zero();
-        assert_eq!(&a * &zero, zero);
+        assert_eq!(a * zero, zero);
     }
 
     #[test]
-    fn test_fp3_mul() {
+    fn test_fp3_mul_commutativity() {
         let a = Fp3E::new([FpE::from(1u64), FpE::from(2u64), FpE::from(3u64)]);
         let b = Fp3E::new([FpE::from(4u64), FpE::from(5u64), FpE::from(6u64)]);
-        // Verify multiplication is commutative
-        assert_eq!(&a * &b, &b * &a);
+        assert_eq!(a * b, b * a);
     }
 
     #[test]
     fn test_fp3_inv() {
         let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
         let a_inv = a.inv().unwrap();
-        assert_eq!(&a * &a_inv, Fp3E::one());
+        assert_eq!(a * a_inv, Fp3E::one());
     }
 
     #[test]
@@ -220,16 +585,15 @@ mod tests {
     fn test_fp3_div() {
         let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
         let b = Fp3E::new([FpE::from(4u64), FpE::from(2u64), FpE::from(3u64)]);
-        let result = (&a / &b).unwrap();
-        // Verify: result * b = a
-        assert_eq!(&result * &b, a);
+        let result = (a / b).unwrap();
+        assert_eq!(result * b, a);
     }
 
     #[test]
     fn test_fp3_pow() {
         let a = Fp3E::new([FpE::from(2u64), FpE::from(3u64), FpE::from(4u64)]);
-        let a_squared = &a * &a;
-        let a_cubed = &a_squared * &a;
+        let a_squared = a * a;
+        let a_cubed = a_squared * a;
         assert_eq!(a.pow(2u64), a_squared);
         assert_eq!(a.pow(3u64), a_cubed);
     }
@@ -237,8 +601,20 @@ mod tests {
     #[test]
     fn test_fp3_neg() {
         let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
-        let neg_a = -&a;
-        assert_eq!(&a + &neg_a, Fp3E::zero());
+        let neg_a = -a;
+        assert_eq!(a + neg_a, Fp3E::zero());
+    }
+
+    #[test]
+    fn test_fp3_square_equals_mul() {
+        let a = Fp3E::new([FpE::from(7u64), FpE::from(11u64), FpE::from(13u64)]);
+        assert_eq!(a.square(), a * a);
+    }
+
+    #[test]
+    fn test_fp3_double() {
+        let a = Fp3E::new([FpE::from(7u64), FpE::from(11u64), FpE::from(13u64)]);
+        assert_eq!(a.double(), a + a);
     }
 
     // =====================================================
@@ -264,20 +640,18 @@ mod tests {
 
     #[test]
     fn test_fp2_base_mul() {
-        // Test that base field elements multiply correctly in the extension
         let a = FpE::from(5u64);
         let b = Fp2E::new([FpE::from(2u64), FpE::from(3u64)]);
-        let result = a * &b;
+        let result = a * b;
         let expected = Fp2E::new([FpE::from(10u64), FpE::from(15u64)]);
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_fp3_base_mul() {
-        // Test that base field elements multiply correctly in the extension
         let a = FpE::from(5u64);
         let b = Fp3E::new([FpE::from(2u64), FpE::from(3u64), FpE::from(4u64)]);
-        let result = a * &b;
+        let result = a * b;
         let expected = Fp3E::new([FpE::from(10u64), FpE::from(15u64), FpE::from(20u64)]);
         assert_eq!(result, expected);
     }
@@ -291,7 +665,7 @@ mod tests {
         let a = Fp2E::new([FpE::from(2u64), FpE::from(3u64)]);
         let b = Fp2E::new([FpE::from(4u64), FpE::from(5u64)]);
         let c = Fp2E::new([FpE::from(6u64), FpE::from(7u64)]);
-        assert_eq!(&(&a * &b) * &c, &a * &(&b * &c));
+        assert_eq!((a * b) * c, a * (b * c));
     }
 
     #[test]
@@ -299,7 +673,7 @@ mod tests {
         let a = Fp3E::new([FpE::from(2u64), FpE::from(3u64), FpE::from(4u64)]);
         let b = Fp3E::new([FpE::from(5u64), FpE::from(6u64), FpE::from(7u64)]);
         let c = Fp3E::new([FpE::from(8u64), FpE::from(9u64), FpE::from(10u64)]);
-        assert_eq!(&(&a * &b) * &c, &a * &(&b * &c));
+        assert_eq!((a * b) * c, a * (b * c));
     }
 
     #[test]
@@ -307,8 +681,7 @@ mod tests {
         let a = Fp2E::new([FpE::from(2u64), FpE::from(3u64)]);
         let b = Fp2E::new([FpE::from(4u64), FpE::from(5u64)]);
         let c = Fp2E::new([FpE::from(6u64), FpE::from(7u64)]);
-        // a * (b + c) = a * b + a * c
-        assert_eq!(&a * &(&b + &c), &(&a * &b) + &(&a * &c));
+        assert_eq!(a * (b + c), a * b + a * c);
     }
 
     #[test]
@@ -316,12 +689,11 @@ mod tests {
         let a = Fp3E::new([FpE::from(2u64), FpE::from(3u64), FpE::from(4u64)]);
         let b = Fp3E::new([FpE::from(5u64), FpE::from(6u64), FpE::from(7u64)]);
         let c = Fp3E::new([FpE::from(8u64), FpE::from(9u64), FpE::from(10u64)]);
-        // a * (b + c) = a * b + a * c
-        assert_eq!(&a * &(&b + &c), &(&a * &b) + &(&a * &c));
+        assert_eq!(a * (b + c), a * b + a * c);
     }
 
     // =====================================================
-    // RANDOM ELEMENT TESTS WITH LARGER VALUES
+    // LARGE VALUE TESTS
     // =====================================================
 
     #[test]
@@ -335,13 +707,11 @@ mod tests {
             FpE::from(11111111111111111u64),
         ]);
 
-        // Test that a * a^-1 = 1
         let a_inv = a.inv().unwrap();
-        assert_eq!(&a * &a_inv, Fp2E::one());
+        assert_eq!(a * a_inv, Fp2E::one());
 
-        // Test division
-        let result = (&a / &b).unwrap();
-        assert_eq!(&result * &b, a);
+        let result = (a / b).unwrap();
+        assert_eq!(result * b, a);
     }
 
     #[test]
@@ -357,12 +727,11 @@ mod tests {
             FpE::from(22222222222222222u64),
         ]);
 
-        // Test that a * a^-1 = 1
         let a_inv = a.inv().unwrap();
-        assert_eq!(&a * &a_inv, Fp3E::one());
+        assert_eq!(a * a_inv, Fp3E::one());
 
-        // Test division
-        let result = (&a / &b).unwrap();
-        assert_eq!(&result * &b, a);
+        let result = (a / b).unwrap();
+        assert_eq!(result * b, a);
     }
+
 }

--- a/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
@@ -1,0 +1,363 @@
+use crate::field::{
+    element::FieldElement,
+    extensions::{
+        cubic::{CubicExtensionField, HasCubicNonResidue},
+        quadratic::{HasQuadraticNonResidue, QuadraticExtensionField},
+    },
+    fields::fft_friendly::u64_goldilocks::U64GoldilocksPrimeField,
+};
+
+// =====================================================
+// QUADRATIC EXTENSION (Fp2)
+// =====================================================
+// The quadratic extension is constructed using x^2 - 7,
+// where 7 is a quadratic non-residue in the Goldilocks field.
+// This means Fp2 = Fp[x] / (x^2 - 7)
+
+/// Quadratic field extension of Goldilocks (degree 2)
+/// Elements are represented as a + b*w where w^2 = 7
+pub type Degree2GoldilocksExtensionField =
+    QuadraticExtensionField<U64GoldilocksPrimeField, U64GoldilocksPrimeField>;
+
+impl HasQuadraticNonResidue<U64GoldilocksPrimeField> for U64GoldilocksPrimeField {
+    /// Returns the quadratic non-residue used for the extension.
+    /// We use 7, which is verified to be a quadratic non-residue in the Goldilocks field.
+    fn residue() -> FieldElement<U64GoldilocksPrimeField> {
+        FieldElement::from(7u64)
+    }
+}
+
+/// Field element type for the quadratic extension of Goldilocks
+pub type Degree2GoldilocksExtensionFieldElement =
+    FieldElement<Degree2GoldilocksExtensionField>;
+
+// =====================================================
+// CUBIC EXTENSION (Fp3)
+// =====================================================
+// The cubic extension is constructed using x^3 - 2,
+// where 2 is a cubic non-residue in the Goldilocks field.
+// This means Fp3 = Fp[x] / (x^3 - 2)
+
+#[derive(Debug, Clone)]
+pub struct GoldilocksCubicNonResidue;
+
+impl HasCubicNonResidue<U64GoldilocksPrimeField> for GoldilocksCubicNonResidue {
+    /// Returns the cubic non-residue used for the extension.
+    /// We use 2, which is a cubic non-residue in the Goldilocks field.
+    fn residue() -> FieldElement<U64GoldilocksPrimeField> {
+        FieldElement::from(2u64)
+    }
+}
+
+/// Cubic field extension of Goldilocks (degree 3)
+/// Elements are represented as a + b*w + c*w^2 where w^3 = 2
+pub type Degree3GoldilocksExtensionField =
+    CubicExtensionField<U64GoldilocksPrimeField, GoldilocksCubicNonResidue>;
+
+/// Field element type for the cubic extension of Goldilocks
+pub type Degree3GoldilocksExtensionFieldElement =
+    FieldElement<Degree3GoldilocksExtensionField>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type FpE = FieldElement<U64GoldilocksPrimeField>;
+    type Fp2E = Degree2GoldilocksExtensionFieldElement;
+    type Fp3E = Degree3GoldilocksExtensionFieldElement;
+
+    // =====================================================
+    // QUADRATIC EXTENSION TESTS
+    // =====================================================
+
+    #[test]
+    fn test_fp2_add() {
+        let a = Fp2E::new([FpE::from(0u64), FpE::from(3u64)]);
+        let b = Fp2E::new([FpE::from(2u64), FpE::from(8u64)]);
+        let expected = Fp2E::new([FpE::from(2u64), FpE::from(11u64)]);
+        assert_eq!(a + b, expected);
+    }
+
+    #[test]
+    fn test_fp2_sub() {
+        let a = Fp2E::new([FpE::from(10u64), FpE::from(5u64)]);
+        let b = Fp2E::new([FpE::from(3u64), FpE::from(2u64)]);
+        let expected = Fp2E::new([FpE::from(7u64), FpE::from(3u64)]);
+        assert_eq!(a - b, expected);
+    }
+
+    #[test]
+    fn test_fp2_mul() {
+        // (a0 + a1*w) * (b0 + b1*w) = (a0*b0 + a1*b1*7) + (a0*b1 + a1*b0)*w
+        let a = Fp2E::new([FpE::from(2u64), FpE::from(3u64)]);
+        let b = Fp2E::new([FpE::from(4u64), FpE::from(5u64)]);
+        // c0 = 2*4 + 3*5*7 = 8 + 105 = 113
+        // c1 = 2*5 + 3*4 = 10 + 12 = 22
+        let expected = Fp2E::new([FpE::from(113u64), FpE::from(22u64)]);
+        assert_eq!(a * b, expected);
+    }
+
+    #[test]
+    fn test_fp2_mul_by_one() {
+        let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
+        let one = Fp2E::one();
+        assert_eq!(&a * &one, a);
+    }
+
+    #[test]
+    fn test_fp2_mul_by_zero() {
+        let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
+        let zero = Fp2E::zero();
+        assert_eq!(&a * &zero, zero);
+    }
+
+    #[test]
+    fn test_fp2_inv() {
+        let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
+        let a_inv = a.inv().unwrap();
+        assert_eq!(&a * &a_inv, Fp2E::one());
+    }
+
+    #[test]
+    fn test_fp2_inv_one() {
+        let one = Fp2E::one();
+        assert_eq!(one.inv().unwrap(), one);
+    }
+
+    #[test]
+    fn test_fp2_div() {
+        let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
+        let b = Fp2E::new([FpE::from(4u64), FpE::from(2u64)]);
+        let result = (&a / &b).unwrap();
+        // Verify: result * b = a
+        assert_eq!(&result * &b, a);
+    }
+
+    #[test]
+    fn test_fp2_pow() {
+        let a = Fp2E::new([FpE::from(2u64), FpE::from(3u64)]);
+        let a_squared = &a * &a;
+        let a_cubed = &a_squared * &a;
+        assert_eq!(a.pow(2u64), a_squared);
+        assert_eq!(a.pow(3u64), a_cubed);
+    }
+
+    #[test]
+    fn test_fp2_conjugate() {
+        let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
+        let expected = Fp2E::new([FpE::from(12u64), -FpE::from(5u64)]);
+        assert_eq!(a.conjugate(), expected);
+    }
+
+    #[test]
+    fn test_fp2_neg() {
+        let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
+        let neg_a = -&a;
+        assert_eq!(&a + &neg_a, Fp2E::zero());
+    }
+
+    #[test]
+    fn test_fp2_square_equals_mul() {
+        let a = Fp2E::new([FpE::from(7u64), FpE::from(11u64)]);
+        assert_eq!(a.square(), &a * &a);
+    }
+
+    // =====================================================
+    // CUBIC EXTENSION TESTS
+    // =====================================================
+
+    #[test]
+    fn test_fp3_add() {
+        let a = Fp3E::new([FpE::from(1u64), FpE::from(2u64), FpE::from(3u64)]);
+        let b = Fp3E::new([FpE::from(4u64), FpE::from(5u64), FpE::from(6u64)]);
+        let expected = Fp3E::new([FpE::from(5u64), FpE::from(7u64), FpE::from(9u64)]);
+        assert_eq!(a + b, expected);
+    }
+
+    #[test]
+    fn test_fp3_sub() {
+        let a = Fp3E::new([FpE::from(10u64), FpE::from(8u64), FpE::from(6u64)]);
+        let b = Fp3E::new([FpE::from(3u64), FpE::from(2u64), FpE::from(1u64)]);
+        let expected = Fp3E::new([FpE::from(7u64), FpE::from(6u64), FpE::from(5u64)]);
+        assert_eq!(a - b, expected);
+    }
+
+    #[test]
+    fn test_fp3_mul_by_one() {
+        let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
+        let one = Fp3E::one();
+        assert_eq!(&a * &one, a);
+    }
+
+    #[test]
+    fn test_fp3_mul_by_zero() {
+        let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
+        let zero = Fp3E::zero();
+        assert_eq!(&a * &zero, zero);
+    }
+
+    #[test]
+    fn test_fp3_mul() {
+        let a = Fp3E::new([FpE::from(1u64), FpE::from(2u64), FpE::from(3u64)]);
+        let b = Fp3E::new([FpE::from(4u64), FpE::from(5u64), FpE::from(6u64)]);
+        // Verify multiplication is commutative
+        assert_eq!(&a * &b, &b * &a);
+    }
+
+    #[test]
+    fn test_fp3_inv() {
+        let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
+        let a_inv = a.inv().unwrap();
+        assert_eq!(&a * &a_inv, Fp3E::one());
+    }
+
+    #[test]
+    fn test_fp3_inv_one() {
+        let one = Fp3E::one();
+        assert_eq!(one.inv().unwrap(), one);
+    }
+
+    #[test]
+    fn test_fp3_div() {
+        let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
+        let b = Fp3E::new([FpE::from(4u64), FpE::from(2u64), FpE::from(3u64)]);
+        let result = (&a / &b).unwrap();
+        // Verify: result * b = a
+        assert_eq!(&result * &b, a);
+    }
+
+    #[test]
+    fn test_fp3_pow() {
+        let a = Fp3E::new([FpE::from(2u64), FpE::from(3u64), FpE::from(4u64)]);
+        let a_squared = &a * &a;
+        let a_cubed = &a_squared * &a;
+        assert_eq!(a.pow(2u64), a_squared);
+        assert_eq!(a.pow(3u64), a_cubed);
+    }
+
+    #[test]
+    fn test_fp3_neg() {
+        let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
+        let neg_a = -&a;
+        assert_eq!(&a + &neg_a, Fp3E::zero());
+    }
+
+    // =====================================================
+    // EMBEDDING TESTS (Base field into extension)
+    // =====================================================
+
+    #[test]
+    fn test_fp2_from_base() {
+        let base = FpE::from(42u64);
+        let ext = Fp2E::from(42u64);
+        assert_eq!(ext.value()[0], base);
+        assert_eq!(ext.value()[1], FpE::zero());
+    }
+
+    #[test]
+    fn test_fp3_from_base() {
+        let base = FpE::from(42u64);
+        let ext = Fp3E::from(42u64);
+        assert_eq!(ext.value()[0], base);
+        assert_eq!(ext.value()[1], FpE::zero());
+        assert_eq!(ext.value()[2], FpE::zero());
+    }
+
+    #[test]
+    fn test_fp2_base_mul() {
+        // Test that base field elements multiply correctly in the extension
+        let a = FpE::from(5u64);
+        let b = Fp2E::new([FpE::from(2u64), FpE::from(3u64)]);
+        let result = a * &b;
+        let expected = Fp2E::new([FpE::from(10u64), FpE::from(15u64)]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_fp3_base_mul() {
+        // Test that base field elements multiply correctly in the extension
+        let a = FpE::from(5u64);
+        let b = Fp3E::new([FpE::from(2u64), FpE::from(3u64), FpE::from(4u64)]);
+        let result = a * &b;
+        let expected = Fp3E::new([FpE::from(10u64), FpE::from(15u64), FpE::from(20u64)]);
+        assert_eq!(result, expected);
+    }
+
+    // =====================================================
+    // ASSOCIATIVITY AND DISTRIBUTIVITY TESTS
+    // =====================================================
+
+    #[test]
+    fn test_fp2_mul_associativity() {
+        let a = Fp2E::new([FpE::from(2u64), FpE::from(3u64)]);
+        let b = Fp2E::new([FpE::from(4u64), FpE::from(5u64)]);
+        let c = Fp2E::new([FpE::from(6u64), FpE::from(7u64)]);
+        assert_eq!(&(&a * &b) * &c, &a * &(&b * &c));
+    }
+
+    #[test]
+    fn test_fp3_mul_associativity() {
+        let a = Fp3E::new([FpE::from(2u64), FpE::from(3u64), FpE::from(4u64)]);
+        let b = Fp3E::new([FpE::from(5u64), FpE::from(6u64), FpE::from(7u64)]);
+        let c = Fp3E::new([FpE::from(8u64), FpE::from(9u64), FpE::from(10u64)]);
+        assert_eq!(&(&a * &b) * &c, &a * &(&b * &c));
+    }
+
+    #[test]
+    fn test_fp2_distributivity() {
+        let a = Fp2E::new([FpE::from(2u64), FpE::from(3u64)]);
+        let b = Fp2E::new([FpE::from(4u64), FpE::from(5u64)]);
+        let c = Fp2E::new([FpE::from(6u64), FpE::from(7u64)]);
+        // a * (b + c) = a * b + a * c
+        assert_eq!(&a * &(&b + &c), &(&a * &b) + &(&a * &c));
+    }
+
+    #[test]
+    fn test_fp3_distributivity() {
+        let a = Fp3E::new([FpE::from(2u64), FpE::from(3u64), FpE::from(4u64)]);
+        let b = Fp3E::new([FpE::from(5u64), FpE::from(6u64), FpE::from(7u64)]);
+        let c = Fp3E::new([FpE::from(8u64), FpE::from(9u64), FpE::from(10u64)]);
+        // a * (b + c) = a * b + a * c
+        assert_eq!(&a * &(&b + &c), &(&a * &b) + &(&a * &c));
+    }
+
+    // =====================================================
+    // RANDOM ELEMENT TESTS WITH LARGER VALUES
+    // =====================================================
+
+    #[test]
+    fn test_fp2_large_values() {
+        let a = Fp2E::new([FpE::from(18446744069414584300u64), FpE::from(12345678901234567u64)]);
+        let b = Fp2E::new([FpE::from(9876543210987654u64), FpE::from(11111111111111111u64)]);
+
+        // Test that a * a^-1 = 1
+        let a_inv = a.inv().unwrap();
+        assert_eq!(&a * &a_inv, Fp2E::one());
+
+        // Test division
+        let result = (&a / &b).unwrap();
+        assert_eq!(&result * &b, a);
+    }
+
+    #[test]
+    fn test_fp3_large_values() {
+        let a = Fp3E::new([
+            FpE::from(18446744069414584300u64),
+            FpE::from(12345678901234567u64),
+            FpE::from(98765432109876543u64),
+        ]);
+        let b = Fp3E::new([
+            FpE::from(9876543210987654u64),
+            FpE::from(11111111111111111u64),
+            FpE::from(22222222222222222u64),
+        ]);
+
+        // Test that a * a^-1 = 1
+        let a_inv = a.inv().unwrap();
+        assert_eq!(&a * &a_inv, Fp3E::one());
+
+        // Test division
+        let result = (&a / &b).unwrap();
+        assert_eq!(&result * &b, a);
+    }
+}

--- a/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
@@ -10,6 +10,7 @@ use crate::field::{
 // =====================================================
 // QUADRATIC EXTENSION (Fp2)
 // =====================================================
+// The non-residue was taken from [Plonky3](https://github.com/Plonky3/Plonky3/blob/main/goldilocks/src/extension.rs)
 // The quadratic extension is constructed using x^2 - 7,
 // where 7 is a quadratic non-residue in the Goldilocks field.
 // This means Fp2 = Fp[x] / (x^2 - 7)

--- a/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
@@ -99,44 +99,6 @@ impl IsField for Degree2GoldilocksExtensionField {
     fn double(a: &Self::BaseType) -> Self::BaseType {
         [a[0].double(), a[1].double()]
     }
-
-    fn pow<T>(a: &Self::BaseType, mut exponent: T) -> Self::BaseType
-    where
-        T: crate::unsigned_integer::traits::IsUnsignedInteger,
-    {
-        let zero = T::from(0);
-        let one = T::from(1);
-
-        if exponent == zero {
-            return Self::one();
-        }
-        if exponent == one {
-            return *a;
-        }
-
-        let mut result = *a;
-
-        while exponent & one == zero {
-            result = Self::square(&result);
-            exponent >>= 1;
-            if exponent == zero {
-                return result;
-            }
-        }
-
-        let mut base = result;
-        exponent >>= 1;
-
-        while exponent != zero {
-            base = Self::square(&base);
-            if exponent & one == one {
-                result = <Self as IsField>::mul(&result, &base);
-            }
-            exponent >>= 1;
-        }
-
-        result
-    }
 }
 
 impl IsSubFieldOf<Degree2GoldilocksExtensionField> for U64GoldilocksPrimeField {
@@ -324,44 +286,6 @@ impl IsField for Degree3GoldilocksExtensionField {
 
     fn double(a: &Self::BaseType) -> Self::BaseType {
         [a[0].double(), a[1].double(), a[2].double()]
-    }
-
-    fn pow<T>(a: &Self::BaseType, mut exponent: T) -> Self::BaseType
-    where
-        T: crate::unsigned_integer::traits::IsUnsignedInteger,
-    {
-        let zero = T::from(0);
-        let one = T::from(1);
-
-        if exponent == zero {
-            return Self::one();
-        }
-        if exponent == one {
-            return *a;
-        }
-
-        let mut result = *a;
-
-        while exponent & one == zero {
-            result = Self::square(&result);
-            exponent >>= 1;
-            if exponent == zero {
-                return result;
-            }
-        }
-
-        let mut base = result;
-        exponent >>= 1;
-
-        while exponent != zero {
-            base = Self::square(&base);
-            if exponent & one == one {
-                result = <Self as IsField>::mul(&result, &base);
-            }
-            exponent >>= 1;
-        }
-
-        result
     }
 }
 
@@ -727,5 +651,113 @@ mod tests {
 
         let result = (a / b).unwrap();
         assert_eq!(result * b, a);
+    }
+
+    // =====================================================
+    // BATCH INVERSE TESTS
+    // =====================================================
+
+    #[test]
+    fn test_fp2_batch_inverse() {
+        let a = Fp2E::new([FpE::from(2u64), FpE::from(3u64)]);
+        let b = Fp2E::new([FpE::from(4u64), FpE::from(5u64)]);
+        let c = Fp2E::new([FpE::from(6u64), FpE::from(7u64)]);
+        let d = Fp2E::new([FpE::from(8u64), FpE::from(9u64)]);
+
+        let original = [a, b, c, d];
+        let mut to_invert = original.clone();
+
+        Fp2E::inplace_batch_inverse(&mut to_invert).unwrap();
+
+        // Verify each element was correctly inverted
+        for (inv, orig) in to_invert.iter().zip(original.iter()) {
+            assert_eq!(*inv * *orig, Fp2E::one());
+        }
+    }
+
+    #[test]
+    fn test_fp2_batch_inverse_single_element() {
+        let a = Fp2E::new([FpE::from(12u64), FpE::from(5u64)]);
+        let mut to_invert = [a];
+
+        Fp2E::inplace_batch_inverse(&mut to_invert).unwrap();
+
+        assert_eq!(to_invert[0] * a, Fp2E::one());
+        assert_eq!(to_invert[0], a.inv().unwrap());
+    }
+
+    #[test]
+    fn test_fp2_batch_inverse_empty() {
+        let mut empty: [Fp2E; 0] = [];
+        assert!(Fp2E::inplace_batch_inverse(&mut empty).is_ok());
+    }
+
+    #[test]
+    fn test_fp3_batch_inverse() {
+        let a = Fp3E::new([FpE::from(2u64), FpE::from(3u64), FpE::from(4u64)]);
+        let b = Fp3E::new([FpE::from(5u64), FpE::from(6u64), FpE::from(7u64)]);
+        let c = Fp3E::new([FpE::from(8u64), FpE::from(9u64), FpE::from(10u64)]);
+        let d = Fp3E::new([FpE::from(11u64), FpE::from(12u64), FpE::from(13u64)]);
+
+        let original = [a, b, c, d];
+        let mut to_invert = original.clone();
+
+        Fp3E::inplace_batch_inverse(&mut to_invert).unwrap();
+
+        // Verify each element was correctly inverted
+        for (inv, orig) in to_invert.iter().zip(original.iter()) {
+            assert_eq!(*inv * *orig, Fp3E::one());
+        }
+    }
+
+    #[test]
+    fn test_fp3_batch_inverse_single_element() {
+        let a = Fp3E::new([FpE::from(12u64), FpE::from(5u64), FpE::from(7u64)]);
+        let mut to_invert = [a];
+
+        Fp3E::inplace_batch_inverse(&mut to_invert).unwrap();
+
+        assert_eq!(to_invert[0] * a, Fp3E::one());
+        assert_eq!(to_invert[0], a.inv().unwrap());
+    }
+
+    #[test]
+    fn test_fp3_batch_inverse_empty() {
+        let mut empty: [Fp3E; 0] = [];
+        assert!(Fp3E::inplace_batch_inverse(&mut empty).is_ok());
+    }
+
+    #[test]
+    fn test_fp2_batch_inverse_large() {
+        // Test with larger batch
+        let elements: Vec<Fp2E> = (1u64..=20)
+            .map(|i| Fp2E::new([FpE::from(i), FpE::from(i + 100)]))
+            .collect();
+
+        let original = elements.clone();
+        let mut to_invert = elements;
+
+        Fp2E::inplace_batch_inverse(&mut to_invert).unwrap();
+
+        for (inv, orig) in to_invert.iter().zip(original.iter()) {
+            assert_eq!(*inv * *orig, Fp2E::one());
+        }
+    }
+
+    #[test]
+    fn test_fp3_batch_inverse_large() {
+        // Test with larger batch
+        let elements: Vec<Fp3E> = (1u64..=20)
+            .map(|i| Fp3E::new([FpE::from(i), FpE::from(i + 100), FpE::from(i + 200)]))
+            .collect();
+
+        let original = elements.clone();
+        let mut to_invert = elements;
+
+        Fp3E::inplace_batch_inverse(&mut to_invert).unwrap();
+
+        for (inv, orig) in to_invert.iter().zip(original.iter()) {
+            assert_eq!(*inv * *orig, Fp3E::one());
+        }
     }
 }

--- a/crypto/math/src/field/fields/fft_friendly/mod.rs
+++ b/crypto/math/src/field/fields/fft_friendly/mod.rs
@@ -1,5 +1,7 @@
 /// Implemenation of the Babybear Prime Field p = 2^31 - 2^27 + 1
 pub mod babybear;
+/// Implementation of the quadratic and cubic extensions of the Goldilocks field
+pub mod extensions_goldilocks;
 /// Implementation of the quadratic extension of the babybear field
 pub mod quadratic_babybear;
 /// Implementation of the extension of degree 4 of the babybear field using u64.
@@ -10,8 +12,6 @@ pub mod stark_101_prime_field;
 pub mod stark_252_prime_field;
 /// Implemenation of the Goldilocks Prime Field p = 2^64 - 2^32 + 1
 pub mod u64_goldilocks;
-/// Implementation of the quadratic and cubic extensions of the Goldilocks field
-pub mod extensions_goldilocks;
 /// Implemenation of the Mersenne Prime field p = 2^31 - 1
 pub mod u64_mersenne_montgomery_field;
 

--- a/crypto/math/src/field/fields/fft_friendly/mod.rs
+++ b/crypto/math/src/field/fields/fft_friendly/mod.rs
@@ -10,6 +10,8 @@ pub mod stark_101_prime_field;
 pub mod stark_252_prime_field;
 /// Implemenation of the Goldilocks Prime Field p = 2^64 - 2^32 + 1
 pub mod u64_goldilocks;
+/// Implementation of the quadratic and cubic extensions of the Goldilocks field
+pub mod extensions_goldilocks;
 /// Implemenation of the Mersenne Prime field p = 2^31 - 1
 pub mod u64_mersenne_montgomery_field;
 


### PR DESCRIPTION
Add Fp2 and Fp3 field extensions for the Goldilocks prime field:
- Quadratic extension
- Cubic extension