### PR TITLE
perf(stark): remove unnecessary clones

### DIFF
--- a/crypto/stark/src/constraints/evaluator.rs
+++ b/crypto/stark/src/constraints/evaluator.rs
@@ -70,7 +70,7 @@ where
                     let mut evals = domain
                         .lde_roots_of_unity_coset
                         .iter()
-                        .map(|v| v.clone() - point)
+                        .map(|v| v - point)
                         .collect::<Vec<FieldElement<Field>>>();
                     FieldElement::inplace_batch_inverse(&mut evals).unwrap();
                     evals

--- a/crypto/stark/src/fri/mod.rs
+++ b/crypto/stark/src/fri/mod.rs
@@ -48,11 +48,12 @@ where
         // Compute layer polynomial and domain
         current_poly = FieldElement::<F>::from(2) * fold_polynomial(&current_poly, &zeta);
         current_layer = new_fri_layer(&current_poly, &coset_offset, domain_size);
-        let new_data = &current_layer.merkle_tree.root;
-        fri_layer_list.push(current_layer.clone()); // TODO: remove this clone
+        // Copy just the root (small, 32 bytes) before moving the layer
+        let new_data = current_layer.merkle_tree.root;
+        fri_layer_list.push(current_layer);
 
         // >>>> Send commitment: [pₖ]
-        transcript.append_bytes(new_data);
+        transcript.append_bytes(&new_data);
     }
 
     // <<<< Receive challenge: 𝜁ₙ₋₁


### PR DESCRIPTION
- Remove FRI layer clone in commit_phase by copying just the root (32 bytes) before moving
- Remove clone in constraint evaluator boundary zerofier computation (use reference subtraction)

These changes reduce memory allocations in hot paths.