### PR TITLE
64-bit VM Prover - Initial Tables

### DIFF
--- a/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
@@ -2,8 +2,9 @@ use crate::field::{
     element::FieldElement,
     errors::FieldError,
     fields::fft_friendly::u64_goldilocks::U64GoldilocksPrimeField,
-    traits::{IsField, IsSubFieldOf},
+    traits::{HasDefaultTranscript, IsField, IsSubFieldOf},
 };
+use crate::traits::{AsBytes, ByteConversion};
 
 // =====================================================
 // QUADRATIC EXTENSION (Fp2)
@@ -340,3 +341,78 @@ impl IsSubFieldOf<Degree3GoldilocksExtensionField> for U64GoldilocksPrimeField {
 
 /// Field element type for the cubic extension of Goldilocks
 pub type Fp3E = FieldElement<Degree3GoldilocksExtensionField>;
+
+// =====================================================
+// TRAIT IMPLEMENTATIONS FOR PROVER/VERIFIER
+// =====================================================
+
+impl ByteConversion for FieldElement<Degree3GoldilocksExtensionField> {
+    #[cfg(feature = "alloc")]
+    fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
+        let mut byte_slice = ByteConversion::to_bytes_be(&self.value()[0]);
+        byte_slice.extend(ByteConversion::to_bytes_be(&self.value()[1]));
+        byte_slice.extend(ByteConversion::to_bytes_be(&self.value()[2]));
+        byte_slice
+    }
+
+    #[cfg(feature = "alloc")]
+    fn to_bytes_le(&self) -> alloc::vec::Vec<u8> {
+        let mut byte_slice = ByteConversion::to_bytes_le(&self.value()[0]);
+        byte_slice.extend(ByteConversion::to_bytes_le(&self.value()[1]));
+        byte_slice.extend(ByteConversion::to_bytes_le(&self.value()[2]));
+        byte_slice
+    }
+
+    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized,
+    {
+        const BYTES_PER_FIELD: usize = 8;
+        let x0 = FieldElement::from_bytes_be(&bytes[0..BYTES_PER_FIELD])?;
+        let x1 = FieldElement::from_bytes_be(&bytes[BYTES_PER_FIELD..BYTES_PER_FIELD * 2])?;
+        let x2 = FieldElement::from_bytes_be(&bytes[BYTES_PER_FIELD * 2..BYTES_PER_FIELD * 3])?;
+
+        Ok(Self::new([x0, x1, x2]))
+    }
+
+    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    where
+        Self: Sized,
+    {
+        const BYTES_PER_FIELD: usize = 8;
+        let x0 = FieldElement::from_bytes_le(&bytes[0..BYTES_PER_FIELD])?;
+        let x1 = FieldElement::from_bytes_le(&bytes[BYTES_PER_FIELD..BYTES_PER_FIELD * 2])?;
+        let x2 = FieldElement::from_bytes_le(&bytes[BYTES_PER_FIELD * 2..BYTES_PER_FIELD * 3])?;
+
+        Ok(Self::new([x0, x1, x2]))
+    }
+}
+
+impl AsBytes for FieldElement<Degree3GoldilocksExtensionField> {
+    fn as_bytes(&self) -> alloc::vec::Vec<u8> {
+        self.to_bytes_be()
+    }
+}
+
+impl HasDefaultTranscript for Degree3GoldilocksExtensionField {
+    fn get_random_field_element_from_rng(rng: &mut impl rand::Rng) -> FieldElement<Self> {
+        // Goldilocks prime: p = 2^64 - 2^32 + 1 = 0xFFFFFFFF00000001
+        const MODULUS: u64 = 0xFFFFFFFF00000001;
+
+        let mut sample = [0u8; 8];
+        let mut coeffs = [FpE::zero(), FpE::zero(), FpE::zero()];
+
+        for coeff in &mut coeffs {
+            loop {
+                rng.fill(&mut sample);
+                let int_sample = u64::from_be_bytes(sample);
+                if int_sample < MODULUS {
+                    *coeff = FpE::from(int_sample);
+                    break;
+                }
+            }
+        }
+
+        FieldElement::<Self>::new(coeffs)
+    }
+}

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -127,6 +127,11 @@ pub enum Packing {
     /// 8 halves → 4 words. **Compound: 4× Word2L.**
     /// Columns: 8, Bus elements: 4
     QuadHL,
+
+    /// 4 words → 4 bus elements. **Compound: 4× Direct.**
+    /// Columns: 4, Bus elements: 4
+    /// Used for MUL table result (128-bit as 4 words).
+    QuadWL,
 }
 
 impl Packing {
@@ -144,6 +149,7 @@ impl Packing {
             Packing::DWordHL => 4,  // 2× Word2L
             Packing::DWordBL => 8,  // 2× Word4L
             Packing::QuadHL => 8,   // 4× Word2L
+            Packing::QuadWL => 4,   // 4× Direct
         }
     }
 
@@ -161,6 +167,7 @@ impl Packing {
             Packing::DWordHL => 2,  // 2× Word2L
             Packing::DWordBL => 2,  // 2× Word4L
             Packing::QuadHL => 4,   // 4× Word2L
+            Packing::QuadWL => 4,   // 4× Direct
         }
     }
 
@@ -277,6 +284,15 @@ impl Packing {
                 result.extend(Packing::Word2L.combine(&columns[2..4]));
                 result.extend(Packing::Word2L.combine(&columns[4..6]));
                 result.extend(Packing::Word2L.combine(&columns[6..8]));
+                result
+            }
+
+            Packing::QuadWL => {
+                // 4× Direct
+                let mut result = Packing::Direct.combine(&columns[0..1]);
+                result.extend(Packing::Direct.combine(&columns[1..2]));
+                result.extend(Packing::Direct.combine(&columns[2..3]));
+                result.extend(Packing::Direct.combine(&columns[3..4]));
                 result
             }
         }

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -945,7 +945,6 @@ pub trait IsStarkProver<
     where
         FieldElement<Field>: AsBytes,
         FieldElement<FieldExtension>: AsBytes,
-        FieldExtension: IsFFTField,
         PI: Send + Sync + Clone,
     {
         info!("Started proof generation...");
@@ -1036,7 +1035,6 @@ pub trait IsStarkProver<
     where
         FieldElement<Field>: AsBytes,
         FieldElement<FieldExtension>: AsBytes,
-        FieldExtension: IsFFTField,
         PI: Send + Sync + Clone,
     {
         let air_trace_pairs = vec![(air, trace, pub_inputs)];
@@ -1056,7 +1054,6 @@ pub trait IsStarkProver<
     ) -> Result<StarkProof<Field, FieldExtension, PI>, ProvingError>
     where
         FieldElement<Field>: AsBytes,
-        FieldExtension: IsFFTField,
         FieldElement<FieldExtension>: AsBytes,
         PI: Send + Sync + Clone,
     {

--- a/crypto/stark/src/tests/bus_tests/packing_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/packing_tests.rs
@@ -259,6 +259,46 @@ fn test_quad_hl_equals_four_word2l() {
     assert_eq!(compound_result, manual_result);
 }
 
+#[test]
+fn test_quad_wl() {
+    // 4 words → 4 bus elements (no combining, 4× Direct)
+    // columns: [0x11111111, 0x22222222, 0x33333333, 0x44444444]
+    // Expected: [0x11111111, 0x22222222, 0x33333333, 0x44444444] (pass-through)
+    let words = vec![
+        FE::from(0x11111111u64),
+        FE::from(0x22222222u64),
+        FE::from(0x33333333u64),
+        FE::from(0x44444444u64),
+    ];
+    let combined = Packing::QuadWL.combine(&words);
+    assert_eq!(combined.len(), 4);
+    assert_eq!(combined[0], FE::from(0x11111111u64));
+    assert_eq!(combined[1], FE::from(0x22222222u64));
+    assert_eq!(combined[2], FE::from(0x33333333u64));
+    assert_eq!(combined[3], FE::from(0x44444444u64));
+}
+
+#[test]
+fn test_quad_wl_equals_four_direct() {
+    let words = vec![
+        FE::from(0xAABBCCDDu64),
+        FE::from(0x11223344u64),
+        FE::from(0x55667788u64),
+        FE::from(0x99AABBCCu64),
+    ];
+
+    // Compound
+    let compound_result = Packing::QuadWL.combine(&words);
+
+    // Manual: 4× Direct
+    let mut manual_result = Packing::Direct.combine(&words[0..1]);
+    manual_result.extend(Packing::Direct.combine(&words[1..2]));
+    manual_result.extend(Packing::Direct.combine(&words[2..3]));
+    manual_result.extend(Packing::Direct.combine(&words[3..4]));
+
+    assert_eq!(compound_result, manual_result);
+}
+
 // =============================================================================
 // AIR layout tests
 // =============================================================================

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -38,7 +38,7 @@ pub struct Verifier<
 
 impl<
     Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsFFTField,
+    FieldExtension: IsField + Send + Sync,
     PI,
 > IsStarkVerifier<Field, FieldExtension, PI> for Verifier<Field, FieldExtension, PI>
 {

--- a/prover/src/constraints64/mod.rs
+++ b/prover/src/constraints64/mod.rs
@@ -1,0 +1,6 @@
+//! 64-bit VM prover constraint templates.
+//!
+//! This module provides constraint templates for the 64-bit VM prover
+//! using the Goldilocks field.
+
+pub mod templates;

--- a/prover/src/constraints64/templates.rs
+++ b/prover/src/constraints64/templates.rs
@@ -202,7 +202,10 @@ impl AddLinearTerm {
         E: IsField,
     {
         match self {
-            AddLinearTerm::Column { coefficient, column } => {
+            AddLinearTerm::Column {
+                coefficient,
+                column,
+            } => {
                 let col_val = step.get_main_evaluation_element(0, *column);
                 col_val * i64_to_fe::<F>(*coefficient)
             }
@@ -220,7 +223,10 @@ where
     if terms.is_empty() {
         FieldElement::zero()
     } else {
-        terms.iter().map(|t| t.eval(step)).fold(FieldElement::zero(), |acc, x| acc + x)
+        terms
+            .iter()
+            .map(|t| t.eval(step))
+            .fold(FieldElement::zero(), |acc, x| acc + x)
     }
 }
 
@@ -246,9 +252,9 @@ impl AddOperand {
         E: IsField,
     {
         match self {
-            AddOperand::DWordWL { start_column } => {
-                step.get_main_evaluation_element(0, *start_column + 1).clone()
-            }
+            AddOperand::DWordWL { start_column } => step
+                .get_main_evaluation_element(0, *start_column + 1)
+                .clone(),
             AddOperand::Linear { hi, .. } => eval_terms(hi, step),
         }
     }

--- a/prover/src/constraints64/templates.rs
+++ b/prover/src/constraints64/templates.rs
@@ -31,19 +31,14 @@ pub const SHIFT_32: u64 = 1u64 << 32;
 // IS_BIT Template
 // =========================================================================
 
-/// Enforces that a value is binary (0 or 1) when a condition is active.
+/// Enforces that a value is binary (0 or 1).
 ///
-/// Constraint: `cond * X * (1-X) = 0`
-///
-/// This constraint evaluates to 0 in three cases:
-/// - cond = 0 (constraint inactive)
-/// - X = 0 (valid binary value)
-/// - X = 1 (valid binary value)
-///
-/// Degree: 3 (cubic)
+/// Two modes:
+/// - Conditional: `cond * X * (1-X) = 0` (degree 3)
+/// - Unconditional: `X * (1-X) = 0` (degree 2)
 pub struct IsBitConstraint {
-    /// Column index for the condition (cond)
-    cond_col: usize,
+    /// Column index for the condition (None = unconditional)
+    cond_col: Option<usize>,
     /// Column index for the value to check (X)
     value_col: usize,
     /// Unique constraint identifier
@@ -51,29 +46,23 @@ pub struct IsBitConstraint {
 }
 
 impl IsBitConstraint {
-    /// Creates a new IS_BIT constraint.
+    /// Creates a conditional IS_BIT constraint.
     ///
-    /// # Arguments
-    /// * `cond_col` - Column index containing the condition flag
-    /// * `value_col` - Column index containing the value to check
-    /// * `constraint_idx` - Unique constraint identifier
+    /// Constraint: `cond * X * (1-X) = 0`
     pub fn new(cond_col: usize, value_col: usize, constraint_idx: usize) -> Self {
         Self {
-            cond_col,
+            cond_col: Some(cond_col),
             value_col,
             constraint_idx,
         }
     }
 
-    /// Creates an unconditional IS_BIT constraint (always active).
+    /// Creates an unconditional IS_BIT constraint.
     ///
-    /// Uses the value column itself as condition (since 0 or 1 as condition
-    /// still satisfies the constraint when the value is correct).
-    ///
-    /// For truly unconditional constraints, use a column that's always 1.
-    pub fn unconditional(value_col: usize, always_one_col: usize, constraint_idx: usize) -> Self {
+    /// Constraint: `X * (1-X) = 0`
+    pub fn unconditional(value_col: usize, constraint_idx: usize) -> Self {
         Self {
-            cond_col: always_one_col,
+            cond_col: None,
             value_col,
             constraint_idx,
         }
@@ -84,18 +73,29 @@ impl IsBitConstraint {
         F: IsSubFieldOf<E>,
         E: IsField,
     {
-        let cond = step.get_main_evaluation_element(0, self.cond_col).clone();
         let x = step.get_main_evaluation_element(0, self.value_col).clone();
         let one = FieldElement::<F>::one();
 
-        // cond * X * (1 - X)
-        &cond * &x * (one - x)
+        match self.cond_col {
+            Some(cond_col) => {
+                let cond = step.get_main_evaluation_element(0, cond_col).clone();
+                // cond * X * (1 - X)
+                &cond * &x * (one - x)
+            }
+            None => {
+                // X * (1 - X)
+                &x * (one - &x)
+            }
+        }
     }
 }
 
 impl TransitionConstraint<GoldilocksField, GoldilocksExtension> for IsBitConstraint {
     fn degree(&self) -> usize {
-        3 // cubic: cond * X * (1-X)
+        match self.cond_col {
+            Some(_) => 3, // cubic: cond * X * (1-X)
+            None => 2,    // quadratic: X * (1-X)
+        }
     }
 
     fn constraint_idx(&self) -> usize {
@@ -137,6 +137,235 @@ impl TransitionConstraint<GoldilocksField, GoldilocksExtension> for IsBitConstra
 // ADD Template (Embedded Carry Approach)
 // =========================================================================
 
+// -------------------------------------------------------------------------
+// AddOperand - Flexible operand representation for ADD constraints
+// -------------------------------------------------------------------------
+
+/// A term in a linear combination: coeff * column OR constant.
+///
+/// Uses i64 for coefficients to support negative values (e.g., `4 - 2*c`).
+/// Converted to FieldElement in eval().
+#[derive(Debug, Clone)]
+pub enum AddLinearTerm {
+    /// coefficient * column_value
+    Column {
+        /// Coefficient (can be negative, e.g., -2 for subtraction)
+        coefficient: i64,
+        /// Column index to read from
+        column: usize,
+    },
+    /// A constant value
+    Constant(i64),
+}
+
+/// An ADD operand representing a 64-bit value as [lo, hi] words.
+///
+/// Supports various representations:
+/// - DWordWL: 2 consecutive columns (most common case)
+/// - Linear: Arbitrary linear combinations for lo and hi limbs
+///
+/// The Linear variant handles:
+/// - Constants: `AddOperand::constant(42)` → lo=42, hi=0
+/// - Word → DWordWL: `AddOperand::from_word(col)` → lo=col, hi=0
+/// - DWordHL → DWordWL: `AddOperand::from_dword_hl(col)` → repack 4 halves
+/// - DWordBL → DWordWL: `AddOperand::from_dword_bl(col)` → repack 8 bytes
+/// - Expressions: `AddOperand::linear(...)` → arbitrary linear combinations
+#[derive(Debug, Clone)]
+pub enum AddOperand {
+    /// Two consecutive columns (DWordWL): evaluates to [col, col+1]
+    DWordWL { start_column: usize },
+
+    /// Linear combination for lo and hi limbs.
+    /// Handles: constants, single columns, expressions, and virtual columns.
+    Linear {
+        /// Terms for the low 32-bit word
+        lo: Vec<AddLinearTerm>,
+        /// Terms for the high 32-bit word (empty = zero)
+        hi: Vec<AddLinearTerm>,
+    },
+}
+
+/// Convert i64 to FieldElement (handles negative values via field negation).
+fn i64_to_fe<F: IsField>(val: i64) -> FieldElement<F> {
+    if val >= 0 {
+        FieldElement::from(val as u64)
+    } else {
+        -FieldElement::from((-val) as u64)
+    }
+}
+
+impl AddLinearTerm {
+    /// Evaluate this term using values from the trace.
+    fn eval<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        match self {
+            AddLinearTerm::Column { coefficient, column } => {
+                let col_val = step.get_main_evaluation_element(0, *column);
+                col_val * i64_to_fe::<F>(*coefficient)
+            }
+            AddLinearTerm::Constant(value) => i64_to_fe(*value),
+        }
+    }
+}
+
+/// Evaluate a slice of terms as a sum.
+fn eval_terms<F, E>(terms: &[AddLinearTerm], step: &TableView<F, E>) -> FieldElement<F>
+where
+    F: IsSubFieldOf<E>,
+    E: IsField,
+{
+    if terms.is_empty() {
+        FieldElement::zero()
+    } else {
+        terms.iter().map(|t| t.eval(step)).fold(FieldElement::zero(), |acc, x| acc + x)
+    }
+}
+
+impl AddOperand {
+    /// Get the low word value from the trace.
+    pub fn eval_lo<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        match self {
+            AddOperand::DWordWL { start_column } => {
+                step.get_main_evaluation_element(0, *start_column).clone()
+            }
+            AddOperand::Linear { lo, .. } => eval_terms(lo, step),
+        }
+    }
+
+    /// Get the high word value from the trace.
+    pub fn eval_hi<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        match self {
+            AddOperand::DWordWL { start_column } => {
+                step.get_main_evaluation_element(0, *start_column + 1).clone()
+            }
+            AddOperand::Linear { hi, .. } => eval_terms(hi, step),
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Convenience constructors for common cast types
+    // -------------------------------------------------------------------------
+
+    /// DWordWL: 2 consecutive columns [col, col+1].
+    pub fn dword(start_column: usize) -> Self {
+        AddOperand::DWordWL { start_column }
+    }
+
+    /// Constant: single value, zero-extended to 64 bits.
+    /// hi = 0 (since constants fit in 32 bits for VM use cases).
+    pub fn constant(value: i64) -> Self {
+        AddOperand::Linear {
+            lo: vec![AddLinearTerm::Constant(value)],
+            hi: vec![],
+        }
+    }
+
+    /// Word → DWordWL: single column, zero-extended.
+    /// hi = 0.
+    pub fn from_word(col: usize) -> Self {
+        AddOperand::Linear {
+            lo: vec![AddLinearTerm::Column {
+                coefficient: 1,
+                column: col,
+            }],
+            hi: vec![],
+        }
+    }
+
+    /// DWordHL → DWordWL: repack 4 half-words into 2 words.
+    /// lo = h[0] + 2^16 * h[1]
+    /// hi = h[2] + 2^16 * h[3]
+    pub fn from_dword_hl(start_column: usize) -> Self {
+        AddOperand::Linear {
+            lo: vec![
+                AddLinearTerm::Column {
+                    coefficient: 1,
+                    column: start_column,
+                },
+                AddLinearTerm::Column {
+                    coefficient: 1 << 16,
+                    column: start_column + 1,
+                },
+            ],
+            hi: vec![
+                AddLinearTerm::Column {
+                    coefficient: 1,
+                    column: start_column + 2,
+                },
+                AddLinearTerm::Column {
+                    coefficient: 1 << 16,
+                    column: start_column + 3,
+                },
+            ],
+        }
+    }
+
+    /// DWordBL → DWordWL: repack 8 bytes into 2 words.
+    /// lo = b[0] + 2^8*b[1] + 2^16*b[2] + 2^24*b[3]
+    /// hi = b[4] + 2^8*b[5] + 2^16*b[6] + 2^24*b[7]
+    pub fn from_dword_bl(start_column: usize) -> Self {
+        AddOperand::Linear {
+            lo: vec![
+                AddLinearTerm::Column {
+                    coefficient: 1,
+                    column: start_column,
+                },
+                AddLinearTerm::Column {
+                    coefficient: 1 << 8,
+                    column: start_column + 1,
+                },
+                AddLinearTerm::Column {
+                    coefficient: 1 << 16,
+                    column: start_column + 2,
+                },
+                AddLinearTerm::Column {
+                    coefficient: 1 << 24,
+                    column: start_column + 3,
+                },
+            ],
+            hi: vec![
+                AddLinearTerm::Column {
+                    coefficient: 1,
+                    column: start_column + 4,
+                },
+                AddLinearTerm::Column {
+                    coefficient: 1 << 8,
+                    column: start_column + 5,
+                },
+                AddLinearTerm::Column {
+                    coefficient: 1 << 16,
+                    column: start_column + 6,
+                },
+                AddLinearTerm::Column {
+                    coefficient: 1 << 24,
+                    column: start_column + 7,
+                },
+            ],
+        }
+    }
+
+    /// Creates a Linear operand from explicit lo/hi term lists.
+    /// Use this for complex expressions like `4 - 2*c` or virtual columns.
+    pub fn linear(lo: Vec<AddLinearTerm>, hi: Vec<AddLinearTerm>) -> Self {
+        AddOperand::Linear { lo, hi }
+    }
+}
+
+// -------------------------------------------------------------------------
+// AddConstraint
+// -------------------------------------------------------------------------
+
 /// 64-bit addition constraint with embedded carry.
 ///
 /// Enforces: `lhs + rhs = sum (mod 2^64)`
@@ -159,12 +388,12 @@ impl TransitionConstraint<GoldilocksField, GoldilocksExtension> for IsBitConstra
 pub struct AddConstraint {
     /// Column index for condition flag
     cond_col: usize,
-    /// Starting column index for lhs (2 consecutive columns)
-    lhs_start_col: usize,
-    /// Starting column index for rhs (2 consecutive columns)
-    rhs_start_col: usize,
-    /// Starting column index for sum (2 consecutive columns)
-    sum_start_col: usize,
+    /// Left-hand side operand (flexible representation)
+    lhs: AddOperand,
+    /// Right-hand side operand (flexible representation)
+    rhs: AddOperand,
+    /// Sum/output operand (flexible representation)
+    sum: AddOperand,
     /// Which carry constraint this is (0 or 1)
     carry_idx: usize,
     /// Unique constraint identifier
@@ -175,27 +404,34 @@ impl AddConstraint {
     /// Creates ADD constraints for both carries.
     ///
     /// Returns two constraints: one for carry_0 and one for carry_1.
+    ///
+    /// # Arguments
+    /// * `cond_col` - Column index for the condition flag
+    /// * `lhs` - Left-hand side operand (flexible representation)
+    /// * `rhs` - Right-hand side operand (flexible representation)
+    /// * `sum` - Sum/output operand (flexible representation)
+    /// * `constraint_idx_start` - Starting constraint index (uses 2 consecutive indices)
     pub fn new_pair(
         cond_col: usize,
-        lhs_start_col: usize,
-        rhs_start_col: usize,
-        sum_start_col: usize,
+        lhs: AddOperand,
+        rhs: AddOperand,
+        sum: AddOperand,
         constraint_idx_start: usize,
     ) -> (Self, Self) {
         let carry_0 = Self {
             cond_col,
-            lhs_start_col,
-            rhs_start_col,
-            sum_start_col,
+            lhs: lhs.clone(),
+            rhs: rhs.clone(),
+            sum: sum.clone(),
             carry_idx: 0,
             constraint_idx: constraint_idx_start,
         };
 
         let carry_1 = Self {
             cond_col,
-            lhs_start_col,
-            rhs_start_col,
-            sum_start_col,
+            lhs,
+            rhs,
+            sum,
             carry_idx: 1,
             constraint_idx: constraint_idx_start + 1,
         };
@@ -209,9 +445,9 @@ impl AddConstraint {
         F: IsSubFieldOf<E>,
         E: IsField,
     {
-        let lhs_lo = step.get_main_evaluation_element(0, self.lhs_start_col);
-        let rhs_lo = step.get_main_evaluation_element(0, self.rhs_start_col);
-        let sum_lo = step.get_main_evaluation_element(0, self.sum_start_col);
+        let lhs_lo = self.lhs.eval_lo(step);
+        let rhs_lo = self.rhs.eval_lo(step);
+        let sum_lo = self.sum.eval_lo(step);
 
         // carry_0 = (lhs_lo + rhs_lo - sum_lo) * 2^(-32)
         let inv_2_32: FieldElement<F> = FieldElement::from(SHIFT_32).inv().unwrap();
@@ -224,9 +460,9 @@ impl AddConstraint {
         F: IsSubFieldOf<E>,
         E: IsField,
     {
-        let lhs_hi = step.get_main_evaluation_element(0, self.lhs_start_col + 1);
-        let rhs_hi = step.get_main_evaluation_element(0, self.rhs_start_col + 1);
-        let sum_hi = step.get_main_evaluation_element(0, self.sum_start_col + 1);
+        let lhs_hi = self.lhs.eval_hi(step);
+        let rhs_hi = self.rhs.eval_hi(step);
+        let sum_hi = self.sum.eval_hi(step);
         let carry_0 = self.compute_carry_0(step);
 
         // carry_1 = (lhs_hi + rhs_hi + carry_0 - sum_hi) * 2^(-32)
@@ -300,24 +536,22 @@ impl TransitionConstraint<GoldilocksField, GoldilocksExtension> for AddConstrain
 // Helper Functions
 // =========================================================================
 
-/// Creates multiple IS_BIT constraints for consecutive columns.
+/// Creates multiple unconditional IS_BIT constraints for the given columns.
 ///
 /// # Arguments
-/// * `cond_col` - Column index for the condition flag
 /// * `value_cols` - Slice of column indices to constrain
 /// * `constraint_idx_start` - Starting index for constraint numbering
 ///
 /// # Returns
 /// Vector of IS_BIT constraints and the next available constraint index.
 pub fn new_is_bit_constraints(
-    cond_col: usize,
     value_cols: &[usize],
     constraint_idx_start: usize,
 ) -> (Vec<IsBitConstraint>, usize) {
     let constraints = value_cols
         .iter()
         .enumerate()
-        .map(|(i, &col)| IsBitConstraint::new(cond_col, col, constraint_idx_start + i))
+        .map(|(i, &col)| IsBitConstraint::unconditional(col, constraint_idx_start + i))
         .collect();
 
     (constraints, constraint_idx_start + value_cols.len())

--- a/prover/src/constraints64/templates.rs
+++ b/prover/src/constraints64/templates.rs
@@ -1,0 +1,324 @@
+//! Constraint templates for the 64-bit VM prover.
+//!
+//! This module provides reusable constraint templates using the Goldilocks field.
+//!
+//! ## Templates
+//!
+//! - **IS_BIT**: Enforces that a value is binary (0 or 1)
+//!   - Constraint: `cond * X * (1-X) = 0`
+//!
+//! - **ADD**: 64-bit addition with embedded virtual carry columns
+//!   - lhs, rhs, sum: DWordWL (2 × 32-bit words)
+//!   - Embeds carry constraints inline
+
+use math::field::element::FieldElement;
+use math::field::traits::{IsField, IsSubFieldOf};
+use stark::{
+    constraints::transition::TransitionConstraint, table::TableView,
+    traits::TransitionEvaluationContext,
+};
+
+use crate::tables64::types::{GoldilocksExtension, GoldilocksField};
+
+// =========================================================================
+// Constants
+// =========================================================================
+
+/// 2^32 for word combining and carry extraction
+pub const SHIFT_32: u64 = 1u64 << 32;
+
+// =========================================================================
+// IS_BIT Template
+// =========================================================================
+
+/// Enforces that a value is binary (0 or 1) when a condition is active.
+///
+/// Constraint: `cond * X * (1-X) = 0`
+///
+/// This constraint evaluates to 0 in three cases:
+/// - cond = 0 (constraint inactive)
+/// - X = 0 (valid binary value)
+/// - X = 1 (valid binary value)
+///
+/// Degree: 3 (cubic)
+pub struct IsBitConstraint {
+    /// Column index for the condition (cond)
+    cond_col: usize,
+    /// Column index for the value to check (X)
+    value_col: usize,
+    /// Unique constraint identifier
+    constraint_idx: usize,
+}
+
+impl IsBitConstraint {
+    /// Creates a new IS_BIT constraint.
+    ///
+    /// # Arguments
+    /// * `cond_col` - Column index containing the condition flag
+    /// * `value_col` - Column index containing the value to check
+    /// * `constraint_idx` - Unique constraint identifier
+    pub fn new(cond_col: usize, value_col: usize, constraint_idx: usize) -> Self {
+        Self {
+            cond_col,
+            value_col,
+            constraint_idx,
+        }
+    }
+
+    /// Creates an unconditional IS_BIT constraint (always active).
+    ///
+    /// Uses the value column itself as condition (since 0 or 1 as condition
+    /// still satisfies the constraint when the value is correct).
+    ///
+    /// For truly unconditional constraints, use a column that's always 1.
+    pub fn unconditional(value_col: usize, always_one_col: usize, constraint_idx: usize) -> Self {
+        Self {
+            cond_col: always_one_col,
+            value_col,
+            constraint_idx,
+        }
+    }
+
+    fn compute<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        let cond = step.get_main_evaluation_element(0, self.cond_col).clone();
+        let x = step.get_main_evaluation_element(0, self.value_col).clone();
+        let one = FieldElement::<F>::one();
+
+        // cond * X * (1 - X)
+        &cond * &x * (one - x)
+    }
+}
+
+impl TransitionConstraint<GoldilocksField, GoldilocksExtension> for IsBitConstraint {
+    fn degree(&self) -> usize {
+        3 // cubic: cond * X * (1-X)
+    }
+
+    fn constraint_idx(&self) -> usize {
+        self.constraint_idx
+    }
+
+    fn end_exemptions(&self) -> usize {
+        0
+    }
+
+    fn evaluate(
+        &self,
+        evaluation_context: &TransitionEvaluationContext<GoldilocksField, GoldilocksExtension>,
+        transition_evaluations: &mut [FieldElement<GoldilocksExtension>],
+    ) {
+        match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values: _,
+                rap_challenges: _,
+            } => {
+                let constraint_value = self.compute(frame.get_evaluation_step(0));
+                transition_evaluations[self.constraint_idx] = constraint_value.to_extension();
+            }
+
+            TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values: _,
+                rap_challenges: _,
+            } => {
+                let constraint_value = self.compute(frame.get_evaluation_step(0));
+                transition_evaluations[self.constraint_idx] = constraint_value;
+            }
+        }
+    }
+}
+
+// =========================================================================
+// ADD Template (Embedded Carry Approach)
+// =========================================================================
+
+/// 64-bit addition constraint with embedded carry.
+///
+/// Enforces: `lhs + rhs = sum (mod 2^64)`
+///
+/// Uses DWordWL representation (2 × 32-bit words):
+/// - lhs = [lhs_lo, lhs_hi]
+/// - rhs = [rhs_lo, rhs_hi]
+/// - sum = [sum_lo, sum_hi]
+///
+/// Embeds virtual carry columns inline:
+/// - carry_0 = (lhs_lo + rhs_lo - sum_lo) / 2^32
+/// - carry_1 = (lhs_hi + rhs_hi + carry_0 - sum_hi) / 2^32
+///
+/// Constraints:
+/// - carry_0 is a bit: cond * carry_0 * (1 - carry_0) = 0
+/// - carry_1 is a bit: cond * carry_1 * (1 - carry_1) = 0
+///
+/// Assumptions (must be verified via bus lookups):
+/// - lhs_lo, lhs_hi, rhs_lo, rhs_hi, sum_lo, sum_hi are all valid 32-bit words
+pub struct AddConstraint {
+    /// Column index for condition flag
+    cond_col: usize,
+    /// Starting column index for lhs (2 consecutive columns)
+    lhs_start_col: usize,
+    /// Starting column index for rhs (2 consecutive columns)
+    rhs_start_col: usize,
+    /// Starting column index for sum (2 consecutive columns)
+    sum_start_col: usize,
+    /// Which carry constraint this is (0 or 1)
+    carry_idx: usize,
+    /// Unique constraint identifier
+    constraint_idx: usize,
+}
+
+impl AddConstraint {
+    /// Creates ADD constraints for both carries.
+    ///
+    /// Returns two constraints: one for carry_0 and one for carry_1.
+    pub fn new_pair(
+        cond_col: usize,
+        lhs_start_col: usize,
+        rhs_start_col: usize,
+        sum_start_col: usize,
+        constraint_idx_start: usize,
+    ) -> (Self, Self) {
+        let carry_0 = Self {
+            cond_col,
+            lhs_start_col,
+            rhs_start_col,
+            sum_start_col,
+            carry_idx: 0,
+            constraint_idx: constraint_idx_start,
+        };
+
+        let carry_1 = Self {
+            cond_col,
+            lhs_start_col,
+            rhs_start_col,
+            sum_start_col,
+            carry_idx: 1,
+            constraint_idx: constraint_idx_start + 1,
+        };
+
+        (carry_0, carry_1)
+    }
+
+    /// Compute carry_0 inline from trace values.
+    fn compute_carry_0<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        let lhs_lo = step.get_main_evaluation_element(0, self.lhs_start_col);
+        let rhs_lo = step.get_main_evaluation_element(0, self.rhs_start_col);
+        let sum_lo = step.get_main_evaluation_element(0, self.sum_start_col);
+
+        // carry_0 = (lhs_lo + rhs_lo - sum_lo) * 2^(-32)
+        let inv_2_32: FieldElement<F> = FieldElement::from(SHIFT_32).inv().unwrap();
+        (lhs_lo + rhs_lo - sum_lo) * inv_2_32
+    }
+
+    /// Compute carry_1 inline from trace values.
+    fn compute_carry_1<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        let lhs_hi = step.get_main_evaluation_element(0, self.lhs_start_col + 1);
+        let rhs_hi = step.get_main_evaluation_element(0, self.rhs_start_col + 1);
+        let sum_hi = step.get_main_evaluation_element(0, self.sum_start_col + 1);
+        let carry_0 = self.compute_carry_0(step);
+
+        // carry_1 = (lhs_hi + rhs_hi + carry_0 - sum_hi) * 2^(-32)
+        let inv_2_32: FieldElement<F> = FieldElement::from(SHIFT_32).inv().unwrap();
+        (lhs_hi + rhs_hi + carry_0 - sum_hi) * inv_2_32
+    }
+
+    fn compute<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        let cond = step.get_main_evaluation_element(0, self.cond_col);
+        let one = FieldElement::<F>::one();
+
+        let carry = match self.carry_idx {
+            0 => self.compute_carry_0(step),
+            1 => self.compute_carry_1(step),
+            _ => panic!("Invalid carry index"),
+        };
+
+        // cond * carry * (1 - carry)
+        cond * &carry * (one - carry)
+    }
+}
+
+impl TransitionConstraint<GoldilocksField, GoldilocksExtension> for AddConstraint {
+    fn degree(&self) -> usize {
+        // The constraint is cond * carry * (1 - carry)
+        // where carry involves division by 2^32 (degree 1 in trace elements)
+        // So total degree: 1 (cond) * 1 (carry) * 1 (1-carry) = 3
+        3
+    }
+
+    fn constraint_idx(&self) -> usize {
+        self.constraint_idx
+    }
+
+    fn end_exemptions(&self) -> usize {
+        0
+    }
+
+    fn evaluate(
+        &self,
+        evaluation_context: &TransitionEvaluationContext<GoldilocksField, GoldilocksExtension>,
+        transition_evaluations: &mut [FieldElement<GoldilocksExtension>],
+    ) {
+        match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values: _,
+                rap_challenges: _,
+            } => {
+                let constraint_value = self.compute(frame.get_evaluation_step(0));
+                transition_evaluations[self.constraint_idx] = constraint_value.to_extension();
+            }
+
+            TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values: _,
+                rap_challenges: _,
+            } => {
+                let constraint_value = self.compute(frame.get_evaluation_step(0));
+                transition_evaluations[self.constraint_idx] = constraint_value;
+            }
+        }
+    }
+}
+
+// =========================================================================
+// Helper Functions
+// =========================================================================
+
+/// Creates multiple IS_BIT constraints for consecutive columns.
+///
+/// # Arguments
+/// * `cond_col` - Column index for the condition flag
+/// * `value_cols` - Slice of column indices to constrain
+/// * `constraint_idx_start` - Starting index for constraint numbering
+///
+/// # Returns
+/// Vector of IS_BIT constraints and the next available constraint index.
+pub fn new_is_bit_constraints(
+    cond_col: usize,
+    value_cols: &[usize],
+    constraint_idx_start: usize,
+) -> (Vec<IsBitConstraint>, usize) {
+    let constraints = value_cols
+        .iter()
+        .enumerate()
+        .map(|(i, &col)| IsBitConstraint::new(cond_col, col, constraint_idx_start + i))
+        .collect();
+
+    (constraints, constraint_idx_start + value_cols.len())
+}

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod constraints;
+pub mod constraints64;
 pub mod tables;
+pub mod tables64;
 pub mod tests;
 pub mod utils;

--- a/prover/src/tables64/bitwise.rs
+++ b/prover/src/tables64/bitwise.rs
@@ -1,0 +1,435 @@
+//! BITWISE precomputed lookup table.
+//!
+//! This table provides 11 different lookup types used by other tables:
+//!
+//! ## Range Checks
+//! - `IS_BYTE[X]` - X is a valid byte [0, 256)
+//! - `IS_HALF[X]` - X is a valid halfword [0, 2^16)
+//! - `IS_B20[X]` - X is a valid 20-bit value [0, 2^20)
+//!
+//! ## Bitwise Operations
+//! - `AND_BYTE[X, Y]` -> X & Y
+//! - `OR_BYTE[X, Y]` -> X | Y
+//! - `XOR_BYTE[X, Y]` -> X ^ Y
+//! - `MSB8[X]` -> most significant bit of byte
+//! - `MSB16[X]` -> most significant bit of halfword
+//! - `ZERO[X]` -> whether X is zero
+//!
+//! ## Shift Helpers
+//! - `HWSL[X, Z]` -> (X << Z) mod 2^16
+//! - `HWSLC[X, Z]` -> X >> (16 - Z)
+//!
+//! ## Table Structure
+//!
+//! The table has 2^20 rows (256 * 256 * 16) with precomputed values.
+//! Each row is indexed by (X: Byte, Y: Byte, Z: B4).
+//!
+//! All lookups are provided as receivers with negative multiplicity,
+//! meaning other tables send to this table.
+
+use stark::lookup::{BusInteraction, BusValue, Multiplicity, Packing};
+use stark::trace::TraceTable;
+
+use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
+
+// =========================================================================
+// Column indices for BITWISE table
+// =========================================================================
+
+/// Input columns (precomputed)
+pub mod cols {
+    /// X: Byte input (0-255)
+    pub const X: usize = 0;
+    /// Y: Byte input (0-255)
+    pub const Y: usize = 1;
+    /// Z: 4-bit input (0-15) for shift amount
+    pub const Z: usize = 2;
+
+    /// AND result: X & Y
+    pub const AND: usize = 3;
+    /// OR result: X | Y
+    pub const OR: usize = 4;
+    /// XOR result: X ^ Y
+    pub const XOR: usize = 5;
+    /// MSB of byte X: (X >> 7) & 1
+    pub const MSB8: usize = 6;
+    /// MSB of halfword (X + 256*Y): ((X + 256*Y) >> 15) & 1
+    pub const MSB16: usize = 7;
+    /// Zero check: (X == 0 && Y == 0) ? 1 : 0
+    pub const ZERO: usize = 8;
+    /// Shift left result: ((X + 256*Y) << Z) & 0xFFFF
+    pub const SLL: usize = 9;
+    /// Shift left carry: (X + 256*Y) >> (16 - Z)
+    pub const SLLC: usize = 10;
+
+    // Multiplicity columns for each lookup type
+    /// Multiplicity for AND_BYTE lookups
+    pub const MU_AND: usize = 11;
+    /// Multiplicity for OR_BYTE lookups
+    pub const MU_OR: usize = 12;
+    /// Multiplicity for XOR_BYTE lookups
+    pub const MU_XOR: usize = 13;
+    /// Multiplicity for MSB8 lookups
+    pub const MU_MSB8: usize = 14;
+    /// Multiplicity for MSB16 lookups
+    pub const MU_MSB16: usize = 15;
+    /// Multiplicity for ZERO lookups
+    pub const MU_ZERO: usize = 16;
+    /// Multiplicity for IS_BYTE lookups
+    pub const MU_IS_BYTE: usize = 17;
+    /// Multiplicity for IS_HALF lookups
+    pub const MU_IS_HALF: usize = 18;
+    /// Multiplicity for IS_B20 lookups
+    pub const MU_IS_B20: usize = 19;
+    /// Multiplicity for HWSL lookups
+    pub const MU_HWSL: usize = 20;
+    /// Multiplicity for HWSLC lookups
+    pub const MU_HWSLC: usize = 21;
+
+    /// Total number of columns
+    pub const NUM_COLUMNS: usize = 22;
+}
+
+/// Number of rows in the BITWISE table: 256 * 256 * 16 = 2^20
+pub const NUM_ROWS: usize = 256 * 256 * 16;
+
+// =========================================================================
+// Trace generation
+// =========================================================================
+
+/// Generates the precomputed BITWISE trace table.
+///
+/// This creates a table with 2^20 rows, one for each combination of:
+/// - X: 0..256 (byte)
+/// - Y: 0..256 (byte)
+/// - Z: 0..16 (4-bit shift amount)
+///
+/// All output columns are precomputed. Multiplicity columns are initialized
+/// to zero and will be updated when other tables send lookups.
+pub fn generate_bitwise_trace() -> TraceTable<GoldilocksField, GoldilocksExtension> {
+    let mut data = vec![FE::zero(); NUM_ROWS * cols::NUM_COLUMNS];
+
+    for x in 0u32..256 {
+        for y in 0u32..256 {
+            for z in 0u32..16 {
+                let row_idx = (x as usize) + (y as usize) * 256 + (z as usize) * 256 * 256;
+                let base = row_idx * cols::NUM_COLUMNS;
+
+                // Input columns
+                data[base + cols::X] = FE::from(x as u64);
+                data[base + cols::Y] = FE::from(y as u64);
+                data[base + cols::Z] = FE::from(z as u64);
+
+                // Bitwise operation results
+                data[base + cols::AND] = FE::from((x & y) as u64);
+                data[base + cols::OR] = FE::from((x | y) as u64);
+                data[base + cols::XOR] = FE::from((x ^ y) as u64);
+
+                // MSB extractions
+                let msb8 = (x >> 7) & 1;
+                let halfword = x + y * 256;
+                let msb16 = (halfword >> 15) & 1;
+                data[base + cols::MSB8] = FE::from(msb8 as u64);
+                data[base + cols::MSB16] = FE::from(msb16 as u64);
+
+                // Zero check (both X and Y must be zero)
+                let is_zero = if x == 0 && y == 0 { 1u64 } else { 0u64 };
+                data[base + cols::ZERO] = FE::from(is_zero);
+
+                // Shift operations on halfword
+                let sll = if z == 0 {
+                    halfword
+                } else {
+                    (halfword << z) & 0xFFFF
+                };
+                let sllc = if z == 0 { 0 } else { halfword >> (16 - z) };
+                data[base + cols::SLL] = FE::from(sll as u64);
+                data[base + cols::SLLC] = FE::from(sllc as u64);
+
+                // Multiplicity columns start at zero
+                // They will be updated by update_multiplicities()
+            }
+        }
+    }
+
+    TraceTable::new_main(data, cols::NUM_COLUMNS, 1)
+}
+
+/// Computes the row index for a given (X, Y, Z) tuple.
+#[inline]
+pub fn row_index(x: u8, y: u8, z: u8) -> usize {
+    debug_assert!(z < 16, "Z must be in range [0, 16)");
+    (x as usize) + (y as usize) * 256 + (z as usize) * 256 * 256
+}
+
+/// Updates multiplicity columns based on lookups from other tables.
+///
+/// This function should be called after all other tables have recorded their lookups.
+///
+/// # Arguments
+/// * `trace` - The BITWISE trace table to update
+/// * `lookups` - Vector of (lookup_type, x, y, z) tuples
+pub fn update_multiplicities(
+    trace: &mut TraceTable<GoldilocksField, GoldilocksExtension>,
+    lookups: &[(BitwiseLookup, u8, u8, u8)],
+) {
+    for (lookup_type, x, y, z) in lookups {
+        let row = row_index(*x, *y, *z);
+        let mu_col = match lookup_type {
+            BitwiseLookup::AndByte => cols::MU_AND,
+            BitwiseLookup::OrByte => cols::MU_OR,
+            BitwiseLookup::XorByte => cols::MU_XOR,
+            BitwiseLookup::Msb8 => cols::MU_MSB8,
+            BitwiseLookup::Msb16 => cols::MU_MSB16,
+            BitwiseLookup::Zero => cols::MU_ZERO,
+            BitwiseLookup::IsByte => cols::MU_IS_BYTE,
+            BitwiseLookup::IsHalf => cols::MU_IS_HALF,
+            BitwiseLookup::IsB20 => cols::MU_IS_B20,
+            BitwiseLookup::Hwsl => cols::MU_HWSL,
+            BitwiseLookup::Hwslc => cols::MU_HWSLC,
+        };
+
+        // Increment multiplicity
+        let current = trace.main_table.get_row(row)[mu_col];
+        trace.set_main(row, mu_col, current + FE::one());
+    }
+}
+
+/// Types of lookups the BITWISE table provides.
+#[derive(Debug, Clone, Copy)]
+pub enum BitwiseLookup {
+    AndByte,
+    OrByte,
+    XorByte,
+    Msb8,
+    Msb16,
+    Zero,
+    IsByte,
+    IsHalf,
+    IsB20,
+    Hwsl,
+    Hwslc,
+}
+
+// =========================================================================
+// Bus interactions
+// =========================================================================
+
+/// Creates all bus interactions for the BITWISE table.
+///
+/// The BITWISE table is a **receiver** for all lookups (negative multiplicity
+/// in the spec corresponds to receiving lookups from other tables).
+pub fn bus_interactions() -> Vec<BusInteraction> {
+    vec![
+        // AND_BYTE[X, Y] -> AND
+        BusInteraction::receiver(
+            BusId::AndByte,
+            Multiplicity::Column(cols::MU_AND),
+            vec![
+                BusValue::Packed {
+                    start_column: cols::X,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::Y,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::AND,
+                    packing: Packing::Direct,
+                },
+            ],
+        ),
+        // OR_BYTE[X, Y] -> OR
+        BusInteraction::receiver(
+            BusId::OrByte,
+            Multiplicity::Column(cols::MU_OR),
+            vec![
+                BusValue::Packed {
+                    start_column: cols::X,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::Y,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::OR,
+                    packing: Packing::Direct,
+                },
+            ],
+        ),
+        // XOR_BYTE[X, Y] -> XOR
+        BusInteraction::receiver(
+            BusId::XorByte,
+            Multiplicity::Column(cols::MU_XOR),
+            vec![
+                BusValue::Packed {
+                    start_column: cols::X,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::Y,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::XOR,
+                    packing: Packing::Direct,
+                },
+            ],
+        ),
+        // MSB8[X] -> MSB8
+        BusInteraction::receiver(
+            BusId::Msb8,
+            Multiplicity::Column(cols::MU_MSB8),
+            vec![
+                BusValue::Packed {
+                    start_column: cols::X,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::MSB8,
+                    packing: Packing::Direct,
+                },
+            ],
+        ),
+        // MSB16[X + 256*Y] -> MSB16
+        // Input is packed as Word2L (X + 2^8 * Y would need custom, but spec says X + 256*Y)
+        // Since X and Y are bytes, we use a linear combination
+        BusInteraction::receiver(
+            BusId::Msb16,
+            Multiplicity::Column(cols::MU_MSB16),
+            vec![
+                // X + 256*Y as linear combination
+                BusValue::linear(vec![
+                    stark::lookup::LinearTerm::Column {
+                        coefficient: 1,
+                        column: cols::X,
+                    },
+                    stark::lookup::LinearTerm::Column {
+                        coefficient: 256,
+                        column: cols::Y,
+                    },
+                ]),
+                BusValue::Packed {
+                    start_column: cols::MSB16,
+                    packing: Packing::Direct,
+                },
+            ],
+        ),
+        // ZERO[X + 256*Y] -> ZERO
+        BusInteraction::receiver(
+            BusId::Zero,
+            Multiplicity::Column(cols::MU_ZERO),
+            vec![
+                BusValue::linear(vec![
+                    stark::lookup::LinearTerm::Column {
+                        coefficient: 1,
+                        column: cols::X,
+                    },
+                    stark::lookup::LinearTerm::Column {
+                        coefficient: 256,
+                        column: cols::Y,
+                    },
+                ]),
+                BusValue::Packed {
+                    start_column: cols::ZERO,
+                    packing: Packing::Direct,
+                },
+            ],
+        ),
+        // IS_BYTE[X] - range check, no output
+        BusInteraction::receiver(
+            BusId::IsByte,
+            Multiplicity::Column(cols::MU_IS_BYTE),
+            vec![BusValue::Packed {
+                start_column: cols::X,
+                packing: Packing::Direct,
+            }],
+        ),
+        // IS_HALF[X + 256*Y] - range check for halfword
+        BusInteraction::receiver(
+            BusId::IsHalfword,
+            Multiplicity::Column(cols::MU_IS_HALF),
+            vec![BusValue::linear(vec![
+                stark::lookup::LinearTerm::Column {
+                    coefficient: 1,
+                    column: cols::X,
+                },
+                stark::lookup::LinearTerm::Column {
+                    coefficient: 256,
+                    column: cols::Y,
+                },
+            ])],
+        ),
+        // IS_B20[X + 256*Y + 65536*Z] - range check for 20-bit
+        BusInteraction::receiver(
+            BusId::IsB20,
+            Multiplicity::Column(cols::MU_IS_B20),
+            vec![BusValue::linear(vec![
+                stark::lookup::LinearTerm::Column {
+                    coefficient: 1,
+                    column: cols::X,
+                },
+                stark::lookup::LinearTerm::Column {
+                    coefficient: 256,
+                    column: cols::Y,
+                },
+                stark::lookup::LinearTerm::Column {
+                    coefficient: 65536,
+                    column: cols::Z,
+                },
+            ])],
+        ),
+        // HWSL[X + 256*Y, Z] -> SLL
+        BusInteraction::receiver(
+            BusId::Hwsl,
+            Multiplicity::Column(cols::MU_HWSL),
+            vec![
+                BusValue::linear(vec![
+                    stark::lookup::LinearTerm::Column {
+                        coefficient: 1,
+                        column: cols::X,
+                    },
+                    stark::lookup::LinearTerm::Column {
+                        coefficient: 256,
+                        column: cols::Y,
+                    },
+                ]),
+                BusValue::Packed {
+                    start_column: cols::Z,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::SLL,
+                    packing: Packing::Direct,
+                },
+            ],
+        ),
+        // HWSLC[X + 256*Y, Z] -> SLLC
+        BusInteraction::receiver(
+            BusId::Hwslc,
+            Multiplicity::Column(cols::MU_HWSLC),
+            vec![
+                BusValue::linear(vec![
+                    stark::lookup::LinearTerm::Column {
+                        coefficient: 1,
+                        column: cols::X,
+                    },
+                    stark::lookup::LinearTerm::Column {
+                        coefficient: 256,
+                        column: cols::Y,
+                    },
+                ]),
+                BusValue::Packed {
+                    start_column: cols::Z,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::SLLC,
+                    packing: Packing::Direct,
+                },
+            ],
+        ),
+    ]
+}

--- a/prover/src/tables64/mod.rs
+++ b/prover/src/tables64/mod.rs
@@ -1,0 +1,39 @@
+//! 64-bit VM prover tables.
+//!
+//! This module contains the table definitions for proving 64-bit RISC-V VM execution.
+//!
+//! ## Tables
+//!
+//! - **BITWISE**: Precomputed lookup table for bitwise operations (2^20 rows)
+//! - **LT**: Less-than comparison table
+//! - **BRANCH**: Branch target computation table
+//! - **MUL**: 64-bit multiplication table
+//! - **SHIFT**: Shift operations table
+//! - **CPU**: Main execution table
+//! - **DECODE**: Instruction decode table (dummy - spec not available)
+//!
+//! ## Deferred (Phase 5)
+//!
+//! - **MEMW**: Memory word read/write table
+//! - **LOAD**: Memory load with extension table
+
+pub mod types;
+
+// Phase 1
+pub mod bitwise;
+
+// Phase 2 (to be added)
+// pub mod lt;
+// pub mod branch;
+// pub mod mul;
+// pub mod shift;
+
+// Phase 3 (to be added)
+// pub mod cpu;
+// pub mod decode;
+
+// Phase 5 - Deferred (to be added)
+// pub mod memw;
+// pub mod load;
+
+pub use types::BusId;

--- a/prover/src/tables64/types.rs
+++ b/prover/src/tables64/types.rs
@@ -1,0 +1,152 @@
+//! Core types for the 64-bit VM prover tables.
+//!
+//! This module defines the bus IDs and helper types used across all 64-bit tables.
+//!
+//! ## Field Choice
+//!
+//! For the 64-bit VM prover, we use the Goldilocks field:
+//! - Prime: p = 2^64 - 2^32 + 1
+//! - Two-adicity: 32 (supports FFT up to 2^32 rows)
+//! - Extension: Degree 3 (cubic extension with w³ = 2, provides 192-bit security)
+
+use math::field::element::FieldElement;
+use math::field::fields::fft_friendly::extensions_goldilocks::Degree3GoldilocksExtensionField;
+use math::field::fields::fft_friendly::u64_goldilocks::U64GoldilocksPrimeField;
+
+/// Base field type: Goldilocks prime field (p = 2^64 - 2^32 + 1)
+pub type GoldilocksField = U64GoldilocksPrimeField;
+
+/// Extension field type: Degree 3 extension of Goldilocks (w³ = 2)
+pub type GoldilocksExtension = Degree3GoldilocksExtensionField;
+
+/// Field element in the base Goldilocks field
+pub type FE = FieldElement<GoldilocksField>;
+
+/// Field element in the Goldilocks extension field
+pub type FEE = FieldElement<GoldilocksExtension>;
+
+/// Bus identifiers for LogUp interactions between tables.
+///
+/// Each bus connects senders (tables that produce values) with receivers
+/// (tables that consume/verify those values). For the bus to balance,
+/// the sum of sender multiplicities must equal the sum of receiver multiplicities.
+#[repr(u64)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BusId {
+    // =========================================================================
+    // Range checks (BITWISE table provides)
+    // =========================================================================
+    /// Range check: value is a valid byte [0, 256)
+    IsByte = 0,
+    /// Range check: value is a valid halfword [0, 2^16)
+    IsHalfword,
+    /// Range check: value is a 20-bit value [0, 2^20)
+    IsB20,
+
+    // =========================================================================
+    // Bitwise operations (BITWISE table provides)
+    // =========================================================================
+    /// Bitwise AND of two bytes: AND_BYTE[X, Y] -> X & Y
+    AndByte,
+    /// Bitwise OR of two bytes: OR_BYTE[X, Y] -> X | Y
+    OrByte,
+    /// Bitwise XOR of two bytes: XOR_BYTE[X, Y] -> X ^ Y
+    XorByte,
+    /// Most significant bit of a byte: MSB8[X] -> (X >> 7) & 1
+    Msb8,
+    /// Most significant bit of a halfword: MSB16[X] -> (X >> 15) & 1
+    Msb16,
+    /// Check if value is zero: ZERO[X] -> X == 0 ? 1 : 0
+    Zero,
+
+    // =========================================================================
+    // Shift helpers (BITWISE table provides)
+    // =========================================================================
+    /// Halfword shift left: HWSL[X, Z] -> (X << Z) & 0xFFFF
+    Hwsl,
+    /// Halfword shift left carry: HWSLC[X, Z] -> X >> (16 - Z)
+    Hwslc,
+
+    // =========================================================================
+    // Arithmetic operations (separate tables)
+    // =========================================================================
+    /// Less-than comparison: LT[lhs, rhs, signed] -> lhs < rhs
+    Lt,
+    /// Multiplication: MUL[lhs, lhs_signed, rhs, rhs_signed, hi] -> product
+    Mul,
+    /// Shift operation: SHIFT[in, shift, dir, signed, word] -> out
+    Shift,
+
+    // =========================================================================
+    // Memory/Control (separate tables, Phase 5)
+    // =========================================================================
+    /// Memory word read/write with timestamps
+    Memw,
+    /// Memory load with sign/zero extension
+    Load,
+    /// Branch target computation
+    Branch,
+
+    // =========================================================================
+    // System (specs not yet defined)
+    // =========================================================================
+    /// Instruction decode lookup
+    Decode,
+    /// System call handling
+    Ecall,
+}
+
+impl From<BusId> for u64 {
+    fn from(id: BusId) -> u64 {
+        id as u64
+    }
+}
+
+// =========================================================================
+// Constants for 64-bit arithmetic
+// =========================================================================
+
+/// 2^16 for halfword combining
+pub const SHIFT_16: u64 = 1 << 16;
+
+/// 2^32 for word combining
+pub const SHIFT_32: u64 = 1 << 32;
+
+/// 2^(-32) mod p for carry extraction in 64-bit addition
+/// In Babybear field: p = 2^31 - 2^27 + 1
+/// We need to find x such that x * 2^32 ≡ 1 (mod p)
+pub const INV_2_32: u64 = {
+    // 2^32 mod p = 2^32 mod (2^31 - 2^27 + 1)
+    // 2^32 = 2 * 2^31 = 2 * (p + 2^27 - 1) = 2p + 2^28 - 2 ≡ 2^28 - 2 (mod p)
+    // We need the inverse of (2^28 - 2) mod p
+    // For now, this is a placeholder - compute at runtime or verify
+    1
+};
+
+/// 2^(-16) mod p for halfword operations
+pub const INV_2_16: u64 = {
+    // Placeholder - compute at runtime or verify
+    1
+};
+
+// =========================================================================
+// Column index helpers
+// =========================================================================
+
+/// Helper to define column ranges for different 64-bit representations.
+pub mod columns {
+    /// A DWordWL (64-bit as 2 words) spans 2 columns
+    pub const DWORD_WL_SIZE: usize = 2;
+
+    /// A DWordHL (64-bit as 4 halves) spans 4 columns
+    pub const DWORD_HL_SIZE: usize = 4;
+
+    /// A DWordBL (64-bit as 8 bytes) spans 8 columns
+    pub const DWORD_BL_SIZE: usize = 8;
+
+    /// A DWordHHW (64-bit as Word, Half, Half) spans 3 columns
+    pub const DWORD_HHW_SIZE: usize = 3;
+
+    /// A QuadWL (128-bit as 4 words) spans 4 columns
+    pub const QUAD_WL_SIZE: usize = 4;
+}

--- a/prover/src/tests/bitwise_bus_tests.rs
+++ b/prover/src/tests/bitwise_bus_tests.rs
@@ -1,0 +1,289 @@
+//! Soundness and completeness tests for BITWISE table bus interactions.
+//!
+//! These tests verify that:
+//! - Completeness: Valid lookups to BITWISE are accepted
+//! - Soundness: Invalid lookups to BITWISE are rejected
+
+use crypto::fiat_shamir::default_transcript::DefaultTranscript;
+
+use stark::constraints::transition::TransitionConstraint;
+use stark::lookup::{
+    AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, BusValue, Multiplicity,
+    NullBoundaryConstraintBuilder, Packing,
+};
+use stark::proof::options::ProofOptions;
+use stark::prover::{IsStarkProver, Prover};
+use stark::trace::TraceTable;
+use stark::traits::AIR;
+use stark::verifier::{IsStarkVerifier, Verifier};
+
+use crate::tables64::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
+
+type F = GoldilocksField;
+type E = GoldilocksExtension;
+
+// =============================================================================
+// Column indices (simplified for testing)
+// =============================================================================
+
+/// Sender table columns
+mod sender_cols {
+    pub const X: usize = 0;
+    pub const Y: usize = 1;
+    pub const AND_RESULT: usize = 2;
+    pub const MU_AND: usize = 3;
+    pub const NUM_COLUMNS: usize = 4;
+}
+
+/// Receiver (BITWISE-like) table columns
+mod receiver_cols {
+    pub const X: usize = 0;
+    pub const Y: usize = 1;
+    pub const AND: usize = 2;
+    pub const MU_AND: usize = 3;
+    pub const NUM_COLUMNS: usize = 4;
+}
+
+// =============================================================================
+// AIR definitions
+// =============================================================================
+
+fn new_sender_air(
+    proof_options: &ProofOptions,
+) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
+    let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+
+    let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+        interactions: vec![BusInteraction::sender(
+            BusId::AndByte,
+            Multiplicity::Column(sender_cols::MU_AND),
+            vec![
+                BusValue::Packed {
+                    start_column: sender_cols::X,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: sender_cols::Y,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: sender_cols::AND_RESULT,
+                    packing: Packing::Direct,
+                },
+            ],
+        )],
+    };
+
+    AirWithBuses::new(
+        sender_cols::NUM_COLUMNS,
+        auxiliary_trace_build_data,
+        proof_options,
+        1,
+        transition_constraints,
+    )
+}
+
+fn new_receiver_air(
+    proof_options: &ProofOptions,
+) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
+    let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+
+    let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+        interactions: vec![BusInteraction::receiver(
+            BusId::AndByte,
+            Multiplicity::Column(receiver_cols::MU_AND),
+            vec![
+                BusValue::Packed {
+                    start_column: receiver_cols::X,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: receiver_cols::Y,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: receiver_cols::AND,
+                    packing: Packing::Direct,
+                },
+            ],
+        )],
+    };
+
+    AirWithBuses::new(
+        receiver_cols::NUM_COLUMNS,
+        auxiliary_trace_build_data,
+        proof_options,
+        1,
+        transition_constraints,
+    )
+}
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+fn create_sender_trace(lookups: &[(u8, u8, u8)]) -> TraceTable<F, E> {
+    let num_rows = lookups.len().next_power_of_two().max(4);
+    let mut data = vec![FE::zero(); num_rows * sender_cols::NUM_COLUMNS];
+
+    for (i, &(x, y, result)) in lookups.iter().enumerate() {
+        let base = i * sender_cols::NUM_COLUMNS;
+        data[base + sender_cols::X] = FE::from(x as u64);
+        data[base + sender_cols::Y] = FE::from(y as u64);
+        data[base + sender_cols::AND_RESULT] = FE::from(result as u64);
+        data[base + sender_cols::MU_AND] = FE::one();
+    }
+
+    TraceTable::new_main(data, sender_cols::NUM_COLUMNS, 1)
+}
+
+fn create_receiver_trace(lookups: &[(u8, u8)]) -> TraceTable<F, E> {
+    let num_rows = lookups.len().next_power_of_two().max(4);
+    let mut data = vec![FE::zero(); num_rows * receiver_cols::NUM_COLUMNS];
+
+    for (i, &(x, y)) in lookups.iter().enumerate() {
+        let base = i * receiver_cols::NUM_COLUMNS;
+        data[base + receiver_cols::X] = FE::from(x as u64);
+        data[base + receiver_cols::Y] = FE::from(y as u64);
+        data[base + receiver_cols::AND] = FE::from((x & y) as u64); // Correct AND result
+        data[base + receiver_cols::MU_AND] = FE::one();
+    }
+
+    TraceTable::new_main(data, receiver_cols::NUM_COLUMNS, 1)
+}
+
+fn prove_and_verify(sender_lookups: &[(u8, u8, u8)], receiver_lookups: &[(u8, u8)]) -> bool {
+    let mut sender_trace = create_sender_trace(sender_lookups);
+    let mut receiver_trace = create_receiver_trace(receiver_lookups);
+
+    let proof_options = ProofOptions::default_test_options();
+    let sender_air = new_sender_air(&proof_options);
+    let receiver_air = new_receiver_air(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&sender_air, &mut sender_trace, &()),
+        (&receiver_air, &mut receiver_trace, &()),
+    ];
+
+    let multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&sender_air, &receiver_air];
+
+    Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[]))
+}
+
+// =============================================================================
+// Completeness Tests - Valid lookups should be ACCEPTED
+// =============================================================================
+
+#[test]
+fn test_completeness_and_byte_simple() {
+    // Sender: AND_BYTE[5, 3] = 1 (correct: 5 & 3 = 1)
+    // Receiver: has row (5, 3) with AND = 1
+    let sender = vec![(5u8, 3u8, 1u8)];
+    let receiver = vec![(5u8, 3u8)];
+
+    assert!(prove_and_verify(&sender, &receiver));
+}
+
+#[test]
+fn test_completeness_and_byte_zero_result() {
+    // 0xAA & 0x55 = 0 (alternating bits)
+    let sender = vec![(0xAAu8, 0x55u8, 0x00u8)];
+    let receiver = vec![(0xAAu8, 0x55u8)];
+
+    assert!(prove_and_verify(&sender, &receiver));
+}
+
+#[test]
+fn test_completeness_and_byte_max() {
+    // 0xFF & 0xFF = 0xFF
+    let sender = vec![(0xFFu8, 0xFFu8, 0xFFu8)];
+    let receiver = vec![(0xFFu8, 0xFFu8)];
+
+    assert!(prove_and_verify(&sender, &receiver));
+}
+
+#[test]
+fn test_completeness_multiple_lookups() {
+    let sender = vec![
+        (0xFFu8, 0xFFu8, 0xFFu8), // FF & FF = FF
+        (0xAAu8, 0x55u8, 0x00u8), // AA & 55 = 00
+        (0x0Fu8, 0xF0u8, 0x00u8), // 0F & F0 = 00
+        (0x12u8, 0x34u8, 0x10u8), // 12 & 34 = 10
+    ];
+    let receiver: Vec<(u8, u8)> = sender.iter().map(|&(x, y, _)| (x, y)).collect();
+
+    assert!(prove_and_verify(&sender, &receiver));
+}
+
+// =============================================================================
+// Soundness Tests - Invalid lookups should be REJECTED
+// =============================================================================
+
+#[test]
+fn test_soundness_wrong_result() {
+    // Sender claims AND_BYTE[5, 3] = 99 (WRONG! Should be 1)
+    let sender = vec![(5u8, 3u8, 99u8)];
+    let receiver = vec![(5u8, 3u8)]; // Has correct value 1
+
+    assert!(!prove_and_verify(&sender, &receiver));
+}
+
+#[test]
+fn test_soundness_off_by_one() {
+    // Sender claims AND_BYTE[0xFF, 0xFF] = 0xFE (WRONG! Should be 0xFF)
+    let sender = vec![(0xFFu8, 0xFFu8, 0xFEu8)];
+    let receiver = vec![(0xFFu8, 0xFFu8)];
+
+    assert!(!prove_and_verify(&sender, &receiver));
+}
+
+#[test]
+fn test_soundness_multiplicity_mismatch() {
+    // Sender sends 2 lookups for same value, receiver expects 1
+    let sender = vec![
+        (5u8, 3u8, 1u8),
+        (5u8, 3u8, 1u8), // Duplicate!
+    ];
+    let receiver = vec![(5u8, 3u8)]; // Only 1 multiplicity
+
+    assert!(!prove_and_verify(&sender, &receiver));
+}
+
+#[test]
+fn test_soundness_missing_receiver_row() {
+    // Sender looks up (100, 200), but receiver only has (5, 3)
+    let sender = vec![(100u8, 200u8, 64u8)]; // 100 & 200 = 64
+    let receiver = vec![(5u8, 3u8)]; // Different row!
+
+    assert!(!prove_and_verify(&sender, &receiver));
+}
+
+#[test]
+fn test_soundness_swapped_inputs() {
+    // Sender: AND_BYTE[3, 5] = 1
+    // Receiver: has (5, 3) not (3, 5) - order matters!
+    let sender = vec![(3u8, 5u8, 1u8)]; // Note: swapped order
+    let receiver = vec![(5u8, 3u8)]; // Different input order
+
+    assert!(!prove_and_verify(&sender, &receiver));
+}
+
+#[test]
+fn test_soundness_extra_sender_lookup() {
+    // Sender sends 2 lookups, receiver only provides 1
+    let sender = vec![
+        (5u8, 3u8, 1u8),
+        (10u8, 6u8, 2u8), // Extra lookup not in receiver
+    ];
+    let receiver = vec![(5u8, 3u8)];
+
+    assert!(!prove_and_verify(&sender, &receiver));
+}

--- a/prover/src/tests/bitwise_bus_tests.rs
+++ b/prover/src/tests/bitwise_bus_tests.rs
@@ -4,6 +4,8 @@
 //! - Completeness: Valid lookups to BITWISE are accepted
 //! - Soundness: Invalid lookups to BITWISE are rejected
 
+use std::collections::HashMap;
+
 use crypto::fiat_shamir::default_transcript::DefaultTranscript;
 
 use stark::constraints::transition::TransitionConstraint;
@@ -31,7 +33,8 @@ mod sender_cols {
     pub const X: usize = 0;
     pub const Y: usize = 1;
     pub const AND_RESULT: usize = 2;
-    pub const MU_AND: usize = 3;
+    /// Flag indicating this row performs an AND operation (0 or 1)
+    pub const AND: usize = 3;
     pub const NUM_COLUMNS: usize = 4;
 }
 
@@ -56,7 +59,7 @@ fn new_sender_air(
     let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
         interactions: vec![BusInteraction::sender(
             BusId::AndByte,
-            Multiplicity::Column(sender_cols::MU_AND),
+            Multiplicity::Column(sender_cols::AND),
             vec![
                 BusValue::Packed {
                     start_column: sender_cols::X,
@@ -131,30 +134,53 @@ fn create_sender_trace(lookups: &[(u8, u8, u8)]) -> TraceTable<F, E> {
         data[base + sender_cols::X] = FE::from(x as u64);
         data[base + sender_cols::Y] = FE::from(y as u64);
         data[base + sender_cols::AND_RESULT] = FE::from(result as u64);
-        data[base + sender_cols::MU_AND] = FE::one();
+        data[base + sender_cols::AND] = FE::one(); // Flag: this row performs AND
     }
 
     TraceTable::new_main(data, sender_cols::NUM_COLUMNS, 1)
 }
 
-fn create_receiver_trace(lookups: &[(u8, u8)]) -> TraceTable<F, E> {
-    let num_rows = lookups.len().next_power_of_two().max(4);
+/// Creates a receiver (BITWISE-like) trace with precomputed values.
+///
+/// This function mimics the real BITWISE table behavior:
+/// 1. Precomputes the AND result for each unique (X, Y) combination
+/// 2. Updates multiplicities based on how many times each tuple is received from sender
+///
+/// # Arguments
+/// * `sender_lookups` - Tuples (X, Y, claimed_result) sent by the sender table
+fn create_receiver_trace(sender_lookups: &[(u8, u8, u8)]) -> TraceTable<F, E> {
+    // Count multiplicities for each unique (X, Y) pair from sender lookups
+    let mut multiplicities: HashMap<(u8, u8), u32> = HashMap::new();
+    for &(x, y, _) in sender_lookups {
+        *multiplicities.entry((x, y)).or_insert(0) += 1;
+    }
+
+    // Build precomputed table with AND results and multiplicities
+    let unique_rows: Vec<((u8, u8), u32)> = multiplicities.into_iter().collect();
+    let num_rows = unique_rows.len().next_power_of_two().max(4);
     let mut data = vec![FE::zero(); num_rows * receiver_cols::NUM_COLUMNS];
 
-    for (i, &(x, y)) in lookups.iter().enumerate() {
+    for (i, &((x, y), multiplicity)) in unique_rows.iter().enumerate() {
         let base = i * receiver_cols::NUM_COLUMNS;
+        // Precomputed values
         data[base + receiver_cols::X] = FE::from(x as u64);
         data[base + receiver_cols::Y] = FE::from(y as u64);
-        data[base + receiver_cols::AND] = FE::from((x & y) as u64); // Correct AND result
-        data[base + receiver_cols::MU_AND] = FE::one();
+        data[base + receiver_cols::AND] = FE::from((x & y) as u64); // Precomputed AND
+        // Multiplicity updated from sender lookups
+        data[base + receiver_cols::MU_AND] = FE::from(multiplicity as u64);
     }
 
     TraceTable::new_main(data, receiver_cols::NUM_COLUMNS, 1)
 }
 
-fn prove_and_verify(sender_lookups: &[(u8, u8, u8)], receiver_lookups: &[(u8, u8)]) -> bool {
+/// Proves and verifies a sender-receiver interaction.
+///
+/// The receiver trace is automatically built from sender lookups, mimicking
+/// how the BITWISE table works: precomputed values with multiplicities
+/// updated based on received lookups.
+fn prove_and_verify(sender_lookups: &[(u8, u8, u8)]) -> bool {
     let mut sender_trace = create_sender_trace(sender_lookups);
-    let mut receiver_trace = create_receiver_trace(receiver_lookups);
+    let mut receiver_trace = create_receiver_trace(sender_lookups);
 
     let proof_options = ProofOptions::default_test_options();
     let sender_air = new_sender_air(&proof_options);
@@ -185,105 +211,164 @@ fn prove_and_verify(sender_lookups: &[(u8, u8, u8)], receiver_lookups: &[(u8, u8
 #[test]
 fn test_completeness_and_byte_simple() {
     // Sender: AND_BYTE[5, 3] = 1 (correct: 5 & 3 = 1)
-    // Receiver: has row (5, 3) with AND = 1
+    // Receiver: precomputed table has row (5, 3) with AND = 1, multiplicity = 1
     let sender = vec![(5u8, 3u8, 1u8)];
-    let receiver = vec![(5u8, 3u8)];
 
-    assert!(prove_and_verify(&sender, &receiver));
+    assert!(prove_and_verify(&sender));
 }
 
 #[test]
 fn test_completeness_and_byte_zero_result() {
     // 0xAA & 0x55 = 0 (alternating bits)
     let sender = vec![(0xAAu8, 0x55u8, 0x00u8)];
-    let receiver = vec![(0xAAu8, 0x55u8)];
 
-    assert!(prove_and_verify(&sender, &receiver));
+    assert!(prove_and_verify(&sender));
 }
 
 #[test]
 fn test_completeness_and_byte_max() {
     // 0xFF & 0xFF = 0xFF
     let sender = vec![(0xFFu8, 0xFFu8, 0xFFu8)];
-    let receiver = vec![(0xFFu8, 0xFFu8)];
 
-    assert!(prove_and_verify(&sender, &receiver));
+    assert!(prove_and_verify(&sender));
 }
 
 #[test]
 fn test_completeness_multiple_lookups() {
+    // Multiple different lookups - receiver precomputes each and sets multiplicity = 1
     let sender = vec![
         (0xFFu8, 0xFFu8, 0xFFu8), // FF & FF = FF
         (0xAAu8, 0x55u8, 0x00u8), // AA & 55 = 00
         (0x0Fu8, 0xF0u8, 0x00u8), // 0F & F0 = 00
         (0x12u8, 0x34u8, 0x10u8), // 12 & 34 = 10
     ];
-    let receiver: Vec<(u8, u8)> = sender.iter().map(|&(x, y, _)| (x, y)).collect();
 
-    assert!(prove_and_verify(&sender, &receiver));
+    assert!(prove_and_verify(&sender));
+}
+
+#[test]
+fn test_completeness_duplicate_lookups() {
+    // Same lookup multiple times - receiver precomputes once with multiplicity = 3
+    let sender = vec![
+        (5u8, 3u8, 1u8), // First lookup
+        (5u8, 3u8, 1u8), // Duplicate
+        (5u8, 3u8, 1u8), // Duplicate
+    ];
+
+    assert!(prove_and_verify(&sender));
 }
 
 // =============================================================================
 // Soundness Tests - Invalid lookups should be REJECTED
 // =============================================================================
 
+/// Creates a custom receiver trace for soundness tests.
+/// Allows specifying exact (X, Y, AND, multiplicity) tuples.
+fn create_custom_receiver_trace(rows: &[(u8, u8, u8, u32)]) -> TraceTable<F, E> {
+    let num_rows = rows.len().next_power_of_two().max(4);
+    let mut data = vec![FE::zero(); num_rows * receiver_cols::NUM_COLUMNS];
+
+    for (i, &(x, y, and_result, multiplicity)) in rows.iter().enumerate() {
+        let base = i * receiver_cols::NUM_COLUMNS;
+        data[base + receiver_cols::X] = FE::from(x as u64);
+        data[base + receiver_cols::Y] = FE::from(y as u64);
+        data[base + receiver_cols::AND] = FE::from(and_result as u64);
+        data[base + receiver_cols::MU_AND] = FE::from(multiplicity as u64);
+    }
+
+    TraceTable::new_main(data, receiver_cols::NUM_COLUMNS, 1)
+}
+
+/// Proves and verifies with a custom receiver trace (for soundness tests).
+fn prove_and_verify_custom(
+    sender_lookups: &[(u8, u8, u8)],
+    receiver_rows: &[(u8, u8, u8, u32)],
+) -> bool {
+    let mut sender_trace = create_sender_trace(sender_lookups);
+    let mut receiver_trace = create_custom_receiver_trace(receiver_rows);
+
+    let proof_options = ProofOptions::default_test_options();
+    let sender_air = new_sender_air(&proof_options);
+    let receiver_air = new_receiver_air(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&sender_air, &mut sender_trace, &()),
+        (&receiver_air, &mut receiver_trace, &()),
+    ];
+
+    let multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&sender_air, &receiver_air];
+
+    Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[]))
+}
+
 #[test]
 fn test_soundness_wrong_result() {
     // Sender claims AND_BYTE[5, 3] = 99 (WRONG! Should be 1)
+    // Receiver has precomputed correct value 1, so verification should fail
     let sender = vec![(5u8, 3u8, 99u8)];
-    let receiver = vec![(5u8, 3u8)]; // Has correct value 1
 
-    assert!(!prove_and_verify(&sender, &receiver));
+    assert!(!prove_and_verify(&sender));
 }
 
 #[test]
 fn test_soundness_off_by_one() {
     // Sender claims AND_BYTE[0xFF, 0xFF] = 0xFE (WRONG! Should be 0xFF)
     let sender = vec![(0xFFu8, 0xFFu8, 0xFEu8)];
-    let receiver = vec![(0xFFu8, 0xFFu8)];
 
-    assert!(!prove_and_verify(&sender, &receiver));
+    assert!(!prove_and_verify(&sender));
 }
 
 #[test]
 fn test_soundness_multiplicity_mismatch() {
-    // Sender sends 2 lookups for same value, receiver expects 1
+    // Sender sends 2 lookups for same value, but receiver has multiplicity 1
     let sender = vec![
         (5u8, 3u8, 1u8),
         (5u8, 3u8, 1u8), // Duplicate!
     ];
-    let receiver = vec![(5u8, 3u8)]; // Only 1 multiplicity
+    // Custom receiver with wrong multiplicity (1 instead of 2)
+    let receiver = vec![(5u8, 3u8, 1u8, 1u32)]; // multiplicity = 1, should be 2
 
-    assert!(!prove_and_verify(&sender, &receiver));
+    assert!(!prove_and_verify_custom(&sender, &receiver));
 }
 
 #[test]
 fn test_soundness_missing_receiver_row() {
     // Sender looks up (100, 200), but receiver only has (5, 3)
     let sender = vec![(100u8, 200u8, 64u8)]; // 100 & 200 = 64
-    let receiver = vec![(5u8, 3u8)]; // Different row!
+    // Custom receiver with different row
+    let receiver = vec![(5u8, 3u8, 1u8, 1u32)]; // Different row!
 
-    assert!(!prove_and_verify(&sender, &receiver));
+    assert!(!prove_and_verify_custom(&sender, &receiver));
 }
 
 #[test]
 fn test_soundness_swapped_inputs() {
     // Sender: AND_BYTE[3, 5] = 1
     // Receiver: has (5, 3) not (3, 5) - order matters!
-    let sender = vec![(3u8, 5u8, 1u8)]; // Note: swapped order
-    let receiver = vec![(5u8, 3u8)]; // Different input order
+    let sender = vec![(3u8, 5u8, 1u8)]; // Note: X=3, Y=5
+    // Custom receiver with swapped inputs
+    let receiver = vec![(5u8, 3u8, 1u8, 1u32)]; // X=5, Y=3 - different input order
 
-    assert!(!prove_and_verify(&sender, &receiver));
+    assert!(!prove_and_verify_custom(&sender, &receiver));
 }
 
 #[test]
 fn test_soundness_extra_sender_lookup() {
-    // Sender sends 2 lookups, receiver only provides 1
+    // Sender sends 2 different lookups, but receiver only provides 1 row
     let sender = vec![
         (5u8, 3u8, 1u8),
         (10u8, 6u8, 2u8), // Extra lookup not in receiver
     ];
-    let receiver = vec![(5u8, 3u8)];
+    // Custom receiver missing the (10, 6) row
+    let receiver = vec![(5u8, 3u8, 1u8, 1u32)];
 
-    assert!(!prove_and_verify(&sender, &receiver));
+    assert!(!prove_and_verify_custom(&sender, &receiver));
 }

--- a/prover/src/tests/bitwise_tests.rs
+++ b/prover/src/tests/bitwise_tests.rs
@@ -1,0 +1,215 @@
+//! Tests for the BITWISE precomputed table.
+
+use crate::tables64::bitwise::{
+    NUM_ROWS, bus_interactions, cols, generate_bitwise_trace, row_index,
+};
+use crate::tables64::types::FE;
+
+#[test]
+fn test_row_index() {
+    // First row: x=0, y=0, z=0
+    assert_eq!(row_index(0, 0, 0), 0);
+
+    // x=1, y=0, z=0
+    assert_eq!(row_index(1, 0, 0), 1);
+
+    // x=0, y=1, z=0
+    assert_eq!(row_index(0, 1, 0), 256);
+
+    // x=0, y=0, z=1
+    assert_eq!(row_index(0, 0, 1), 256 * 256);
+
+    // Last row: x=255, y=255, z=15
+    assert_eq!(row_index(255, 255, 15), NUM_ROWS - 1);
+}
+
+#[test]
+fn test_generate_bitwise_trace() {
+    let trace = generate_bitwise_trace();
+
+    // Check dimensions
+    assert_eq!(trace.num_rows(), NUM_ROWS);
+
+    // Check a few specific values
+    // Row for x=5, y=3, z=0
+    let row = row_index(5, 3, 0);
+    let row_data = trace.main_table.get_row(row);
+
+    assert_eq!(row_data[cols::X], FE::from(5u64));
+    assert_eq!(row_data[cols::Y], FE::from(3u64));
+    assert_eq!(row_data[cols::Z], FE::from(0u64));
+    assert_eq!(row_data[cols::AND], FE::from(1u64)); // 5 & 3 = 1
+    assert_eq!(row_data[cols::OR], FE::from(7u64)); // 5 | 3 = 7
+    assert_eq!(row_data[cols::XOR], FE::from(6u64)); // 5 ^ 3 = 6
+
+    // Check MSB8 for x=128 (MSB set)
+    let row = row_index(128, 0, 0);
+    let row_data = trace.main_table.get_row(row);
+    assert_eq!(row_data[cols::MSB8], FE::from(1u64));
+
+    // Check MSB8 for x=127 (MSB not set)
+    let row = row_index(127, 0, 0);
+    let row_data = trace.main_table.get_row(row);
+    assert_eq!(row_data[cols::MSB8], FE::from(0u64));
+
+    // Check MSB16 for halfword = 32768 (0x8000)
+    // 32768 = 0 + 256 * 128
+    let row = row_index(0, 128, 0);
+    let row_data = trace.main_table.get_row(row);
+    assert_eq!(row_data[cols::MSB16], FE::from(1u64));
+
+    // Check shift: x=1, y=0, z=4 -> SLL = 16, SLLC = 0
+    let row = row_index(1, 0, 4);
+    let row_data = trace.main_table.get_row(row);
+    assert_eq!(row_data[cols::SLL], FE::from(16u64)); // 1 << 4 = 16
+    assert_eq!(row_data[cols::SLLC], FE::from(0u64)); // no carry
+
+    // Check shift with carry: x=0, y=128, z=1 -> halfword=32768, SLL=0, SLLC=1
+    let row = row_index(0, 128, 1);
+    let row_data = trace.main_table.get_row(row);
+    // 32768 << 1 = 65536 & 0xFFFF = 0
+    assert_eq!(row_data[cols::SLL], FE::from(0u64));
+    // 32768 >> (16-1) = 32768 >> 15 = 1
+    assert_eq!(row_data[cols::SLLC], FE::from(1u64));
+}
+
+#[test]
+fn test_zero_check() {
+    let trace = generate_bitwise_trace();
+
+    // ZERO should be 1 only when both X and Y are 0
+    let row = row_index(0, 0, 0);
+    assert_eq!(trace.main_table.get_row(row)[cols::ZERO], FE::from(1u64));
+
+    let row = row_index(1, 0, 0);
+    assert_eq!(trace.main_table.get_row(row)[cols::ZERO], FE::from(0u64));
+
+    let row = row_index(0, 1, 0);
+    assert_eq!(trace.main_table.get_row(row)[cols::ZERO], FE::from(0u64));
+}
+
+#[test]
+fn test_bus_interactions_count() {
+    let interactions = bus_interactions();
+    // Should have 11 interactions (one for each lookup type)
+    assert_eq!(interactions.len(), 11);
+}
+
+#[test]
+fn test_first_row() {
+    // First row: x=0, y=0, z=0
+    let trace = generate_bitwise_trace();
+    let row = row_index(0, 0, 0);
+    let row_data = trace.main_table.get_row(row);
+
+    assert_eq!(row_data[cols::X], FE::from(0u64));
+    assert_eq!(row_data[cols::Y], FE::from(0u64));
+    assert_eq!(row_data[cols::Z], FE::from(0u64));
+    assert_eq!(row_data[cols::AND], FE::from(0u64)); // 0 & 0 = 0
+    assert_eq!(row_data[cols::OR], FE::from(0u64)); // 0 | 0 = 0
+    assert_eq!(row_data[cols::XOR], FE::from(0u64)); // 0 ^ 0 = 0
+    assert_eq!(row_data[cols::MSB8], FE::from(0u64)); // MSB of 0 = 0
+    assert_eq!(row_data[cols::MSB16], FE::from(0u64)); // MSB of 0 = 0
+    assert_eq!(row_data[cols::ZERO], FE::from(1u64)); // 0 and 0 are both zero
+    assert_eq!(row_data[cols::SLL], FE::from(0u64)); // 0 << 0 = 0
+    assert_eq!(row_data[cols::SLLC], FE::from(0u64)); // 0 >> 16 = 0
+}
+
+#[test]
+fn test_last_row() {
+    // Last row: x=255, y=255, z=15
+    let trace = generate_bitwise_trace();
+    let row = row_index(255, 255, 15);
+    let row_data = trace.main_table.get_row(row);
+
+    assert_eq!(row_data[cols::X], FE::from(255u64));
+    assert_eq!(row_data[cols::Y], FE::from(255u64));
+    assert_eq!(row_data[cols::Z], FE::from(15u64));
+    assert_eq!(row_data[cols::AND], FE::from(255u64)); // 255 & 255 = 255
+    assert_eq!(row_data[cols::OR], FE::from(255u64)); // 255 | 255 = 255
+    assert_eq!(row_data[cols::XOR], FE::from(0u64)); // 255 ^ 255 = 0
+    assert_eq!(row_data[cols::MSB8], FE::from(1u64)); // MSB of 255 = 1
+    // halfword = 255 + 256*255 = 65535 = 0xFFFF, MSB is bit 15 = 1
+    assert_eq!(row_data[cols::MSB16], FE::from(1u64));
+    assert_eq!(row_data[cols::ZERO], FE::from(0u64)); // not zero
+    // SLL: (65535 << 15) & 0xFFFF = 0x8000 = 32768
+    assert_eq!(row_data[cols::SLL], FE::from(32768u64));
+    // SLLC: 65535 >> (16 - 15) = 65535 >> 1 = 32767
+    assert_eq!(row_data[cols::SLLC], FE::from(32767u64));
+}
+
+#[test]
+fn test_boundary_msb16() {
+    let trace = generate_bitwise_trace();
+
+    // halfword = 32767 (0x7FFF): MSB16 should be 0
+    // 32767 = 255 + 256*127, so x=255, y=127
+    let row = row_index(255, 127, 0);
+    assert_eq!(trace.main_table.get_row(row)[cols::MSB16], FE::from(0u64));
+
+    // halfword = 32768 (0x8000): MSB16 should be 1
+    // 32768 = 0 + 256*128, so x=0, y=128
+    let row = row_index(0, 128, 0);
+    assert_eq!(trace.main_table.get_row(row)[cols::MSB16], FE::from(1u64));
+}
+
+#[test]
+fn test_shift_boundaries() {
+    let trace = generate_bitwise_trace();
+
+    // Test SLL and SLLC at z=0 (no shift)
+    // halfword = 1 (x=1, y=0)
+    let row = row_index(1, 0, 0);
+    let row_data = trace.main_table.get_row(row);
+    assert_eq!(row_data[cols::SLL], FE::from(1u64)); // 1 << 0 = 1
+    assert_eq!(row_data[cols::SLLC], FE::from(0u64)); // 1 >> 16 = 0
+
+    // Test SLL and SLLC at z=15 (max shift)
+    // halfword = 1 (x=1, y=0)
+    let row = row_index(1, 0, 15);
+    let row_data = trace.main_table.get_row(row);
+    // SLL: (1 << 15) & 0xFFFF = 0x8000 = 32768
+    assert_eq!(row_data[cols::SLL], FE::from(32768u64));
+    // SLLC: 1 >> (16 - 15) = 1 >> 1 = 0
+    assert_eq!(row_data[cols::SLLC], FE::from(0u64));
+
+    // Test with halfword = 0x8001 = 32769 (x=1, y=128)
+    let row = row_index(1, 128, 1);
+    let row_data = trace.main_table.get_row(row);
+    // halfword = 1 + 256*128 = 32769 = 0x8001
+    // SLL: (32769 << 1) & 0xFFFF = 65538 & 0xFFFF = 2
+    assert_eq!(row_data[cols::SLL], FE::from(2u64));
+    // SLLC: 32769 >> (16 - 1) = 32769 >> 15 = 1
+    assert_eq!(row_data[cols::SLLC], FE::from(1u64));
+}
+
+#[test]
+fn test_all_bitwise_operations() {
+    let trace = generate_bitwise_trace();
+
+    // Test with x=0xAA, y=0x55 (alternating bits)
+    let row = row_index(0xAA, 0x55, 0);
+    let row_data = trace.main_table.get_row(row);
+
+    assert_eq!(row_data[cols::AND], FE::from(0u64)); // 0xAA & 0x55 = 0
+    assert_eq!(row_data[cols::OR], FE::from(0xFFu64)); // 0xAA | 0x55 = 0xFF
+    assert_eq!(row_data[cols::XOR], FE::from(0xFFu64)); // 0xAA ^ 0x55 = 0xFF
+    assert_eq!(row_data[cols::MSB8], FE::from(1u64)); // MSB of 0xAA = 1
+
+    // Test with x=0x55, y=0xAA
+    let row = row_index(0x55, 0xAA, 0);
+    let row_data = trace.main_table.get_row(row);
+
+    assert_eq!(row_data[cols::AND], FE::from(0u64)); // 0x55 & 0xAA = 0
+    assert_eq!(row_data[cols::OR], FE::from(0xFFu64)); // 0x55 | 0xAA = 0xFF
+    assert_eq!(row_data[cols::XOR], FE::from(0xFFu64)); // 0x55 ^ 0xAA = 0xFF
+    assert_eq!(row_data[cols::MSB8], FE::from(0u64)); // MSB of 0x55 = 0
+}
+
+#[test]
+fn test_row_count() {
+    let trace = generate_bitwise_trace();
+    // 256 * 256 * 16 = 2^20 = 1048576
+    assert_eq!(trace.num_rows(), 256 * 256 * 16);
+    assert_eq!(trace.num_rows(), 1048576);
+}

--- a/prover/src/tests/constraints64_tests.rs
+++ b/prover/src/tests/constraints64_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the 64-bit VM constraint templates.
 
 use crate::constraints64::templates::{
-    AddConstraint, IsBitConstraint, SHIFT_32, new_is_bit_constraints,
+    AddConstraint, AddLinearTerm, AddOperand, IsBitConstraint, SHIFT_32, new_is_bit_constraints,
 };
 use crate::tables64::types::FE;
 use stark::constraints::transition::TransitionConstraint;
@@ -21,20 +21,37 @@ fn test_inv_2_32() {
 
 #[test]
 fn test_is_bit_constraint_degree() {
-    let constraint = IsBitConstraint::new(0, 1, 0);
-    assert_eq!(constraint.degree(), 3);
+    // Conditional: degree 3
+    let conditional = IsBitConstraint::new(0, 1, 0);
+    assert_eq!(conditional.degree(), 3);
+
+    // Unconditional: degree 2
+    let unconditional = IsBitConstraint::unconditional(1, 0);
+    assert_eq!(unconditional.degree(), 2);
 }
 
 #[test]
 fn test_add_constraint_degree() {
-    let (c0, c1) = AddConstraint::new_pair(0, 1, 3, 5, 0);
+    let (c0, c1) = AddConstraint::new_pair(
+        0,
+        AddOperand::dword(1),
+        AddOperand::dword(3),
+        AddOperand::dword(5),
+        0,
+    );
     assert_eq!(c0.degree(), 3);
     assert_eq!(c1.degree(), 3);
 }
 
 #[test]
 fn test_add_constraint_indices() {
-    let (c0, c1) = AddConstraint::new_pair(0, 1, 3, 5, 10);
+    let (c0, c1) = AddConstraint::new_pair(
+        0,
+        AddOperand::dword(1),
+        AddOperand::dword(3),
+        AddOperand::dword(5),
+        10,
+    );
     assert_eq!(c0.constraint_idx(), 10);
     assert_eq!(c1.constraint_idx(), 11);
 }
@@ -175,15 +192,332 @@ fn test_carry_max_values() {
 
 #[test]
 fn test_new_is_bit_constraints_count() {
-    let (constraints, next_idx) = new_is_bit_constraints(0, &[1, 2, 3, 4], 10);
+    let (constraints, next_idx) = new_is_bit_constraints(&[1, 2, 3, 4], 10);
     assert_eq!(constraints.len(), 4);
     assert_eq!(next_idx, 14);
 }
 
 #[test]
 fn test_new_is_bit_constraints_indices() {
-    let (constraints, _) = new_is_bit_constraints(0, &[5, 6, 7], 100);
+    let (constraints, _) = new_is_bit_constraints(&[5, 6, 7], 100);
     assert_eq!(constraints[0].constraint_idx(), 100);
     assert_eq!(constraints[1].constraint_idx(), 101);
     assert_eq!(constraints[2].constraint_idx(), 102);
+}
+
+// =========================================================================
+// AddOperand tests
+// =========================================================================
+
+#[test]
+fn test_add_operand_constant() {
+    // Test that constant operand creates correct Linear representation
+    let op = AddOperand::constant(42);
+    match op {
+        AddOperand::Linear { lo, hi } => {
+            assert_eq!(lo.len(), 1);
+            assert!(hi.is_empty());
+            match &lo[0] {
+                AddLinearTerm::Constant(v) => assert_eq!(*v, 42),
+                _ => panic!("Expected Constant"),
+            }
+        }
+        _ => panic!("Expected Linear variant"),
+    }
+}
+
+#[test]
+fn test_add_operand_from_word() {
+    // Test Word → DWordWL (single column, zero-extended)
+    let op = AddOperand::from_word(5);
+    match op {
+        AddOperand::Linear { lo, hi } => {
+            assert_eq!(lo.len(), 1);
+            assert!(hi.is_empty());
+            match &lo[0] {
+                AddLinearTerm::Column { coefficient, column } => {
+                    assert_eq!(*coefficient, 1);
+                    assert_eq!(*column, 5);
+                }
+                _ => panic!("Expected Column"),
+            }
+        }
+        _ => panic!("Expected Linear variant"),
+    }
+}
+
+#[test]
+fn test_add_operand_dword() {
+    // Test DWordWL (2 consecutive columns)
+    let op = AddOperand::dword(10);
+    match op {
+        AddOperand::DWordWL { start_column } => {
+            assert_eq!(start_column, 10);
+        }
+        _ => panic!("Expected DWordWL variant"),
+    }
+}
+
+#[test]
+fn test_add_operand_from_dword_hl() {
+    // Test DWordHL → DWordWL (repack 4 halves → 2 words)
+    let op = AddOperand::from_dword_hl(0);
+    match op {
+        AddOperand::Linear { lo, hi } => {
+            assert_eq!(lo.len(), 2);
+            assert_eq!(hi.len(), 2);
+
+            // lo = h[0] + 2^16 * h[1]
+            match &lo[0] {
+                AddLinearTerm::Column { coefficient, column } => {
+                    assert_eq!(*coefficient, 1);
+                    assert_eq!(*column, 0);
+                }
+                _ => panic!("Expected Column"),
+            }
+            match &lo[1] {
+                AddLinearTerm::Column { coefficient, column } => {
+                    assert_eq!(*coefficient, 1 << 16);
+                    assert_eq!(*column, 1);
+                }
+                _ => panic!("Expected Column"),
+            }
+
+            // hi = h[2] + 2^16 * h[3]
+            match &hi[0] {
+                AddLinearTerm::Column { coefficient, column } => {
+                    assert_eq!(*coefficient, 1);
+                    assert_eq!(*column, 2);
+                }
+                _ => panic!("Expected Column"),
+            }
+            match &hi[1] {
+                AddLinearTerm::Column { coefficient, column } => {
+                    assert_eq!(*coefficient, 1 << 16);
+                    assert_eq!(*column, 3);
+                }
+                _ => panic!("Expected Column"),
+            }
+        }
+        _ => panic!("Expected Linear variant"),
+    }
+}
+
+#[test]
+fn test_add_operand_from_dword_bl() {
+    // Test DWordBL → DWordWL (repack 8 bytes → 2 words)
+    let op = AddOperand::from_dword_bl(0);
+    match op {
+        AddOperand::Linear { lo, hi } => {
+            assert_eq!(lo.len(), 4);
+            assert_eq!(hi.len(), 4);
+
+            // Check lo coefficients: 1, 2^8, 2^16, 2^24
+            let lo_coeffs: Vec<i64> = lo
+                .iter()
+                .map(|t| match t {
+                    AddLinearTerm::Column { coefficient, .. } => *coefficient,
+                    _ => panic!("Expected Column"),
+                })
+                .collect();
+            assert_eq!(lo_coeffs, vec![1, 1 << 8, 1 << 16, 1 << 24]);
+
+            // Check hi coefficients: 1, 2^8, 2^16, 2^24
+            let hi_coeffs: Vec<i64> = hi
+                .iter()
+                .map(|t| match t {
+                    AddLinearTerm::Column { coefficient, .. } => *coefficient,
+                    _ => panic!("Expected Column"),
+                })
+                .collect();
+            assert_eq!(hi_coeffs, vec![1, 1 << 8, 1 << 16, 1 << 24]);
+
+            // Check hi columns: 4, 5, 6, 7
+            let hi_cols: Vec<usize> = hi
+                .iter()
+                .map(|t| match t {
+                    AddLinearTerm::Column { column, .. } => *column,
+                    _ => panic!("Expected Column"),
+                })
+                .collect();
+            assert_eq!(hi_cols, vec![4, 5, 6, 7]);
+        }
+        _ => panic!("Expected Linear variant"),
+    }
+}
+
+#[test]
+fn test_add_operand_linear_with_negative_coefficient() {
+    // Test linear operand with negative coefficient: 4 - 2*c
+    // This represents expressions like `4 - 2 * c_type_instruction`
+    let op = AddOperand::linear(
+        vec![
+            AddLinearTerm::Constant(4),
+            AddLinearTerm::Column {
+                coefficient: -2,
+                column: 0,
+            },
+        ],
+        vec![], // hi = 0
+    );
+    match op {
+        AddOperand::Linear { lo, hi } => {
+            assert_eq!(lo.len(), 2);
+            assert!(hi.is_empty());
+
+            match &lo[0] {
+                AddLinearTerm::Constant(v) => assert_eq!(*v, 4),
+                _ => panic!("Expected Constant"),
+            }
+            match &lo[1] {
+                AddLinearTerm::Column { coefficient, column } => {
+                    assert_eq!(*coefficient, -2);
+                    assert_eq!(*column, 0);
+                }
+                _ => panic!("Expected Column"),
+            }
+        }
+        _ => panic!("Expected Linear variant"),
+    }
+}
+
+#[test]
+fn test_add_operand_linear_with_nonzero_hi() {
+    // Test linear operand with non-trivial hi terms (virtual column case)
+    let op = AddOperand::linear(
+        vec![
+            AddLinearTerm::Column {
+                coefficient: 1 << 16,
+                column: 0,
+            },
+            AddLinearTerm::Column {
+                coefficient: 1 << 8,
+                column: 1,
+            },
+            AddLinearTerm::Column {
+                coefficient: 1,
+                column: 2,
+            },
+        ],
+        vec![
+            AddLinearTerm::Column {
+                coefficient: 1 << 16,
+                column: 3,
+            },
+            AddLinearTerm::Column {
+                coefficient: 1,
+                column: 4,
+            },
+        ],
+    );
+    match op {
+        AddOperand::Linear { lo, hi } => {
+            assert_eq!(lo.len(), 3);
+            assert_eq!(hi.len(), 2);
+        }
+        _ => panic!("Expected Linear variant"),
+    }
+}
+
+// =========================================================================
+// i64_to_fe formula verification tests
+// =========================================================================
+
+#[test]
+fn test_i64_to_fe_positive() {
+    // Verify positive conversion
+    let val: i64 = 42;
+    let expected = FE::from(42u64);
+    let fe = if val >= 0 {
+        FE::from(val as u64)
+    } else {
+        -FE::from((-val) as u64)
+    };
+    assert_eq!(fe, expected);
+}
+
+#[test]
+fn test_i64_to_fe_negative() {
+    // Verify negative conversion: -2 in field
+    let val: i64 = -2;
+    let fe = if val >= 0 {
+        FE::from(val as u64)
+    } else {
+        -FE::from((-val) as u64)
+    };
+
+    // -2 + 2 should equal 0
+    let two = FE::from(2u64);
+    assert_eq!(&fe + &two, FE::zero());
+}
+
+#[test]
+fn test_linear_term_negative_coefficient_formula() {
+    // Verify that 4 - 2*1 = 2 using field arithmetic
+    // This simulates: constant(4) + coefficient(-2) * column_value(1)
+    let constant = FE::from(4u64);
+    let coefficient = -FE::from(2u64);
+    let col_value = FE::one();
+
+    let result = &constant + &coefficient * &col_value;
+    assert_eq!(result, FE::from(2u64));
+}
+
+#[test]
+fn test_dword_hl_repack_formula() {
+    // Verify DWordHL → DWordWL repacking formula
+    // lo = h[0] + 2^16 * h[1]
+    // hi = h[2] + 2^16 * h[3]
+    //
+    // Example: h = [0x1234, 0x5678, 0xABCD, 0xEF01]
+    // lo = 0x1234 + 0x5678_0000 = 0x5678_1234
+    // hi = 0xABCD + 0xEF01_0000 = 0xEF01_ABCD
+
+    let h0 = FE::from(0x1234u64);
+    let h1 = FE::from(0x5678u64);
+    let h2 = FE::from(0xABCDu64);
+    let h3 = FE::from(0xEF01u64);
+
+    let shift_16 = FE::from(1u64 << 16);
+
+    let lo = &h0 + &h1 * &shift_16;
+    let hi = &h2 + &h3 * &shift_16;
+
+    assert_eq!(lo, FE::from(0x5678_1234u64));
+    assert_eq!(hi, FE::from(0xEF01_ABCDu64));
+}
+
+#[test]
+fn test_dword_bl_repack_formula() {
+    // Verify DWordBL → DWordWL repacking formula
+    // lo = b[0] + 2^8*b[1] + 2^16*b[2] + 2^24*b[3]
+    // hi = b[4] + 2^8*b[5] + 2^16*b[6] + 2^24*b[7]
+    //
+    // Example: bytes = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]
+    // lo = 0x78563412
+    // hi = 0xF0DEBC9A
+
+    let b: Vec<FE> = vec![
+        FE::from(0x12u64),
+        FE::from(0x34u64),
+        FE::from(0x56u64),
+        FE::from(0x78u64),
+        FE::from(0x9Au64),
+        FE::from(0xBCu64),
+        FE::from(0xDEu64),
+        FE::from(0xF0u64),
+    ];
+
+    let coeffs: Vec<FE> = vec![
+        FE::from(1u64),
+        FE::from(1u64 << 8),
+        FE::from(1u64 << 16),
+        FE::from(1u64 << 24),
+    ];
+
+    let lo = &b[0] * &coeffs[0] + &b[1] * &coeffs[1] + &b[2] * &coeffs[2] + &b[3] * &coeffs[3];
+    let hi = &b[4] * &coeffs[0] + &b[5] * &coeffs[1] + &b[6] * &coeffs[2] + &b[7] * &coeffs[3];
+
+    assert_eq!(lo, FE::from(0x78563412u64));
+    assert_eq!(hi, FE::from(0xF0DEBC9Au64));
 }

--- a/prover/src/tests/constraints64_tests.rs
+++ b/prover/src/tests/constraints64_tests.rs
@@ -235,7 +235,10 @@ fn test_add_operand_from_word() {
             assert_eq!(lo.len(), 1);
             assert!(hi.is_empty());
             match &lo[0] {
-                AddLinearTerm::Column { coefficient, column } => {
+                AddLinearTerm::Column {
+                    coefficient,
+                    column,
+                } => {
                     assert_eq!(*coefficient, 1);
                     assert_eq!(*column, 5);
                 }
@@ -269,14 +272,20 @@ fn test_add_operand_from_dword_hl() {
 
             // lo = h[0] + 2^16 * h[1]
             match &lo[0] {
-                AddLinearTerm::Column { coefficient, column } => {
+                AddLinearTerm::Column {
+                    coefficient,
+                    column,
+                } => {
                     assert_eq!(*coefficient, 1);
                     assert_eq!(*column, 0);
                 }
                 _ => panic!("Expected Column"),
             }
             match &lo[1] {
-                AddLinearTerm::Column { coefficient, column } => {
+                AddLinearTerm::Column {
+                    coefficient,
+                    column,
+                } => {
                     assert_eq!(*coefficient, 1 << 16);
                     assert_eq!(*column, 1);
                 }
@@ -285,14 +294,20 @@ fn test_add_operand_from_dword_hl() {
 
             // hi = h[2] + 2^16 * h[3]
             match &hi[0] {
-                AddLinearTerm::Column { coefficient, column } => {
+                AddLinearTerm::Column {
+                    coefficient,
+                    column,
+                } => {
                     assert_eq!(*coefficient, 1);
                     assert_eq!(*column, 2);
                 }
                 _ => panic!("Expected Column"),
             }
             match &hi[1] {
-                AddLinearTerm::Column { coefficient, column } => {
+                AddLinearTerm::Column {
+                    coefficient,
+                    column,
+                } => {
                     assert_eq!(*coefficient, 1 << 16);
                     assert_eq!(*column, 3);
                 }
@@ -370,7 +385,10 @@ fn test_add_operand_linear_with_negative_coefficient() {
                 _ => panic!("Expected Constant"),
             }
             match &lo[1] {
-                AddLinearTerm::Column { coefficient, column } => {
+                AddLinearTerm::Column {
+                    coefficient,
+                    column,
+                } => {
                     assert_eq!(*coefficient, -2);
                     assert_eq!(*column, 0);
                 }

--- a/prover/src/tests/constraints64_tests.rs
+++ b/prover/src/tests/constraints64_tests.rs
@@ -1,0 +1,189 @@
+//! Tests for the 64-bit VM constraint templates.
+
+use crate::constraints64::templates::{
+    AddConstraint, IsBitConstraint, SHIFT_32, new_is_bit_constraints,
+};
+use crate::tables64::types::FE;
+use stark::constraints::transition::TransitionConstraint;
+
+// =========================================================================
+// Basic tests
+// =========================================================================
+
+#[test]
+fn test_inv_2_32() {
+    // Verify that 2^32 * 2^(-32) = 1 in Goldilocks
+    let two_32 = FE::from(SHIFT_32);
+    let inv = two_32.inv().expect("Should be invertible");
+    let product = &two_32 * &inv;
+    assert_eq!(product, FE::one());
+}
+
+#[test]
+fn test_is_bit_constraint_degree() {
+    let constraint = IsBitConstraint::new(0, 1, 0);
+    assert_eq!(constraint.degree(), 3);
+}
+
+#[test]
+fn test_add_constraint_degree() {
+    let (c0, c1) = AddConstraint::new_pair(0, 1, 3, 5, 0);
+    assert_eq!(c0.degree(), 3);
+    assert_eq!(c1.degree(), 3);
+}
+
+#[test]
+fn test_add_constraint_indices() {
+    let (c0, c1) = AddConstraint::new_pair(0, 1, 3, 5, 10);
+    assert_eq!(c0.constraint_idx(), 10);
+    assert_eq!(c1.constraint_idx(), 11);
+}
+
+// =========================================================================
+// IS_BIT formula verification tests
+// =========================================================================
+
+#[test]
+fn test_is_bit_formula_valid_zero() {
+    // IS_BIT formula: cond * X * (1 - X) = 0
+    // When X = 0: cond * 0 * 1 = 0 ✓
+    let cond = FE::one();
+    let x = FE::zero();
+    let result = &cond * &x * (FE::one() - &x);
+    assert_eq!(result, FE::zero());
+}
+
+#[test]
+fn test_is_bit_formula_valid_one() {
+    // IS_BIT formula: cond * X * (1 - X) = 0
+    // When X = 1: cond * 1 * 0 = 0 ✓
+    let cond = FE::one();
+    let x = FE::one();
+    let result = &cond * &x * (FE::one() - &x);
+    assert_eq!(result, FE::zero());
+}
+
+#[test]
+fn test_is_bit_formula_invalid_two() {
+    // IS_BIT formula: cond * X * (1 - X) = 0
+    // When X = 2: cond * 2 * (-1) = -2 ≠ 0 ✗
+    let cond = FE::one();
+    let x = FE::from(2u64);
+    let result = &cond * &x * (FE::one() - &x);
+    assert_ne!(result, FE::zero());
+}
+
+#[test]
+fn test_is_bit_formula_cond_zero() {
+    // IS_BIT formula: cond * X * (1 - X) = 0
+    // When cond = 0: 0 * X * (1 - X) = 0 always ✓
+    let cond = FE::zero();
+    let x = FE::from(42u64); // Any invalid value
+    let result = &cond * &x * (FE::one() - &x);
+    assert_eq!(result, FE::zero());
+}
+
+// =========================================================================
+// ADD carry computation verification tests
+// =========================================================================
+
+#[test]
+fn test_carry_computation_no_carry() {
+    // lhs_lo + rhs_lo < 2^32, so carry_0 = 0
+    let lhs_lo = FE::from(100u64);
+    let rhs_lo = FE::from(200u64);
+    let sum_lo = FE::from(300u64); // 100 + 200 = 300
+
+    let inv_2_32 = FE::from(SHIFT_32).inv().unwrap();
+    let carry = (&lhs_lo + &rhs_lo - &sum_lo) * &inv_2_32;
+
+    // carry should be 0
+    assert_eq!(carry, FE::zero());
+}
+
+#[test]
+fn test_carry_computation_with_carry() {
+    // lhs_lo + rhs_lo >= 2^32, so carry_0 = 1
+    let lhs_lo = FE::from(0xFFFFFFFFu64); // 2^32 - 1
+    let rhs_lo = FE::from(2u64);
+    // sum_lo = (0xFFFFFFFF + 2) mod 2^32 = 1
+    let sum_lo = FE::from(1u64);
+
+    let inv_2_32 = FE::from(SHIFT_32).inv().unwrap();
+    let carry = (&lhs_lo + &rhs_lo - &sum_lo) * &inv_2_32;
+
+    // carry should be 1: (0xFFFFFFFF + 2 - 1) / 2^32 = 0x100000000 / 2^32 = 1
+    assert_eq!(carry, FE::one());
+}
+
+#[test]
+fn test_carry_is_bit_valid() {
+    // When carry is 0, the IS_BIT constraint is satisfied
+    let carry = FE::zero();
+    let result = &carry * (FE::one() - &carry);
+    assert_eq!(result, FE::zero());
+
+    // When carry is 1, the IS_BIT constraint is satisfied
+    let carry = FE::one();
+    let result = &carry * (FE::one() - &carry);
+    assert_eq!(result, FE::zero());
+}
+
+#[test]
+fn test_carry_boundary_just_below() {
+    // lhs_lo + rhs_lo = 2^32 - 1 (no carry)
+    let lhs_lo = FE::from(0x80000000u64); // 2^31
+    let rhs_lo = FE::from(0x7FFFFFFFu64); // 2^31 - 1
+    let sum_lo = FE::from(0xFFFFFFFFu64); // 2^32 - 1
+
+    let inv_2_32 = FE::from(SHIFT_32).inv().unwrap();
+    let carry = (&lhs_lo + &rhs_lo - &sum_lo) * &inv_2_32;
+
+    assert_eq!(carry, FE::zero());
+}
+
+#[test]
+fn test_carry_boundary_exactly_2_32() {
+    // lhs_lo + rhs_lo = 2^32 (carry = 1)
+    let lhs_lo = FE::from(0x80000000u64); // 2^31
+    let rhs_lo = FE::from(0x80000000u64); // 2^31
+    let sum_lo = FE::from(0u64); // (2^31 + 2^31) mod 2^32 = 0
+
+    let inv_2_32 = FE::from(SHIFT_32).inv().unwrap();
+    let carry = (&lhs_lo + &rhs_lo - &sum_lo) * &inv_2_32;
+
+    assert_eq!(carry, FE::one());
+}
+
+#[test]
+fn test_carry_max_values() {
+    // lhs_lo = 0xFFFFFFFF, rhs_lo = 0xFFFFFFFF
+    // sum = 0x1FFFFFFFE, sum_lo = 0xFFFFFFFE, carry = 1
+    let lhs_lo = FE::from(0xFFFFFFFFu64);
+    let rhs_lo = FE::from(0xFFFFFFFFu64);
+    let sum_lo = FE::from(0xFFFFFFFEu64);
+
+    let inv_2_32 = FE::from(SHIFT_32).inv().unwrap();
+    let carry = (&lhs_lo + &rhs_lo - &sum_lo) * &inv_2_32;
+
+    assert_eq!(carry, FE::one());
+}
+
+// =========================================================================
+// Helper function tests
+// =========================================================================
+
+#[test]
+fn test_new_is_bit_constraints_count() {
+    let (constraints, next_idx) = new_is_bit_constraints(0, &[1, 2, 3, 4], 10);
+    assert_eq!(constraints.len(), 4);
+    assert_eq!(next_idx, 14);
+}
+
+#[test]
+fn test_new_is_bit_constraints_indices() {
+    let (constraints, _) = new_is_bit_constraints(0, &[5, 6, 7], 100);
+    assert_eq!(constraints[0].constraint_idx(), 100);
+    assert_eq!(constraints[1].constraint_idx(), 101);
+    assert_eq!(constraints[2].constraint_idx(), 102);
+}

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -3,6 +3,8 @@ pub mod integration_tests;
 
 // 64-bit VM tests
 #[cfg(test)]
+pub mod bitwise_bus_tests;
+#[cfg(test)]
 pub mod bitwise_tests;
 #[cfg(test)]
 pub mod constraints64_tests;

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -1,2 +1,8 @@
 pub mod cpu_table;
 pub mod integration_tests;
+
+// 64-bit VM tests
+#[cfg(test)]
+pub mod bitwise_tests;
+#[cfg(test)]
+pub mod constraints64_tests;


### PR DESCRIPTION
   ## 64-bit VM Prover - Initial Tables
  
  ### Summary

  Implements the foundation for the 64-bit VM prover using Goldilocks field with degree-3 extension (192-bit security).

  ### Changes

  **Core Types** (`prover/src/tables64/types.rs`)
  - Goldilocks prime field (p = 2^64 - 2^32 + 1) with Montgomery backend
  - Degree-3 cubic extension field (w³ = 2)
  - BusId enum for LogUp bus interactions

  **BITWISE Precomputed Table** (`prover/src/tables64/bitwise.rs`)
  - 2^20 rows (256 × 256 × 16) with 11 lookup types
  - Range checks: IS_BYTE, IS_HALF, IS_B20
  - Bitwise ops: AND_BYTE, OR_BYTE, XOR_BYTE, MSB8, MSB16, ZERO
  - Shift helpers: HWSL, HWSLC

  **Constraint Templates** (`prover/src/constraints64/templates.rs`)
  - `IsBitConstraint`: Enforces binary values via `cond * X * (1-X) = 0`
  - `AddConstraint`: 64-bit addition with embedded carry computation

  **QuadWL Packing** (`crypto/stark/src/lookup.rs`)
  - Added `QuadWL` variant for 4-word (128-bit) bus values

  ### Tests

  - Comprehensive edge case tests for BITWISE table (first/last row, MSB boundaries, shift boundaries)
  - Formula verification tests for IS_BIT and ADD carry computation
  - All 42 tests pass, clippy clean
