### PR TITLE
perf(stark): optimize FRI with fixed-size arrays and in-place folding

### DIFF
--- a/crypto/crypto/src/merkle_tree/backends/field_element_vector.rs
+++ b/crypto/crypto/src/merkle_tree/backends/field_element_vector.rs
@@ -9,6 +9,53 @@ use math::{
     traits::AsBytes,
 };
 
+/// A backend for Merkle trees that uses fixed-size pairs of field elements.
+/// This is more efficient than `FieldElementVectorBackend` when the batch size is always 2,
+/// as it avoids Vec allocation overhead.
+#[derive(Clone)]
+pub struct FieldElementPairBackend<F, D: Digest, const NUM_BYTES: usize> {
+    phantom1: PhantomData<F>,
+    phantom2: PhantomData<D>,
+}
+
+impl<F, D: Digest, const NUM_BYTES: usize> Default for FieldElementPairBackend<F, D, NUM_BYTES> {
+    fn default() -> Self {
+        Self {
+            phantom1: PhantomData,
+            phantom2: PhantomData,
+        }
+    }
+}
+
+impl<F, D: Digest, const NUM_BYTES: usize> IsMerkleTreeBackend
+    for FieldElementPairBackend<F, D, NUM_BYTES>
+where
+    F: IsField,
+    FieldElement<F>: AsBytes,
+    [u8; NUM_BYTES]: From<Output<D>>,
+{
+    type Node = [u8; NUM_BYTES];
+    type Data = [FieldElement<F>; 2];
+
+    fn hash_data(input: &[FieldElement<F>; 2]) -> [u8; NUM_BYTES] {
+        let mut hasher = D::new();
+        hasher.update(input[0].as_bytes());
+        hasher.update(input[1].as_bytes());
+        let mut result_hash = [0_u8; NUM_BYTES];
+        result_hash.copy_from_slice(&hasher.finalize());
+        result_hash
+    }
+
+    fn hash_new_parent(left: &[u8; NUM_BYTES], right: &[u8; NUM_BYTES]) -> [u8; NUM_BYTES] {
+        let mut hasher = D::new();
+        hasher.update(left);
+        hasher.update(right);
+        let mut result_hash = [0_u8; NUM_BYTES];
+        result_hash.copy_from_slice(&hasher.finalize());
+        result_hash
+    }
+}
+
 #[derive(Clone)]
 pub struct FieldElementVectorBackend<F, D: Digest, const NUM_BYTES: usize> {
     phantom1: PhantomData<F>,

--- a/crypto/crypto/src/merkle_tree/backends/types.rs
+++ b/crypto/crypto/src/merkle_tree/backends/types.rs
@@ -1,7 +1,10 @@
 use sha2::{Sha256, Sha512};
 use sha3::{Keccak256, Keccak512, Sha3_256, Sha3_512};
 
-use super::{field_element::FieldElementBackend, field_element_vector::FieldElementVectorBackend};
+use super::{
+    field_element::FieldElementBackend,
+    field_element_vector::{FieldElementPairBackend, FieldElementVectorBackend},
+};
 
 // Field element backend definitions
 
@@ -26,3 +29,10 @@ pub type BatchSha2_256Backend<F> = FieldElementVectorBackend<F, Sha256, 32>;
 pub type BatchSha3_512Backend<F> = FieldElementVectorBackend<F, Sha3_512, 64>;
 pub type BatchKeccak512Backend<F> = FieldElementVectorBackend<F, Keccak512, 64>;
 pub type BatchSha2_512Backend<F> = FieldElementVectorBackend<F, Sha512, 64>;
+
+// Fixed-size pair backends (more efficient for FRI layers)
+
+// - With 256 bit
+pub type PairKeccak256Backend<F> = FieldElementPairBackend<F, Keccak256, 32>;
+pub type PairSha3_256Backend<F> = FieldElementPairBackend<F, Sha3_256, 32>;
+pub type PairSha2_256Backend<F> = FieldElementPairBackend<F, Sha256, 32>;

--- a/crypto/stark/src/config.rs
+++ b/crypto/stark/src/config.rs
@@ -1,5 +1,5 @@
 use crypto::merkle_tree::{
-    backends::types::{BatchKeccak256Backend, Keccak256Backend},
+    backends::types::{BatchKeccak256Backend, Keccak256Backend, PairKeccak256Backend},
     merkle::MerkleTree,
 };
 
@@ -18,3 +18,7 @@ pub type Commitment = [u8; COMMITMENT_SIZE];
 
 pub type BatchedMerkleTreeBackend<F> = BatchKeccak256Backend<F>;
 pub type BatchedMerkleTree<F> = MerkleTree<BatchedMerkleTreeBackend<F>>;
+
+// FRI layer uses fixed-size pairs for efficiency (avoids Vec allocation per pair)
+pub type FriLayerMerkleTreeBackend<F> = PairKeccak256Backend<F>;
+pub type FriLayerMerkleTree<F> = MerkleTree<FriLayerMerkleTreeBackend<F>>;

--- a/crypto/stark/src/fri/fri_functions.rs
+++ b/crypto/stark/src/fri/fri_functions.rs
@@ -1,9 +1,8 @@
 use super::Polynomial;
-use math::{
-    field::{element::FieldElement, traits::IsField},
-    polynomial,
-};
+use math::field::{element::FieldElement, traits::IsField};
 
+/// FRI polynomial folding: computes P_even(x) + beta * P_odd(x)
+/// where P(x) = P_even(x^2) + x * P_odd(x^2)
 pub fn fold_polynomial<F>(
     poly: &Polynomial<FieldElement<F>>,
     beta: &FieldElement<F>,
@@ -11,35 +10,98 @@ pub fn fold_polynomial<F>(
 where
     F: IsField,
 {
-    let coef = poly.coefficients();
-    let even_coef: Vec<FieldElement<F>> = coef.iter().step_by(2).cloned().collect();
+    let coefficients = poly.coefficients();
+    if coefficients.is_empty() {
+        return Polynomial::new(&[]);
+    }
 
-    // odd coeficients of poly are multiplied by beta
-    let odd_coef_mul_beta: Vec<FieldElement<F>> = coef
-        .iter()
-        .skip(1)
-        .step_by(2)
-        .map(|v| (v.clone()) * beta)
-        .collect();
+    let mut result = Vec::with_capacity(coefficients.len().div_ceil(2));
 
-    let (even_poly, odd_poly) = polynomial::pad_with_zero_coefficients(
-        &Polynomial::new(&even_coef),
-        &Polynomial::new(&odd_coef_mul_beta),
-    );
-    even_poly + odd_poly
+    for chunk in coefficients.chunks(2) {
+        let folded = if chunk.len() == 2 {
+            &chunk[0] + &(&chunk[1] * beta)
+        } else {
+            chunk[0].clone()
+        };
+        result.push(folded);
+    }
+
+    Polynomial::new(&result)
+}
+
+/// FRI polynomial folding with fused doubling: 2 * (P_even(x) + beta * P_odd(x))
+///
+/// Uses `double()` which is more efficient than multiplication by 2.
+pub fn fold_polynomial_doubled<F>(
+    poly: &Polynomial<FieldElement<F>>,
+    beta: &FieldElement<F>,
+) -> Polynomial<FieldElement<F>>
+where
+    F: IsField,
+{
+    let coefficients = poly.coefficients();
+    if coefficients.is_empty() {
+        return Polynomial::new(&[]);
+    }
+
+    let mut result = Vec::with_capacity(coefficients.len().div_ceil(2));
+
+    for chunk in coefficients.chunks(2) {
+        let folded = if chunk.len() == 2 {
+            (&chunk[0] + &(&chunk[1] * beta)).double()
+        } else {
+            chunk[0].double()
+        };
+        result.push(folded);
+    }
+
+    Polynomial::new(&result)
+}
+
+/// In-place FRI polynomial folding with fused doubling: 2 * (P_even(x) + beta * P_odd(x))
+///
+/// This modifies the polynomial in place, avoiding memory allocation.
+/// The polynomial degree is halved after this operation.
+pub fn fold_polynomial_doubled_inplace<F>(
+    poly: &mut Polynomial<FieldElement<F>>,
+    beta: &FieldElement<F>,
+) where
+    F: IsField,
+{
+    let coefficients = &mut poly.coefficients;
+    if coefficients.is_empty() {
+        return;
+    }
+
+    let new_len = coefficients.len().div_ceil(2);
+
+    // Fold in place: process pairs and write results back to the beginning
+    for i in 0..new_len {
+        let idx = i * 2;
+        let folded = if idx + 1 < coefficients.len() {
+            (&coefficients[idx] + &(&coefficients[idx + 1] * beta)).double()
+        } else {
+            coefficients[idx].double()
+        };
+        coefficients[i] = folded;
+    }
+
+    // Truncate to the new length
+    coefficients.truncate(new_len);
 }
 
 #[cfg(test)]
 mod tests {
-    use super::fold_polynomial;
+    use super::{fold_polynomial, fold_polynomial_doubled, fold_polynomial_doubled_inplace};
     use math::field::element::FieldElement;
     use math::field::fields::u64_prime_field::U64PrimeField;
-    const MODULUS: u64 = 293;
-    type FE = FieldElement<U64PrimeField<MODULUS>>;
     use math::polynomial::Polynomial;
 
+    const MODULUS: u64 = 293;
+    type FE = FieldElement<U64PrimeField<MODULUS>>;
+
     #[test]
-    fn test_fold() {
+    fn test_fold_power_of_2() {
         let p0 = Polynomial::new(&[
             FE::new(3),
             FE::new(1),
@@ -47,21 +109,79 @@ mod tests {
             FE::new(7),
             FE::new(3),
             FE::new(5),
+            FE::new(4),
+            FE::new(2),
         ]);
         let beta = FE::new(4);
         let p1 = fold_polynomial(&p0, &beta);
         assert_eq!(
             p1,
-            Polynomial::new(&[FE::new(7), FE::new(30), FE::new(23),])
+            Polynomial::new(&[FE::new(7), FE::new(30), FE::new(23), FE::new(12)])
         );
 
         let gamma = FE::new(3);
         let p2 = fold_polynomial(&p1, &gamma);
-        assert_eq!(p2, Polynomial::new(&[FE::new(97), FE::new(23),]));
+        assert_eq!(p2, Polynomial::new(&[FE::new(97), FE::new(59)]));
 
         let delta = FE::new(2);
         let p3 = fold_polynomial(&p2, &delta);
-        assert_eq!(p3, Polynomial::new(&[FE::new(143)]));
+        assert_eq!(p3, Polynomial::new(&[FE::new(215)]));
         assert_eq!(p3.degree(), 0);
+    }
+
+    #[test]
+    fn test_fold_size_2() {
+        let p2 = Polynomial::new(&[FE::new(10), FE::new(20)]);
+        let beta = FE::new(3);
+        let result = fold_polynomial(&p2, &beta);
+        assert_eq!(result, Polynomial::new(&[FE::new(70)]));
+    }
+
+    #[test]
+    fn test_inplace_matches_regular() {
+        let p0 = Polynomial::new(&[
+            FE::new(3),
+            FE::new(1),
+            FE::new(2),
+            FE::new(7),
+            FE::new(3),
+            FE::new(5),
+            FE::new(4),
+            FE::new(2),
+        ]);
+        let beta = FE::new(4);
+
+        // Test that in-place matches regular folding with doubling
+        let expected = fold_polynomial_doubled(&p0, &beta);
+        let mut p_inplace = p0.clone();
+        fold_polynomial_doubled_inplace(&mut p_inplace, &beta);
+        assert_eq!(p_inplace, expected);
+
+        // Test multiple folds
+        let gamma = FE::new(3);
+        let expected2 = fold_polynomial_doubled(&expected, &gamma);
+        fold_polynomial_doubled_inplace(&mut p_inplace, &gamma);
+        assert_eq!(p_inplace, expected2);
+
+        let delta = FE::new(2);
+        let expected3 = fold_polynomial_doubled(&expected2, &delta);
+        fold_polynomial_doubled_inplace(&mut p_inplace, &delta);
+        assert_eq!(p_inplace, expected3);
+    }
+
+    #[test]
+    fn test_inplace_empty() {
+        let mut p: Polynomial<FE> = Polynomial::new(&[]);
+        let beta = FE::new(4);
+        fold_polynomial_doubled_inplace(&mut p, &beta);
+        assert!(p.coefficients.is_empty());
+    }
+
+    #[test]
+    fn test_inplace_single() {
+        let mut p = Polynomial::new(&[FE::new(5)]);
+        let beta = FE::new(4);
+        fold_polynomial_doubled_inplace(&mut p, &beta);
+        assert_eq!(p, Polynomial::new(&[FE::new(10)])); // 5 * 2 = 10
     }
 }

--- a/crypto/stark/src/fri/fri_functions.rs
+++ b/crypto/stark/src/fri/fri_functions.rs
@@ -3,6 +3,7 @@ use math::field::{element::FieldElement, traits::IsField};
 
 /// FRI polynomial folding: computes P_even(x) + beta * P_odd(x)
 /// where P(x) = P_even(x^2) + x * P_odd(x^2)
+#[allow(unused)]
 pub fn fold_polynomial<F>(
     poly: &Polynomial<FieldElement<F>>,
     beta: &FieldElement<F>,
@@ -32,6 +33,7 @@ where
 /// FRI polynomial folding with fused doubling: 2 * (P_even(x) + beta * P_odd(x))
 ///
 /// Uses `double()` which is more efficient than multiplication by 2.
+#[allow(unused)]
 pub fn fold_polynomial_doubled<F>(
     poly: &Polynomial<FieldElement<F>>,
     beta: &FieldElement<F>,

--- a/crypto/stark/src/fri/mod.rs
+++ b/crypto/stark/src/fri/mod.rs
@@ -11,11 +11,11 @@ pub use math::{
     polynomial::Polynomial,
 };
 
-use crate::config::{BatchedMerkleTree, BatchedMerkleTreeBackend};
+use crate::config::{FriLayerMerkleTree, FriLayerMerkleTreeBackend};
 
 use self::fri_commitment::FriLayer;
 use self::fri_decommit::FriDecommitment;
-use self::fri_functions::fold_polynomial;
+use self::fri_functions::fold_polynomial_doubled_inplace;
 
 pub fn commit_phase<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
     number_layers: usize,
@@ -25,7 +25,7 @@ pub fn commit_phase<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
     domain_size: usize,
 ) -> (
     FieldElement<E>,
-    Vec<FriLayer<E, BatchedMerkleTreeBackend<E>>>,
+    Vec<FriLayer<E, FriLayerMerkleTreeBackend<E>>>,
 )
 where
     FieldElement<F>: AsBytes + Sync + Send,
@@ -34,7 +34,7 @@ where
     let mut domain_size = domain_size;
 
     let mut fri_layer_list = Vec::with_capacity(number_layers);
-    let mut current_layer: FriLayer<E, BatchedMerkleTreeBackend<E>>;
+    let mut current_layer: FriLayer<E, FriLayerMerkleTreeBackend<E>>;
     let mut current_poly = p_0;
 
     let mut coset_offset = coset_offset.clone();
@@ -45,8 +45,8 @@ where
         coset_offset = coset_offset.square();
         domain_size /= 2;
 
-        // Compute layer polynomial and domain
-        current_poly = FieldElement::<F>::from(2) * fold_polynomial(&current_poly, &zeta);
+        // In-place folding avoids memory allocation
+        fold_polynomial_doubled_inplace(&mut current_poly, &zeta);
         current_layer = new_fri_layer(&current_poly, &coset_offset, domain_size);
         let new_data = &current_layer.merkle_tree.root;
         fri_layer_list.push(current_layer.clone()); // TODO: remove this clone
@@ -58,9 +58,10 @@ where
     // <<<< Receive challenge: 𝜁ₙ₋₁
     let zeta = transcript.sample_field_element();
 
-    let last_poly = FieldElement::<F>::from(2) * fold_polynomial(&current_poly, &zeta);
+    // Final fold - still in-place
+    fold_polynomial_doubled_inplace(&mut current_poly, &zeta);
 
-    let last_value = last_poly
+    let last_value = current_poly
         .coefficients()
         .first()
         .unwrap_or(&FieldElement::zero())
@@ -73,7 +74,7 @@ where
 }
 
 pub fn query_phase<F: IsField>(
-    fri_layers: &Vec<FriLayer<F, BatchedMerkleTreeBackend<F>>>,
+    fri_layers: &Vec<FriLayer<F, FriLayerMerkleTreeBackend<F>>>,
     iotas: &[usize],
 ) -> Vec<FriDecommitment<F>>
 where
@@ -112,7 +113,7 @@ pub fn new_fri_layer<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
     poly: &Polynomial<FieldElement<E>>,
     coset_offset: &FieldElement<F>,
     domain_size: usize,
-) -> crate::fri::fri_commitment::FriLayer<E, BatchedMerkleTreeBackend<E>>
+) -> FriLayer<E, FriLayerMerkleTreeBackend<E>>
 where
     FieldElement<F>: AsBytes + Sync + Send,
     FieldElement<E>: AsBytes + Sync + Send,
@@ -122,12 +123,13 @@ where
 
     in_place_bit_reverse_permute(&mut evaluation);
 
-    let mut to_commit = Vec::new();
-    for chunk in evaluation.chunks(2) {
-        to_commit.push(vec![chunk[0].clone(), chunk[1].clone()]);
-    }
+    // Use fixed-size arrays instead of Vec for each pair (avoids allocation per pair)
+    let leaves: Vec<[FieldElement<E>; 2]> = evaluation
+        .chunks_exact(2)
+        .map(|chunk| [chunk[0].clone(), chunk[1].clone()])
+        .collect();
 
-    let merkle_tree = BatchedMerkleTree::build(&to_commit).unwrap();
+    let merkle_tree = FriLayerMerkleTree::build(&leaves).unwrap();
 
     FriLayer::new(
         &evaluation,


### PR DESCRIPTION
- Add FieldElementPairBackend for fixed-size [FieldElement; 2] Merkle leaves
- Add fold_polynomial_doubled_inplace for zero-allocation polynomial folding
- Update FRI commit phase to use in-place folding
- Use FriLayerMerkleTree with pair backend to avoid Vec allocation per leaf

This reduces memory allocations during FRI commitment and improves cache locality.