### PR TITLE
fix(cyrpto): Make multiplicity flag for lookups Option<>

### DIFF
--- a/crypto/stark/src/examples/multi_table_lookup.rs
+++ b/crypto/stark/src/examples/multi_table_lookup.rs
@@ -20,13 +20,13 @@ pub fn new_cpu_air_with_lookup(
         interactions: vec![
             // Interaction with ADD table (CPU sends to ADD bus)
             TableInteraction {
-                multiplicity_column: 0,
+                multiplicity_column: Some(0),
                 value_columns: vec![2, 3, 4],
                 is_sender: true,
             },
             // Interaction with MUL table (CPU sends to MUL bus)
             TableInteraction {
-                multiplicity_column: 1,
+                multiplicity_column: Some(1),
                 value_columns: vec![2, 3, 4],
                 is_sender: true,
             },
@@ -51,7 +51,7 @@ pub fn new_mul_air_with_lookup(
         interactions: vec![
             // Interaction with CPU table (MUL table receives from MUL bus)
             TableInteraction {
-                multiplicity_column: 3,
+                multiplicity_column: Some(3),
                 value_columns: vec![0, 1, 2],
                 is_sender: false,
             },
@@ -76,7 +76,7 @@ pub fn new_add_air_with_lookup(
         interactions: vec![
             // Interaction with CPU table (ADD table receives from ADD bus)
             TableInteraction {
-                multiplicity_column: 3,
+                multiplicity_column: Some(3),
                 value_columns: vec![0, 1, 2],
                 is_sender: false,
             },

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -254,7 +254,8 @@ pub struct TableInteraction {
     /// Column index containing the multiplicity for this interaction.
     /// Can be a binary flag (0 or 1) or a general multiplicity (0, 1, 2, ...).
     /// Determines how many times each row contributes to the bus.
-    pub multiplicity_column: usize,
+    /// If None, a constant multiplicity of 1 is used for all rows.
+    pub multiplicity_column: Option<usize>,
     pub value_columns: Vec<usize>,
     /// Whether this side of the interaction is a sender (true) or receiver (false).
     /// Senders contribute positive values to the bus sum, receivers contribute negative.
@@ -323,7 +324,18 @@ fn build_auxiliary_trace_column<F, E>(
         .iter()
         .map(|i| &main_segment_cols[*i])
         .collect::<Vec<_>>();
-    let multiplicity = &main_segment_cols[table_interaction.multiplicity_column];
+
+    let trace_len = trace.num_rows();
+
+    // Handle optional multiplicity column - use constant 1 if None
+    let multiplicity_owned: Vec<FieldElement<F>>;
+    let multiplicity: &[FieldElement<F>] = match table_interaction.multiplicity_column {
+        Some(col) => &main_segment_cols[col],
+        None => {
+            multiplicity_owned = vec![FieldElement::one(); trace_len];
+            &multiplicity_owned
+        }
+    };
 
     // LogUp challenges (must be shared across all tables for bus to balance)
     let z = &challenges[LOGUP_CHALLENGE_Z];
@@ -331,7 +343,6 @@ fn build_auxiliary_trace_column<F, E>(
     // Coefficients for each value column
     let coeffs: Vec<FieldElement<E>> = (0..values.len()).map(|i| alpha.pow(i)).collect();
 
-    let trace_len = trace.num_rows();
     let mut aux_col: Vec<FieldElement<E>> = Vec::new();
 
     // fingerprint = z - (v[0] * alpha^0 + v[1] * alpha^1 +...+ value[n] * alpha^n)
@@ -429,10 +440,11 @@ where
             let z = &rap_challenges[LOGUP_CHALLENGE_Z];
             let alpha = &rap_challenges[LOGUP_CHALLENGE_ALPHA];
 
-            // Main frame elements
-            let multiplicity: FieldElement<A> = second_step
-                .get_main_evaluation_element(0, interaction.multiplicity_column)
-                .clone();
+            // Main frame elements - handle optional multiplicity
+            let multiplicity = match interaction.multiplicity_column {
+                Some(col) => second_step.get_main_evaluation_element(0, col).clone(),
+                None => FieldElement::<A>::one(),
+            };
             let values = interaction
                 .value_columns
                 .iter()

--- a/crypto/stark/src/tests/verifier_tests.rs
+++ b/crypto/stark/src/tests/verifier_tests.rs
@@ -191,12 +191,12 @@ fn create_cpu_air(
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![
             TableInteraction {
-                multiplicity_column: 0,
+                multiplicity_column: Some(0),
                 value_columns: vec![2, 3, 4],
                 is_sender: true,
             },
             TableInteraction {
-                multiplicity_column: 1,
+                multiplicity_column: Some(1),
                 value_columns: vec![2, 3, 4],
                 is_sender: true,
             },
@@ -217,7 +217,7 @@ fn create_add_air(
     let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![TableInteraction {
-            multiplicity_column: 3,
+            multiplicity_column: Some(3),
             value_columns: vec![0, 1, 2],
             is_sender: false,
         }],
@@ -237,7 +237,7 @@ fn create_mul_air(
     let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![TableInteraction {
-            multiplicity_column: 3,
+            multiplicity_column: Some(3),
             value_columns: vec![0, 1, 2],
             is_sender: false,
         }],


### PR DESCRIPTION
In some cases, the lookup does not depend on a flag or a multiplicity; for example, the DECODE lookup in the CPU table.