### PR TITLE
feat(stark): add Multiplicity enum for flexible lookup multiplicities

### DIFF
--- a/crypto/stark/src/examples/multi_table_lookup.rs
+++ b/crypto/stark/src/examples/multi_table_lookup.rs
@@ -1,8 +1,8 @@
 use crate::{
     constraints::transition::TransitionConstraint,
     lookup::{
-        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, NullBoundaryConstraintBuilder,
-        Packing,
+        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, Multiplicity,
+        NullBoundaryConstraintBuilder, Packing,
     },
     proof::options::ProofOptions,
 };
@@ -20,9 +20,9 @@ pub fn new_cpu_air_with_lookup(
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![
             // Interaction with ADD table (CPU sends to ADD bus)
-            BusInteraction::sender(Some(0), Packing::Direct.columns(&[2, 3, 4])),
+            BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[2, 3, 4])),
             // Interaction with MUL table (CPU sends to MUL bus)
-            BusInteraction::sender(Some(1), Packing::Direct.columns(&[2, 3, 4])),
+            BusInteraction::sender(Multiplicity::Column(1), Packing::Direct.columns(&[2, 3, 4])),
         ],
     };
 
@@ -43,7 +43,7 @@ pub fn new_mul_air_with_lookup(
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![
             // Interaction with CPU table (MUL table receives from MUL bus)
-            BusInteraction::receiver(Some(3), Packing::Direct.columns(&[0, 1, 2])),
+            BusInteraction::receiver(Multiplicity::Column(3), Packing::Direct.columns(&[0, 1, 2])),
         ],
     };
 
@@ -64,7 +64,7 @@ pub fn new_add_air_with_lookup(
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![
             // Interaction with CPU table (ADD table receives from ADD bus)
-            BusInteraction::receiver(Some(3), Packing::Direct.columns(&[0, 1, 2])),
+            BusInteraction::receiver(Multiplicity::Column(3), Packing::Direct.columns(&[0, 1, 2])),
         ],
     };
 

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -568,6 +568,33 @@ pub struct AuxiliaryTraceBuildData {
     pub interactions: Vec<BusInteraction>,
 }
 
+// =============================================================================
+// Multiplicity
+// =============================================================================
+
+/// Specifies how to compute the multiplicity for a bus interaction.
+///
+/// The multiplicity determines how many times each row contributes to the bus.
+/// Different use cases require different ways to compute this value.
+#[derive(Clone, Debug)]
+pub enum Multiplicity {
+    /// Constant multiplicity of 1 for all rows.
+    /// Use when every row participates exactly once.
+    One,
+
+    /// Read multiplicity from a single column (index).
+    Column(usize),
+
+    /// Sum of two columns: `col_a + col_b`.
+    /// Useful when multiple flags indicate participation.
+    Sum(usize, usize),
+
+    /// Negation of a bit column: `1 - col_value`.
+    /// The column must contain only 0 or 1.
+    /// Useful for "all rows except those marked by this flag".
+    Negated(usize),
+}
+
 /// Struct representing a lookup interaction for a given table.
 /// Contains the multiplicity and typed values involved in said interaction.
 ///
@@ -576,11 +603,9 @@ pub struct AuxiliaryTraceBuildData {
 /// 2. **Bus fingerprint** (powers of α): Combine all bus elements into one fingerprint
 #[derive(Clone)]
 pub struct BusInteraction {
-    /// Column index containing the multiplicity for this interaction.
-    /// Can be a binary flag (0 or 1) or a general multiplicity (0, 1, 2, ...).
+    /// How to compute the multiplicity for this interaction.
     /// Determines how many times each row contributes to the bus.
-    /// If None, a constant multiplicity of 1 is used for all rows.
-    pub multiplicity_column: Option<usize>,
+    pub multiplicity: Multiplicity,
     /// Typed values that make up this interaction
     pub values: Vec<TypedValue>,
     /// Whether this side of the interaction is a sender (true) or receiver (false).
@@ -591,26 +616,22 @@ pub struct BusInteraction {
 
 impl BusInteraction {
     /// Creates a new table interaction.
-    pub fn new(
-        multiplicity_column: Option<usize>,
-        values: Vec<TypedValue>,
-        is_sender: bool,
-    ) -> Self {
+    pub fn new(multiplicity: Multiplicity, values: Vec<TypedValue>, is_sender: bool) -> Self {
         Self {
-            multiplicity_column,
+            multiplicity,
             values,
             is_sender,
         }
     }
 
     /// Creates a sender interaction.
-    pub fn sender(multiplicity_column: Option<usize>, values: Vec<TypedValue>) -> Self {
-        Self::new(multiplicity_column, values, true)
+    pub fn sender(multiplicity: Multiplicity, values: Vec<TypedValue>) -> Self {
+        Self::new(multiplicity, values, true)
     }
 
     /// Creates a receiver interaction.
-    pub fn receiver(multiplicity_column: Option<usize>, values: Vec<TypedValue>) -> Self {
-        Self::new(multiplicity_column, values, false)
+    pub fn receiver(multiplicity: Multiplicity, values: Vec<TypedValue>) -> Self {
+        Self::new(multiplicity, values, false)
     }
 
     /// Returns total number of bus elements (for α power computation).
@@ -685,16 +706,6 @@ fn build_logup_term_column<F, E>(
     let main_segment_cols = trace.columns_main();
     let trace_len = trace.num_rows();
 
-    // Handle optional multiplicity column - use constant 1 if None
-    let multiplicities_owned: Vec<FieldElement<F>>;
-    let multiplicities: &[FieldElement<F>] = match table_interaction.multiplicity_column {
-        Some(col) => &main_segment_cols[col],
-        None => {
-            multiplicities_owned = vec![FieldElement::one(); trace_len];
-            &multiplicities_owned
-        }
-    };
-
     // LogUp challenges (must be shared across all tables for bus to balance)
     let z = &challenges[LOGUP_CHALLENGE_Z];
     let alpha = &challenges[LOGUP_CHALLENGE_ALPHA];
@@ -711,7 +722,18 @@ fn build_logup_term_column<F, E>(
         -FieldElement::<E>::one()
     };
 
-    for (row, multiplicity) in multiplicities.iter().enumerate() {
+    for row in 0..trace_len {
+        // Compute multiplicity based on the Multiplicity variant
+        let multiplicity: FieldElement<F> = match &table_interaction.multiplicity {
+            Multiplicity::One => FieldElement::<F>::one(),
+            Multiplicity::Column(col) => main_segment_cols[*col][row].clone(),
+            Multiplicity::Sum(col_a, col_b) => {
+                &main_segment_cols[*col_a][row] + &main_segment_cols[*col_b][row]
+            }
+            Multiplicity::Negated(col) => {
+                FieldElement::<F>::one() - &main_segment_cols[*col][row]
+            }
+        };
         // Stage 1: Combine each typed value's columns using powers of 2 (in base field)
         // Stage 2: Convert to extension and combine with powers of α
         let bus_elements: Vec<FieldElement<E>> = table_interaction
@@ -838,10 +860,17 @@ where
             let z = &rap_challenges[LOGUP_CHALLENGE_Z];
             let alpha = &rap_challenges[LOGUP_CHALLENGE_ALPHA];
 
-            // Main frame elements - handle optional multiplicity
-            let multiplicity: FieldElement<A> = match interaction.multiplicity_column {
-                Some(col) => step.get_main_evaluation_element(0, col).clone(),
-                None => FieldElement::<A>::one(),
+            // Compute multiplicity based on the Multiplicity variant
+            let multiplicity: FieldElement<A> = match &interaction.multiplicity {
+                Multiplicity::One => FieldElement::<A>::one(),
+                Multiplicity::Column(col) => step.get_main_evaluation_element(0, *col).clone(),
+                Multiplicity::Sum(col_a, col_b) => {
+                    step.get_main_evaluation_element(0, *col_a)
+                        + step.get_main_evaluation_element(0, *col_b)
+                }
+                Multiplicity::Negated(col) => {
+                    FieldElement::<A>::one() - step.get_main_evaluation_element(0, *col)
+                }
             };
 
             // Stage 1: Combine each typed value's columns using powers of 2 (in base field)

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -731,9 +731,7 @@ fn build_logup_term_column<F, E>(
             Multiplicity::Sum(col_a, col_b) => {
                 &main_segment_cols[*col_a][row] + &main_segment_cols[*col_b][row]
             }
-            Multiplicity::Negated(col) => {
-                FieldElement::<F>::one() - &main_segment_cols[*col][row]
-            }
+            Multiplicity::Negated(col) => FieldElement::<F>::one() - &main_segment_cols[*col][row],
         };
         // Stage 1: Combine each typed value's columns using powers of 2 (in base field)
         // Stage 2: Convert to extension and combine with powers of α

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -694,6 +694,7 @@ where
 /// - `multiplicity` = number of times this row contributes to the bus
 ///
 /// This is NOT accumulated - just the individual contribution for each row.
+#[allow(clippy::needless_range_loop)]
 fn build_logup_term_column<F, E>(
     aux_column_idx: usize,
     table_interaction: &BusInteraction,

--- a/crypto/stark/src/tests/bus_tests/mod.rs
+++ b/crypto/stark/src/tests/bus_tests/mod.rs
@@ -1,5 +1,5 @@
 //! Tests for LogUp bus interactions.
-
 pub mod completeness_tests;
+pub mod multiplicity_tests;
 pub mod packing_tests;
 pub mod soundness_tests;

--- a/crypto/stark/src/tests/bus_tests/multiplicity_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/multiplicity_tests.rs
@@ -166,8 +166,8 @@ fn test_multiplicity_sum() {
     // Row 3: flag_a=0, flag_b=0, sends (40, 400) with mult=0 (no contribution)
     let mut sender_trace = TraceTable::from_columns_main(
         vec![
-            vec![FE::one(), FE::zero(), FE::one(), FE::zero()],  // flag_a
-            vec![FE::zero(), FE::one(), FE::one(), FE::zero()],  // flag_b
+            vec![FE::one(), FE::zero(), FE::one(), FE::zero()], // flag_a
+            vec![FE::zero(), FE::one(), FE::one(), FE::zero()], // flag_b
             vec![FE::from(10), FE::from(20), FE::from(30), FE::from(40)], // value_a
             vec![FE::from(100), FE::from(200), FE::from(300), FE::from(400)], // value_b
         ],
@@ -180,7 +180,7 @@ fn test_multiplicity_sum() {
         vec![
             vec![FE::from(10), FE::from(20), FE::from(30), FE::zero()], // value_a
             vec![FE::from(100), FE::from(200), FE::from(300), FE::zero()], // value_b
-            vec![FE::one(), FE::one(), FE::from(2), FE::zero()], // multiplicity
+            vec![FE::one(), FE::one(), FE::from(2), FE::zero()],        // multiplicity
         ],
         1,
     );
@@ -243,9 +243,10 @@ fn test_multiplicity_negated() {
     ) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
         let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
         let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
-            interactions: vec![
-                BusInteraction::receiver(Multiplicity::Column(2), Packing::Direct.columns(&[0, 1])),
-            ],
+            interactions: vec![BusInteraction::receiver(
+                Multiplicity::Column(2),
+                Packing::Direct.columns(&[0, 1]),
+            )],
         };
         AirWithBuses::new(
             3, // columns: value_a, value_b, multiplicity
@@ -277,7 +278,7 @@ fn test_multiplicity_negated() {
         vec![
             vec![FE::from(10), FE::from(30), FE::from(40), FE::zero()], // value_a
             vec![FE::from(100), FE::from(300), FE::from(400), FE::zero()], // value_b
-            vec![FE::one(), FE::one(), FE::one(), FE::zero()], // multiplicity
+            vec![FE::one(), FE::one(), FE::one(), FE::zero()],          // multiplicity
         ],
         1,
     );

--- a/crypto/stark/src/tests/bus_tests/multiplicity_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/multiplicity_tests.rs
@@ -1,0 +1,308 @@
+//! Tests for Multiplicity variants.
+//!
+//! These tests verify that all Multiplicity variants (One, Column, Sum, Negated)
+//! work correctly for computing bus interaction multiplicities.
+
+use crypto::fiat_shamir::default_transcript::DefaultTranscript;
+use math::field::element::FieldElement;
+use math::field::fields::fft_friendly::{
+    babybear::Babybear31PrimeField, quartic_babybear::Degree4BabyBearExtensionField,
+};
+
+use crate::constraints::transition::TransitionConstraint;
+use crate::lookup::{
+    AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, Multiplicity,
+    NullBoundaryConstraintBuilder, Packing,
+};
+use crate::proof::options::ProofOptions;
+use crate::prover::{IsStarkProver, Prover};
+use crate::trace::TraceTable;
+use crate::traits::AIR;
+use crate::verifier::{IsStarkVerifier, Verifier};
+
+type F = Babybear31PrimeField;
+type E = Degree4BabyBearExtensionField;
+type FE = FieldElement<F>;
+
+// =============================================================================
+// Multiplicity::One tests
+// =============================================================================
+
+/// Test Multiplicity::One: every row contributes with multiplicity 1.
+/// Sender sends 4 values (one per row), receiver receives each once.
+#[test_log::test]
+fn test_multiplicity_one() {
+    fn sender_air(
+        proof_options: &ProofOptions,
+    ) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
+        let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+        let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+            interactions: vec![
+                // Multiplicity::One means every row sends with multiplicity 1
+                BusInteraction::sender(Multiplicity::One, Packing::Direct.columns(&[0, 1])),
+            ],
+        };
+        AirWithBuses::new(
+            2, // columns: a, b
+            auxiliary_trace_build_data,
+            proof_options,
+            1,
+            transition_constraints,
+        )
+    }
+
+    fn receiver_air(
+        proof_options: &ProofOptions,
+    ) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
+        let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+        let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+            interactions: vec![
+                // Receiver also uses Multiplicity::One
+                BusInteraction::receiver(Multiplicity::One, Packing::Direct.columns(&[0, 1])),
+            ],
+        };
+        AirWithBuses::new(
+            2, // columns: a, b
+            auxiliary_trace_build_data,
+            proof_options,
+            1,
+            transition_constraints,
+        )
+    }
+
+    // Sender trace: 4 rows, each sends (a, b) with multiplicity 1
+    let mut sender_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::from(10), FE::from(20), FE::from(30), FE::from(40)], // a
+            vec![FE::from(100), FE::from(200), FE::from(300), FE::from(400)], // b
+        ],
+        1,
+    );
+
+    // Receiver trace: same 4 rows, each receives with multiplicity 1
+    let mut receiver_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::from(10), FE::from(20), FE::from(30), FE::from(40)], // a
+            vec![FE::from(100), FE::from(200), FE::from(300), FE::from(400)], // b
+        ],
+        1,
+    );
+
+    let proof_options = ProofOptions::default_test_options();
+    let sender = sender_air(&proof_options);
+    let receiver = receiver_air(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&sender, &mut sender_trace, &()),
+        (&receiver, &mut receiver_trace, &()),
+    ];
+
+    let multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&sender, &receiver];
+
+    assert!(
+        Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[])),
+        "Multiplicity::One should work for matching sender/receiver"
+    );
+}
+
+// =============================================================================
+// Multiplicity::Sum tests
+// =============================================================================
+
+/// Test Multiplicity::Sum: multiplicity is col_a + col_b.
+/// Sender has two flag columns, receiver uses their sum as multiplicity.
+#[test_log::test]
+fn test_multiplicity_sum() {
+    fn sender_air(
+        proof_options: &ProofOptions,
+    ) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
+        let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+        let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+            interactions: vec![
+                // Multiplicity::Sum(0, 1) means multiplicity = col[0] + col[1]
+                BusInteraction::sender(Multiplicity::Sum(0, 1), Packing::Direct.columns(&[2, 3])),
+            ],
+        };
+        AirWithBuses::new(
+            4, // columns: flag_a, flag_b, value_a, value_b
+            auxiliary_trace_build_data,
+            proof_options,
+            1,
+            transition_constraints,
+        )
+    }
+
+    fn receiver_air(
+        proof_options: &ProofOptions,
+    ) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
+        let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+        let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+            interactions: vec![
+                // Receiver uses Column(2) as multiplicity
+                BusInteraction::receiver(Multiplicity::Column(2), Packing::Direct.columns(&[0, 1])),
+            ],
+        };
+        AirWithBuses::new(
+            3, // columns: value_a, value_b, multiplicity
+            auxiliary_trace_build_data,
+            proof_options,
+            1,
+            transition_constraints,
+        )
+    }
+
+    // Sender trace:
+    // Row 0: flag_a=1, flag_b=0, sends (10, 100) with mult=1
+    // Row 1: flag_a=0, flag_b=1, sends (20, 200) with mult=1
+    // Row 2: flag_a=1, flag_b=1, sends (30, 300) with mult=2
+    // Row 3: flag_a=0, flag_b=0, sends (40, 400) with mult=0 (no contribution)
+    let mut sender_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::one(), FE::zero(), FE::one(), FE::zero()],  // flag_a
+            vec![FE::zero(), FE::one(), FE::one(), FE::zero()],  // flag_b
+            vec![FE::from(10), FE::from(20), FE::from(30), FE::from(40)], // value_a
+            vec![FE::from(100), FE::from(200), FE::from(300), FE::from(400)], // value_b
+        ],
+        1,
+    );
+
+    // Receiver trace: receives the values with matching multiplicities
+    // (10, 100) with mult=1, (20, 200) with mult=1, (30, 300) with mult=2
+    let mut receiver_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::from(10), FE::from(20), FE::from(30), FE::zero()], // value_a
+            vec![FE::from(100), FE::from(200), FE::from(300), FE::zero()], // value_b
+            vec![FE::one(), FE::one(), FE::from(2), FE::zero()], // multiplicity
+        ],
+        1,
+    );
+
+    let proof_options = ProofOptions::default_test_options();
+    let sender = sender_air(&proof_options);
+    let receiver = receiver_air(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&sender, &mut sender_trace, &()),
+        (&receiver, &mut receiver_trace, &()),
+    ];
+
+    let multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&sender, &receiver];
+
+    assert!(
+        Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[])),
+        "Multiplicity::Sum should work for matching sender/receiver"
+    );
+}
+
+// =============================================================================
+// Multiplicity::Negated tests
+// =============================================================================
+
+/// Test Multiplicity::Negated: multiplicity is 1 - col_value.
+/// Useful for "all rows except those marked by this flag".
+#[test_log::test]
+fn test_multiplicity_negated() {
+    fn sender_air(
+        proof_options: &ProofOptions,
+    ) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
+        let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+        let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+            interactions: vec![
+                // Multiplicity::Negated(0) means multiplicity = 1 - col[0]
+                // When col[0]=0, multiplicity=1; when col[0]=1, multiplicity=0
+                BusInteraction::sender(Multiplicity::Negated(0), Packing::Direct.columns(&[1, 2])),
+            ],
+        };
+        AirWithBuses::new(
+            3, // columns: skip_flag, value_a, value_b
+            auxiliary_trace_build_data,
+            proof_options,
+            1,
+            transition_constraints,
+        )
+    }
+
+    fn receiver_air(
+        proof_options: &ProofOptions,
+    ) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
+        let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+        let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+            interactions: vec![
+                BusInteraction::receiver(Multiplicity::Column(2), Packing::Direct.columns(&[0, 1])),
+            ],
+        };
+        AirWithBuses::new(
+            3, // columns: value_a, value_b, multiplicity
+            auxiliary_trace_build_data,
+            proof_options,
+            1,
+            transition_constraints,
+        )
+    }
+
+    // Sender trace:
+    // Row 0: skip_flag=0, sends (10, 100) with mult=1-0=1
+    // Row 1: skip_flag=1, sends (20, 200) with mult=1-1=0 (skipped!)
+    // Row 2: skip_flag=0, sends (30, 300) with mult=1-0=1
+    // Row 3: skip_flag=0, sends (40, 400) with mult=1-0=1
+    let mut sender_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::zero(), FE::one(), FE::zero(), FE::zero()], // skip_flag
+            vec![FE::from(10), FE::from(20), FE::from(30), FE::from(40)], // value_a
+            vec![FE::from(100), FE::from(200), FE::from(300), FE::from(400)], // value_b
+        ],
+        1,
+    );
+
+    // Receiver trace: only receives rows where skip_flag=0
+    // (10, 100), (30, 300), (40, 400) each with multiplicity 1
+    // Row 1 is padding (not used)
+    let mut receiver_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::from(10), FE::from(30), FE::from(40), FE::zero()], // value_a
+            vec![FE::from(100), FE::from(300), FE::from(400), FE::zero()], // value_b
+            vec![FE::one(), FE::one(), FE::one(), FE::zero()], // multiplicity
+        ],
+        1,
+    );
+
+    let proof_options = ProofOptions::default_test_options();
+    let sender = sender_air(&proof_options);
+    let receiver = receiver_air(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&sender, &mut sender_trace, &()),
+        (&receiver, &mut receiver_trace, &()),
+    ];
+
+    let multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&sender, &receiver];
+
+    assert!(
+        Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[])),
+        "Multiplicity::Negated should work for skipping flagged rows"
+    );
+}

--- a/crypto/stark/src/tests/bus_tests/packing_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/packing_tests.rs
@@ -264,7 +264,8 @@ fn test_quad_hl_equals_four_word2l() {
 fn test_air_layout_single_interaction() {
     type E = math::field::fields::fft_friendly::quartic_babybear::Degree4BabyBearExtensionField;
 
-    let interaction = BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[1, 2, 3]));
+    let interaction =
+        BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[1, 2, 3]));
     let build_data = AuxiliaryTraceBuildData {
         interactions: vec![interaction],
     };
@@ -286,8 +287,10 @@ fn test_air_layout_single_interaction() {
 fn test_air_layout_multiple_interactions() {
     type E = math::field::fields::fft_friendly::quartic_babybear::Degree4BabyBearExtensionField;
 
-    let interaction1 = BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[1, 2]));
-    let interaction2 = BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[3, 4]));
+    let interaction1 =
+        BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[1, 2]));
+    let interaction2 =
+        BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[3, 4]));
     let build_data = AuxiliaryTraceBuildData {
         interactions: vec![interaction1, interaction2],
     };

--- a/crypto/stark/src/tests/bus_tests/packing_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/packing_tests.rs
@@ -4,7 +4,8 @@ use math::field::element::FieldElement;
 use math::field::fields::fft_friendly::babybear::Babybear31PrimeField;
 
 use crate::lookup::{
-    AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, NullBoundaryConstraintBuilder, Packing,
+    AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, Multiplicity,
+    NullBoundaryConstraintBuilder, Packing,
 };
 use crate::proof::options::ProofOptions;
 use crate::traits::AIR;
@@ -263,7 +264,7 @@ fn test_quad_hl_equals_four_word2l() {
 fn test_air_layout_single_interaction() {
     type E = math::field::fields::fft_friendly::quartic_babybear::Degree4BabyBearExtensionField;
 
-    let interaction = BusInteraction::sender(Some(0), Packing::Direct.columns(&[1, 2, 3]));
+    let interaction = BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[1, 2, 3]));
     let build_data = AuxiliaryTraceBuildData {
         interactions: vec![interaction],
     };
@@ -285,8 +286,8 @@ fn test_air_layout_single_interaction() {
 fn test_air_layout_multiple_interactions() {
     type E = math::field::fields::fft_friendly::quartic_babybear::Degree4BabyBearExtensionField;
 
-    let interaction1 = BusInteraction::sender(Some(0), Packing::Direct.columns(&[1, 2]));
-    let interaction2 = BusInteraction::sender(Some(0), Packing::Direct.columns(&[3, 4]));
+    let interaction1 = BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[1, 2]));
+    let interaction2 = BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[3, 4]));
     let build_data = AuxiliaryTraceBuildData {
         interactions: vec![interaction1, interaction2],
     };

--- a/crypto/stark/src/tests/bus_tests/soundness_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/soundness_tests.rs
@@ -787,8 +787,8 @@ fn test_full_scenario_wrong_add() {
 #[test_log::test]
 fn test_packing_mismatch_direct_vs_word2l() {
     use crate::lookup::{
-        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, NullBoundaryConstraintBuilder,
-        Packing,
+        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, Multiplicity,
+        NullBoundaryConstraintBuilder, Packing,
     };
 
     fn sender_air_direct(
@@ -797,7 +797,7 @@ fn test_packing_mismatch_direct_vs_word2l() {
         let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
             interactions: vec![
                 // Sender uses Direct: 2 separate elements
-                BusInteraction::sender(Some(0), Packing::Direct.columns(&[1, 2])),
+                BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[1, 2])),
             ],
         };
         AirWithBuses::new(3, auxiliary_trace_build_data, proof_options, 1, vec![])
@@ -810,7 +810,7 @@ fn test_packing_mismatch_direct_vs_word2l() {
             interactions: vec![
                 // Receiver uses Word2L: combines 2 columns into 1 element
                 // Formula: (v0 + 2^16 * v1) - different from v0 + α*v1
-                BusInteraction::receiver(Some(0), Packing::Word2L.columns(&[1])),
+                BusInteraction::receiver(Multiplicity::Column(0), Packing::Word2L.columns(&[1])),
             ],
         };
         AirWithBuses::new(
@@ -879,8 +879,8 @@ fn test_packing_mismatch_direct_vs_word2l() {
 #[test_log::test]
 fn test_packing_mismatch_element_count() {
     use crate::lookup::{
-        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, NullBoundaryConstraintBuilder,
-        Packing,
+        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, Multiplicity,
+        NullBoundaryConstraintBuilder, Packing,
     };
 
     fn sender_air_3_direct(
@@ -890,7 +890,7 @@ fn test_packing_mismatch_element_count() {
             interactions: vec![
                 // Sender uses 3 Direct elements: produces [col1, col2, col3]
                 // Fingerprint: z - (col1 + α*col2 + α²*col3)
-                BusInteraction::sender(Some(0), Packing::Direct.columns(&[1, 2, 3])),
+                BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[1, 2, 3])),
             ],
         };
         AirWithBuses::new(4, auxiliary_trace_build_data, proof_options, 1, vec![])
@@ -905,7 +905,7 @@ fn test_packing_mismatch_element_count() {
                 // Produces 2 bus elements: [(col1 + 2^16*col2), col3]
                 // Fingerprint: z - ((col1 + 2^16*col2) + α*col3)
                 BusInteraction::receiver(
-                    Some(0),
+                    Multiplicity::Column(0),
                     vec![
                         Packing::Word2L.columns(&[1])[0].clone(),
                         Packing::Direct.columns(&[3])[0].clone(),
@@ -971,8 +971,8 @@ fn test_packing_mismatch_element_count() {
 #[test_log::test]
 fn test_packing_mismatch_shift_constant() {
     use crate::lookup::{
-        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, NullBoundaryConstraintBuilder,
-        Packing,
+        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, Multiplicity,
+        NullBoundaryConstraintBuilder, Packing,
     };
 
     fn sender_air_word4l(
@@ -981,7 +981,7 @@ fn test_packing_mismatch_shift_constant() {
         let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
             interactions: vec![
                 // Word4L: b0 + 2^8*b1 + 2^16*b2 + 2^24*b3
-                BusInteraction::sender(Some(0), Packing::Word4L.columns(&[1])),
+                BusInteraction::sender(Multiplicity::Column(0), Packing::Word4L.columns(&[1])),
             ],
         };
         AirWithBuses::new(5, auxiliary_trace_build_data, proof_options, 1, vec![])
@@ -993,7 +993,7 @@ fn test_packing_mismatch_shift_constant() {
         let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
             interactions: vec![
                 // DWordHL: [h0 + 2^16*h1, h2 + 2^16*h3] - different shift pattern!
-                BusInteraction::receiver(Some(0), Packing::DWordHL.columns(&[1])),
+                BusInteraction::receiver(Multiplicity::Column(0), Packing::DWordHL.columns(&[1])),
             ],
         };
         AirWithBuses::new(5, auxiliary_trace_build_data, proof_options, 1, vec![])
@@ -1059,8 +1059,8 @@ fn test_packing_mismatch_shift_constant() {
 #[test_log::test]
 fn test_compound_mismatch_dwordhhw_vs_dwordwhh() {
     use crate::lookup::{
-        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, NullBoundaryConstraintBuilder,
-        Packing,
+        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, Multiplicity,
+        NullBoundaryConstraintBuilder, Packing,
     };
 
     fn sender_air_dwordhhw(
@@ -1069,7 +1069,7 @@ fn test_compound_mismatch_dwordhhw_vs_dwordwhh() {
         let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
             interactions: vec![
                 // DWordHHW: [Word, Half, Half] at columns 1, 2, 3
-                BusInteraction::sender(Some(0), Packing::DWordHHW.columns(&[1])),
+                BusInteraction::sender(Multiplicity::Column(0), Packing::DWordHHW.columns(&[1])),
             ],
         };
         AirWithBuses::new(4, auxiliary_trace_build_data, proof_options, 1, vec![])
@@ -1081,7 +1081,7 @@ fn test_compound_mismatch_dwordhhw_vs_dwordwhh() {
         let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
             interactions: vec![
                 // DWordWHH: [Half, Half, Word] at columns 1, 2, 3
-                BusInteraction::receiver(Some(0), Packing::DWordWHH.columns(&[1])),
+                BusInteraction::receiver(Multiplicity::Column(0), Packing::DWordWHH.columns(&[1])),
             ],
         };
         AirWithBuses::new(4, auxiliary_trace_build_data, proof_options, 1, vec![])
@@ -1145,8 +1145,8 @@ fn test_compound_mismatch_dwordhhw_vs_dwordwhh() {
 #[test_log::test]
 fn test_compound_equals_primitive_expansion() {
     use crate::lookup::{
-        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, NullBoundaryConstraintBuilder,
-        Packing,
+        AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, Multiplicity,
+        NullBoundaryConstraintBuilder, Packing,
     };
 
     fn sender_air_compound(
@@ -1155,7 +1155,7 @@ fn test_compound_equals_primitive_expansion() {
         let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
             interactions: vec![
                 // DWordHL (compound): 4 halves at columns 1-4
-                BusInteraction::sender(Some(0), Packing::DWordHL.columns(&[1])),
+                BusInteraction::sender(Multiplicity::Column(0), Packing::DWordHL.columns(&[1])),
             ],
         };
         AirWithBuses::new(5, auxiliary_trace_build_data, proof_options, 1, vec![])
@@ -1167,7 +1167,7 @@ fn test_compound_equals_primitive_expansion() {
         let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
             interactions: vec![
                 // Equivalent: 2× Word2L at columns 1-2 and 3-4
-                BusInteraction::receiver(Some(0), Packing::Word2L.columns(&[1, 3])),
+                BusInteraction::receiver(Multiplicity::Column(0), Packing::Word2L.columns(&[1, 3])),
             ],
         };
         AirWithBuses::new(5, auxiliary_trace_build_data, proof_options, 1, vec![])

--- a/crypto/stark/src/tests/bus_tests/soundness_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/soundness_tests.rs
@@ -890,7 +890,10 @@ fn test_packing_mismatch_element_count() {
             interactions: vec![
                 // Sender uses 3 Direct elements: produces [col1, col2, col3]
                 // Fingerprint: z - (col1 + α*col2 + α²*col3)
-                BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[1, 2, 3])),
+                BusInteraction::sender(
+                    Multiplicity::Column(0),
+                    Packing::Direct.columns(&[1, 2, 3]),
+                ),
             ],
         };
         AirWithBuses::new(4, auxiliary_trace_build_data, proof_options, 1, vec![])

--- a/crypto/stark/src/tests/prove_verify_roundtrip_tests.rs
+++ b/crypto/stark/src/tests/prove_verify_roundtrip_tests.rs
@@ -11,7 +11,8 @@ use math::field::fields::fft_friendly::{
 
 use crate::constraints::transition::TransitionConstraint;
 use crate::lookup::{
-    AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, NullBoundaryConstraintBuilder, Packing,
+    AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, Multiplicity,
+    NullBoundaryConstraintBuilder, Packing,
 };
 use crate::proof::options::ProofOptions;
 use crate::proof::stark::MultiProof;
@@ -174,8 +175,8 @@ fn create_cpu_air(
     let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![
-            BusInteraction::sender(Some(0), Packing::Direct.columns(&[2, 3, 4])),
-            BusInteraction::sender(Some(1), Packing::Direct.columns(&[2, 3, 4])),
+            BusInteraction::sender(Multiplicity::Column(0), Packing::Direct.columns(&[2, 3, 4])),
+            BusInteraction::sender(Multiplicity::Column(1), Packing::Direct.columns(&[2, 3, 4])),
         ],
     };
     AirWithBuses::new(
@@ -193,7 +194,7 @@ fn create_add_air(
     let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![BusInteraction::receiver(
-            Some(3),
+            Multiplicity::Column(3),
             Packing::Direct.columns(&[0, 1, 2]),
         )],
     };
@@ -212,7 +213,7 @@ fn create_mul_air(
     let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![BusInteraction::receiver(
-            Some(3),
+            Multiplicity::Column(3),
             Packing::Direct.columns(&[0, 1, 2]),
         )],
     };


### PR DESCRIPTION
  - Replace `Option<usize>` with `Multiplicity` enum for bus interaction multiplicities
  - Support four multiplicity modes: constant one, single column, sum of two columns, and bit negation