### PR TITLE
Remove hardcoded values in AIR builder

### DIFF
--- a/prover/src/constraints/constraints_templates.rs
+++ b/prover/src/constraints/constraints_templates.rs
@@ -113,21 +113,27 @@ impl TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField
 /// A vector of boxed `BitConstraint` trait objects, one for each specified column.
 pub fn new_bit_constraints(
     column_idx: &[usize],
-    constraint_idx_start: usize,
-) -> Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>> {
-    column_idx
-        .iter()
-        .enumerate()
-        .map(|(i, &column_idx)| {
-            Box::new(BitConstraint::new(column_idx, constraint_idx_start + i))
-                as Box<
-                    dyn TransitionConstraint<
-                        Babybear31PrimeField,
-                        Degree4BabyBearU32ExtensionField,
-                    >,
-                >
-        })
-        .collect()
+    constraint_index: usize,
+) -> (
+    Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>>,
+    usize,
+) {
+    (
+        column_idx
+            .iter()
+            .enumerate()
+            .map(|(i, &column_idx)| {
+                Box::new(BitConstraint::new(column_idx, constraint_index + i))
+                    as Box<
+                        dyn TransitionConstraint<
+                                Babybear31PrimeField,
+                                Degree4BabyBearU32ExtensionField,
+                            >,
+                    >
+            })
+            .collect(),
+        constraint_index + column_idx.len(),
+    )
 }
 
 /// Identifies which carry bit (from a two-word addition) to constrain.
@@ -326,26 +332,32 @@ pub fn new_add_constraint(
     lhs_start_idx: usize,
     rhs_start_idx: usize,
     res_start_idx: usize,
-    constraint_idx_start: usize,
-) -> Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>> {
-    vec![
-        Box::new(CarryBitConstraint::new(
-            CarryIndex::Zero,
-            flags_idx.clone(),
-            lhs_start_idx,
-            rhs_start_idx,
-            res_start_idx,
-            constraint_idx_start,
-        )),
-        Box::new(CarryBitConstraint::new(
-            CarryIndex::One,
-            flags_idx,
-            lhs_start_idx,
-            rhs_start_idx,
-            res_start_idx,
-            constraint_idx_start + 1,
-        )),
-    ]
+    constraint_index: usize,
+) -> (
+    Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>>,
+    usize,
+) {
+    (
+        vec![
+            Box::new(CarryBitConstraint::new(
+                CarryIndex::Zero,
+                flags_idx.clone(),
+                lhs_start_idx,
+                rhs_start_idx,
+                res_start_idx,
+                constraint_index,
+            )),
+            Box::new(CarryBitConstraint::new(
+                CarryIndex::One,
+                flags_idx,
+                lhs_start_idx,
+                rhs_start_idx,
+                res_start_idx,
+                constraint_index + 1,
+            )),
+        ],
+        constraint_index + 2,
+    )
 }
 
 /// Creates a pair of carry bit constraints for a complete 32-bit substraction operation.
@@ -374,26 +386,32 @@ pub fn new_sub_constraint(
     lhs_start_idx: usize,
     rhs_start_idx: usize,
     res_start_idx: usize,
-    constraint_idx_start: usize,
-) -> Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>> {
-    vec![
-        Box::new(CarryBitConstraint::new(
-            CarryIndex::Zero,
-            flags_idx.clone(),
-            res_start_idx,
-            rhs_start_idx,
-            lhs_start_idx,
-            constraint_idx_start,
-        )),
-        Box::new(CarryBitConstraint::new(
-            CarryIndex::One,
-            flags_idx,
-            res_start_idx,
-            rhs_start_idx,
-            lhs_start_idx,
-            constraint_idx_start + 1,
-        )),
-    ]
+    constraint_index: usize,
+) -> (
+    Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>>,
+    usize,
+) {
+    (
+        vec![
+            Box::new(CarryBitConstraint::new(
+                CarryIndex::Zero,
+                flags_idx.clone(),
+                res_start_idx,
+                rhs_start_idx,
+                lhs_start_idx,
+                constraint_index,
+            )),
+            Box::new(CarryBitConstraint::new(
+                CarryIndex::One,
+                flags_idx,
+                res_start_idx,
+                rhs_start_idx,
+                lhs_start_idx,
+                constraint_index + 1,
+            )),
+        ],
+        constraint_index + 2,
+    )
 }
 
 #[derive(Clone)]
@@ -532,30 +550,36 @@ pub fn new_arg2_validity_constraint(
     rv2_start_index: usize,
     imm_start_index: usize,
     column_indexes: Arg2ValidityColumnIndexes,
-    constraint_idx: usize,
-) -> Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>> {
-    vec![
-        Box::new(Arg2ValidityConstraint::new(
-            arg2_start_index,
-            rv2_start_index,
-            imm_start_index,
-            column_indexes.clone(),
-            constraint_idx,
-        ))
-            as Box<
-                dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>,
-            >,
-        Box::new(Arg2ValidityConstraint::new(
-            arg2_start_index + 1,
-            rv2_start_index + 2,
-            imm_start_index + 1,
-            column_indexes,
-            constraint_idx + 1,
-        ))
-            as Box<
-                dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>,
-            >,
-    ]
+    constraint_index: usize,
+) -> (
+    Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>>,
+    usize,
+) {
+    (
+        vec![
+            Box::new(Arg2ValidityConstraint::new(
+                arg2_start_index,
+                rv2_start_index,
+                imm_start_index,
+                column_indexes.clone(),
+                constraint_index,
+            ))
+                as Box<
+                    dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>,
+                >,
+            Box::new(Arg2ValidityConstraint::new(
+                arg2_start_index + 1,
+                rv2_start_index + 2,
+                imm_start_index + 1,
+                column_indexes,
+                constraint_index + 1,
+            ))
+                as Box<
+                    dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>,
+                >,
+        ],
+        constraint_index + 2,
+    )
 }
 
 /// Enforces correct carry bit values for adding 4 to a 32-bit table value.
@@ -728,22 +752,28 @@ pub fn new_add_four_constraint(
     flag_idx: usize,
     lhs_start_idx: usize,
     res_start_idx: usize,
-    constraint_idx_start: usize,
-) -> Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>> {
-    vec![
-        Box::new(AddFourCarryBitConstraint::new(
-            CarryIndex::Zero,
-            flag_idx,
-            lhs_start_idx,
-            res_start_idx,
-            constraint_idx_start,
-        )),
-        Box::new(AddFourCarryBitConstraint::new(
-            CarryIndex::One,
-            flag_idx,
-            lhs_start_idx,
-            res_start_idx,
-            constraint_idx_start + 1,
-        )),
-    ]
+    constraint_index: usize,
+) -> (
+    Vec<Box<dyn TransitionConstraint<Babybear31PrimeField, Degree4BabyBearU32ExtensionField>>>,
+    usize,
+) {
+    (
+        vec![
+            Box::new(AddFourCarryBitConstraint::new(
+                CarryIndex::Zero,
+                flag_idx,
+                lhs_start_idx,
+                res_start_idx,
+                constraint_index,
+            )),
+            Box::new(AddFourCarryBitConstraint::new(
+                CarryIndex::One,
+                flag_idx,
+                lhs_start_idx,
+                res_start_idx,
+                constraint_index + 1,
+            )),
+        ],
+        constraint_index + 2,
+    )
 }

--- a/prover/src/constraints/cpu_air.rs
+++ b/prover/src/constraints/cpu_air.rs
@@ -2,6 +2,7 @@ use crate::constraints::constraints_templates::{
     Arg2ValidityColumnIndexes, new_add_constraint, new_add_four_constraint,
     new_arg2_validity_constraint, new_bit_constraints, new_sub_constraint,
 };
+use crate::tables::cpu::CpuTableRow;
 
 use math::field::{
     element::FieldElement,
@@ -16,45 +17,6 @@ use stark::{
     trace::TraceTable,
     traits::AIR,
 };
-
-// CPU Columns indeces:
-// const TIMESTAMP: usize = 0;
-const PC: usize = 2;
-// const RS1: usize = 4;
-// const RS2: usize = 5;
-// const RD: usize = 6;
-const WRITE_REGISTER: usize = 7;
-const MEMORY_2BYTES: usize = 8;
-const MEMORY_4BYTES: usize = 9;
-const IMM: usize = 10;
-const SIGNED: usize = 12;
-const MP_SELECTOR: usize = 13;
-const MULDIV_SELECTOR: usize = 14;
-const ADD: usize = 15;
-const SUB: usize = 16;
-const SLT: usize = 17;
-const AND: usize = 18;
-const OR: usize = 19;
-const XOR: usize = 20;
-const SL: usize = 21;
-const SR: usize = 22;
-const JALR: usize = 23;
-const BEQ: usize = 24;
-const BLT: usize = 25;
-const LOAD: usize = 26;
-const STORE: usize = 27;
-const MUL: usize = 28;
-const DIVREM: usize = 29;
-const ECALL: usize = 30;
-const EBREAK: usize = 31;
-// const NEXT_PC: usize = 32;
-const RV_ONE: usize = 34;
-const RV_TWO: usize = 38;
-// const RVD: usize = 42;
-const ARG_TWO: usize = 44;
-const RES: usize = 46;
-// const IS_EQUAL: usize = 50;
-// const BRANCH_COND: usize = 51;
 
 type FE = FieldElement<Babybear31PrimeField>;
 
@@ -82,80 +44,77 @@ impl AIR for CPUTableAIR {
         _pub_inputs: &Self::PublicInputs,
         proof_options: &ProofOptions,
     ) -> Self {
+        let constraint_index = 0;
         // Bit constraints:
         // Enforce that these columns are binary. They include:
         // - decode flags like `write_register`, `signed`, `mp_selector`, `muldiv_selector`
         // - the one-hot instruction flags (ADD, SUB, ..., EBREAK)
         let bit_columns_index_to_constraint = [
-            WRITE_REGISTER,
-            MEMORY_2BYTES,
-            MEMORY_4BYTES,
-            SIGNED,
-            MP_SELECTOR,
-            MULDIV_SELECTOR,
-            ADD,
-            SUB,
-            SLT,
-            AND,
-            OR,
-            XOR,
-            SL,
-            SR,
-            JALR,
-            BEQ,
-            BLT,
-            LOAD,
-            STORE,
-            MUL,
-            DIVREM,
-            ECALL,
-            EBREAK,
+            CpuTableRow::WRITE_REGISTER,
+            CpuTableRow::MEMORY_2BYTES,
+            CpuTableRow::MEMORY_4BYTES,
+            CpuTableRow::SIGNED,
+            CpuTableRow::MP_SELECTOR,
+            CpuTableRow::MULDIV_SELECTOR,
+            CpuTableRow::ADD,
+            CpuTableRow::SUB,
+            CpuTableRow::SLT,
+            CpuTableRow::AND,
+            CpuTableRow::OR,
+            CpuTableRow::XOR,
+            CpuTableRow::SL,
+            CpuTableRow::SR,
+            CpuTableRow::JALR,
+            CpuTableRow::BEQ,
+            CpuTableRow::BLT,
+            CpuTableRow::LOAD,
+            CpuTableRow::STORE,
+            CpuTableRow::MUL,
+            CpuTableRow::DIVREM,
+            CpuTableRow::ECALL,
+            CpuTableRow::EBREAK,
         ];
-        let bit_constraints = new_bit_constraints(&bit_columns_index_to_constraint, 0);
+        let (bit_constraints, constraint_index) =
+            new_bit_constraints(&bit_columns_index_to_constraint, constraint_index);
 
-        let mut next_index = bit_columns_index_to_constraint.len();
         // Add constraint
         // Enforces that lhs (Word4L) + rhs (Word4L) = res (Word4L), with carry bits constrained.
         // It is enforced only on rows where the selected instruction flags are active.
-        let add_constraints = new_add_constraint(
-            vec![ADD, LOAD, STORE], // flags_idx,
-            RV_ONE,                 // lhs_start_idx,
-            ARG_TWO,                // rhs_start_idx,
-            RES,                    // res_start_idx,
-            next_index,             // constraint_idx_start,
+        let (add_constraints, constraint_index) = new_add_constraint(
+            vec![CpuTableRow::ADD, CpuTableRow::LOAD, CpuTableRow::STORE], // flags_idx,
+            CpuTableRow::RV1_0,                                            // lhs_start_idx,
+            CpuTableRow::ARG2_0,                                           // rhs_start_idx,
+            CpuTableRow::RES_0,                                            // res_start_idx,
+            constraint_index,                                              // constraint_idx_start,
         );
-        next_index += 2;
 
-        let sub_constraints = new_sub_constraint(
-            vec![SUB, BEQ], // flags_idx,
-            RV_ONE,         // lhs_start_idx,
-            ARG_TWO,        // rhs_start_idx,
-            RES,            // res_start_idx,
-            next_index,     // constraint_idx_start,
+        let (sub_constraints, constraint_index) = new_sub_constraint(
+            vec![CpuTableRow::SUB, CpuTableRow::BEQ], // flags_idx,
+            CpuTableRow::RV1_0,                       // lhs_start_idx,
+            CpuTableRow::ARG2_0,                      // rhs_start_idx,
+            CpuTableRow::RES_0,                       // res_start_idx,
+            constraint_index,                         // constraint_idx_start,
         );
-        next_index += 2;
 
         // Enforces RES = PC + 4 in a JALR instruction
-        let next_pc_value_constraint = new_add_four_constraint(
-            JALR,       // flags_idx,
-            PC,         // rhs_start_idx,
-            RES,        // res_start_idx,
-            next_index, // constraint_idx_start,
+        let (next_pc_value_constraint, constraint_index) = new_add_four_constraint(
+            CpuTableRow::JALR,  // flags_idx,
+            CpuTableRow::PC_0,  // rhs_start_idx,
+            CpuTableRow::RES_0, // res_start_idx,
+            constraint_index,   // constraint_idx_start,
         );
 
-        next_index += 2;
-
-        let arg2_validity_constraints = new_arg2_validity_constraint(
-            ARG_TWO,
-            RV_TWO,
-            IMM,
+        let (arg2_validity_constraints, _) = new_arg2_validity_constraint(
+            CpuTableRow::ARG2_0,
+            CpuTableRow::RV2_0,
+            CpuTableRow::IMM_0,
             Arg2ValidityColumnIndexes {
-                load_index: LOAD,
-                store_index: STORE,
-                beq_index: BEQ,
-                blt_index: BLT,
+                load_index: CpuTableRow::LOAD,
+                store_index: CpuTableRow::STORE,
+                beq_index: CpuTableRow::BEQ,
+                blt_index: CpuTableRow::BLT,
             },
-            next_index,
+            constraint_index,
         );
 
         let mut constraints = bit_constraints;
@@ -168,7 +127,7 @@ impl AIR for CPUTableAIR {
 
         let context = AirContext {
             proof_options: proof_options.clone(),
-            trace_columns: 52,
+            trace_columns: CpuTableRow::NUM_COLUMNS,
             transition_offsets: vec![0],
             num_transition_constraints,
         };
@@ -206,7 +165,7 @@ impl AIR for CPUTableAIR {
     }
 
     fn trace_layout(&self) -> (usize, usize) {
-        (52, 0)
+        (CpuTableRow::NUM_COLUMNS, 0)
     }
 
     fn pub_inputs(&self) -> &Self::PublicInputs {

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -58,6 +58,61 @@ pub struct CpuTableRow {
 }
 
 impl CpuTableRow {
+    pub const NUM_COLUMNS: usize = 52;
+
+    pub const TIMESTAMP_0: usize = 0;
+    pub const TIMESTAMP_1: usize = 1;
+    pub const PC_0: usize = 2;
+    pub const PC_1: usize = 3;
+    pub const RS1: usize = 4;
+    pub const RS2: usize = 5;
+    pub const RD: usize = 6;
+    pub const WRITE_REGISTER: usize = 7;
+    pub const MEMORY_2BYTES: usize = 8;
+    pub const MEMORY_4BYTES: usize = 9;
+    pub const IMM_0: usize = 10;
+    pub const IMM_1: usize = 11;
+    pub const SIGNED: usize = 12;
+    pub const MP_SELECTOR: usize = 13;
+    pub const MULDIV_SELECTOR: usize = 14;
+    pub const ADD: usize = 15;
+    pub const SUB: usize = 16;
+    pub const SLT: usize = 17;
+    pub const AND: usize = 18;
+    pub const OR: usize = 19;
+    pub const XOR: usize = 20;
+    pub const SL: usize = 21;
+    pub const SR: usize = 22;
+    pub const JALR: usize = 23;
+    pub const BEQ: usize = 24;
+    pub const BLT: usize = 25;
+    pub const LOAD: usize = 26;
+    pub const STORE: usize = 27;
+    pub const MUL: usize = 28;
+    pub const DIVREM: usize = 29;
+    pub const ECALL: usize = 30;
+    pub const EBREAK: usize = 31;
+    pub const NEXT_PC_0: usize = 32;
+    pub const NEXT_PC_1: usize = 33;
+    pub const RV1_0: usize = 34;
+    pub const RV1_1: usize = 35;
+    pub const RV1_2: usize = 36;
+    pub const RV1_3: usize = 37;
+    pub const RV2_0: usize = 38;
+    pub const RV2_1: usize = 39;
+    pub const RV2_2: usize = 40;
+    pub const RV2_3: usize = 41;
+    pub const RVD_0: usize = 42;
+    pub const RVD_1: usize = 43;
+    pub const ARG2_0: usize = 44;
+    pub const ARG2_1: usize = 45;
+    pub const RES_0: usize = 46;
+    pub const RES_1: usize = 47;
+    pub const RES_2: usize = 48;
+    pub const RES_3: usize = 49;
+    pub const IS_EQUAL: usize = 50;
+    pub const BRANCH_COND: usize = 51;
+
     pub fn from_log(log: Log, timestamp: u32) -> Self {
         let mut row = Self {
             timestamp: u32_to_2_limbs(timestamp),


### PR DESCRIPTION
- Removes some hardcoded values in the AIR builder
- Removes the necessity to manually add the number of constraints after each constraint definition.