### PR TITLE
spec: repeat column table subheader on page wrap

### DIFF
--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -90,7 +90,7 @@
     table.header([*Label*], [*Type*], table.cell(colspan: 2, [*Description*])),
     table.hline(stroke: stroke(thickness: 2pt)),
     ..for (cat, vars) in chip.variables.pairs() {
-      (table.cell(colspan: 4, emph(cat)), table.hline(stroke: .6pt))
+      (table.header(level:2, table.cell(colspan: 4, emph(cat))), table.hline(stroke: .6pt))
       for var in vars {
         (
           [#raw(var.name)], 


### PR DESCRIPTION
from
<img width="691" height="550" alt="image" src="https://github.com/user-attachments/assets/c3c68906-232b-4710-8eed-b2e73061b2fd" />


to
<img width="691" height="550" alt="image" src="https://github.com/user-attachments/assets/62851dd8-32c3-4731-917b-8b965f500917" />
