### PR TITLE
spec: drop `dot` when multiplying constant with one-letter variable

### DIFF
--- a/spec/expr.typ
+++ b/spec/expr.typ
@@ -142,7 +142,15 @@
         pp <= PREC.sub
       )
     },
-    "*": (pp, rec, e) => mwrap($#e.slice(1).map(rec.with(PREC.mul)).join($dot$)$, pp < PREC.mul),
+    "*": (pp, rec, e) => {
+      if e.len() == 3 and type(e.at(1)) == int and type(e.at(2)) == str and e.at(2).len() == 1 {
+        // multiplication of a constant with one-letter variable. 
+        // Dropping the "dot"
+        mwrap($#e.slice(1).map(rec.with(PREC.mul)).join($$)$, pp < PREC.mul)
+      } else {
+        mwrap($#e.slice(1).map(rec.with(PREC.mul)).join($dot$)$, pp < PREC.mul)
+      }
+    },
     "/": (pp, rec, e) => $#rec(PREC.div, e.at(1)) / #rec(PREC.div, e.at(2))$,
     "^": (pp, rec, e) => {
       assert(type(e.at(1)) == int and type(e.at(2)) == int, message: "Can only exponentiate constants")


### PR DESCRIPTION
from
<img width="825" height="78" alt="image" src="https://github.com/user-attachments/assets/e059ff9a-c5c7-48fa-bc95-b6347f679eef" />

to
<img width="825" height="78" alt="image" src="https://github.com/user-attachments/assets/4cf8ab55-0c64-4787-a32d-87cc85e7a565" />
