### PR TITLE
perf(stark): add Vec capacity pre-allocation to reduce allocations

### DIFF
--- a/crypto/crypto/src/merkle_tree/merkle.rs
+++ b/crypto/crypto/src/merkle_tree/merkle.rs
@@ -84,7 +84,9 @@ where
 
     /// Returns the Merkle path for the element/s for the leaf at position pos
     fn build_merkle_path(&self, pos: usize) -> Result<Vec<B::Node>, Error> {
-        let mut merkle_path = Vec::new();
+        // Pre-allocate based on tree depth (log2 of tree size)
+        let tree_depth = (self.nodes.len() + 1).ilog2() as usize;
+        let mut merkle_path = Vec::with_capacity(tree_depth);
         let mut pos = pos;
 
         while pos != ROOT {

--- a/crypto/stark/src/fri/mod.rs
+++ b/crypto/stark/src/fri/mod.rs
@@ -80,11 +80,12 @@ where
     FieldElement<F>: AsBytes + Sync + Send,
 {
     if !fri_layers.is_empty() {
+        let num_layers = fri_layers.len();
         iotas
             .iter()
             .map(|iota_s| {
-                let mut layers_evaluations_sym = Vec::new();
-                let mut layers_auth_paths_sym = Vec::new();
+                let mut layers_evaluations_sym = Vec::with_capacity(num_layers);
+                let mut layers_auth_paths_sym = Vec::with_capacity(num_layers);
 
                 let mut index = *iota_s;
                 for layer in fri_layers {

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -888,7 +888,7 @@ pub trait IsStarkProver<
         FieldElement<Field>: AsBytes,
         FieldElement<FieldExtension>: AsBytes,
     {
-        let mut openings = Vec::new();
+        let mut openings = Vec::with_capacity(indexes_to_open.len());
 
         for index in indexes_to_open.iter() {
             let main_trace_opening = Self::open_trace_polys::<Field>(
@@ -955,6 +955,8 @@ pub trait IsStarkProver<
     {
         info!("Started proof generation...");
 
+        let num_airs = air_trace_pairs.len();
+
         // Check if any AIR uses LogUp (has auxiliary trace for running sums)
         let needs_logup_challenges = air_trace_pairs
             .iter()
@@ -966,8 +968,8 @@ pub trait IsStarkProver<
         // All main trace commitments must be in the transcript before sampling
         // LogUp challenges. This ensures the challenges depend on ALL tables.
 
-        let mut domains = Vec::new();
-        let mut main_commitments: Vec<MainCommitment<Field>> = Vec::new();
+        let mut domains = Vec::with_capacity(num_airs);
+        let mut main_commitments: Vec<MainCommitment<Field>> = Vec::with_capacity(num_airs);
 
         for (air, trace, _pub_inputs) in &*air_trace_pairs {
             let trace_length = trace.num_rows();
@@ -996,7 +998,7 @@ pub trait IsStarkProver<
         // =====================================================================
         // Each AIR builds its LogUp running-sum columns using the shared challenges.
 
-        let mut round_1_results: Vec<Round1<Field, FieldExtension>> = Vec::new();
+        let mut round_1_results: Vec<Round1<Field, FieldExtension>> = Vec::with_capacity(num_airs);
         for (((air, trace, _pub_inputs), (main, main_evaluations)), domain) in air_trace_pairs
             .iter_mut()
             .zip(main_commitments)
@@ -1018,7 +1020,7 @@ pub trait IsStarkProver<
         // Rounds 2-4: Standard STARK protocol for each AIR
         // =====================================================================
 
-        let mut proofs = Vec::new();
+        let mut proofs = Vec::with_capacity(num_airs);
         for (((air, _, pub_inputs), round_1_result), domain) in
             air_trace_pairs.iter().zip(round_1_results).zip(domains)
         {

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -652,8 +652,9 @@ pub trait IsStarkVerifier<
         domain: &Domain<Field>,
         proof: &StarkProof<Field, FieldExtension, PI>,
     ) -> DeepPolynomialEvaluations<FieldExtension> {
-        let mut deep_poly_evaluations = Vec::new();
-        let mut deep_poly_evaluations_sym = Vec::new();
+        let num_queries = challenges.iotas.len();
+        let mut deep_poly_evaluations = Vec::with_capacity(num_queries);
+        let mut deep_poly_evaluations_sym = Vec::with_capacity(num_queries);
         for (i, iota) in challenges.iotas.iter().enumerate() {
             let primitive_root =
                 &Field::get_primitive_root_of_unity(domain.root_order as u64).unwrap();


### PR DESCRIPTION
Pre-allocate Vec capacity in hot paths to avoid reallocations:

- prover.rs: Pre-allocate openings, round_1_results, domains, main_commitments, and proofs vectors based on num_airs
- verifier.rs: Pre-allocate deep_poly_evaluations vectors based on num_queries
- merkle.rs: Pre-allocate merkle_path based on tree depth (log2)
- fri/mod.rs: Pre-allocate layers_evaluations_sym and layers_auth_paths_sym based on num_layers

This reduces memory allocation overhead during proving and verification by avoiding repeated Vec growth operations.