### PR TITLE
fix(ci): improve Rust ELF cache reliability for merge queue

### DIFF
--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -76,7 +76,9 @@ jobs:
           path: |
             executor/program_artifacts/rust
             executor/shared_target
-          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json') }}
+          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**') }}
+          restore-keys: |
+            rust-elf-artifacts-
 
       - name: Compile Rust programs to ELF
         if: steps.cache-rust-elfs.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
  - Add `syscalls/**` to cache key hash to prevent stale cache hits
  - Add `restore-keys` fallback for cross-branch cache access

  ## Problem

  The CI was recompiling Rust programs on every merge queue run, even when source files hadn't changed. Investigation revealed two issues:

  1. **Missing dependency in cache key:** Rust programs depend on `syscalls/` via path dependency (`lambda-vm-syscalls = { path = "../../../../syscalls" }`), but this wasn't included in
  the cache key hash. Changes to `syscalls/` would incorrectly use stale cached ELFs.

  2. **Merge queue cache isolation:** GitHub Actions caches are scoped by branch. Merge queue branches (`gh-readonly-queue/main/pr-XXX-...`) couldn't find caches saved by PR branches or
  previous merge queue runs, causing full recompilation every time.

  ## Solution

  - `syscalls/**` in hash → invalidates cache when syscalls change (correctness fix)
  - `restore-keys` prefix → falls back to any matching cache when exact key not found (performance fix)

  ## Behavior after fix

  **Merge queue, no changes:** Before: cache miss, full recompile (~8 min) → After: cache hit, skip compile

  **Merge queue, first run with new key:** Before: cache miss, full recompile → After: restore partial cache, faster recompile

  **syscalls/ changed:** Before: stale cache used (wrong ELFs!) → After: cache invalidated, recompile