### PR TITLE
chore: move executor/Makefile to main directory

### DIFF
--- a/.github/workflows/hyperfine.yaml
+++ b/.github/workflows/hyperfine.yaml
@@ -43,8 +43,8 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p ${{ matrix.branch }}_programs
-          cd executor && make -j compile-bench
-          cp program_artifacts/bench/*.elf ../${{ matrix.branch }}_programs
+          make -j compile-bench
+          cp executor/program_artifacts/bench/*.elf ${{ matrix.branch }}_programs
 
       - name: Export benchmark hashes
         id: export-hashes

--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Compile ASM programs to ELF
         if: steps.cache-asm-elfs.outputs.cache-hit != 'true'
         run: |
-          cd executor && make compile-programs-asm
+          make compile-programs-asm
 
       - name: Cache compiled Rust ELF artifacts and build cache
         id: cache-rust-elfs
@@ -83,15 +83,15 @@ jobs:
       - name: Compile Rust programs to ELF
         if: steps.cache-rust-elfs.outputs.cache-hit != 'true'
         run: |
-          cd executor && make compile-programs-rust
+          make compile-programs-rust
 
-      - name: Run asm tests
+      - name: Run asm tests (no compile)
         run: |
-          cd executor && make test-asm-no-compile
+          make test-asm-no-compile
 
       - name: Run rust tests (no compile)
         run: |
-          cd executor && cargo test --test rust
+          make test-rust-no-compile
 
       - name: Run prover and crypto tests
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,12 +320,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -639,12 +633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "const-default"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,12 +787,6 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam"
@@ -1091,24 +1073,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "embedded-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2de9133f68db0d4627ad69db767726c99ff8585272716708227008d3f1bddd"
-dependencies = [
- "const-default",
- "critical-section",
- "linked_list_allocator",
- "rlsf",
-]
-
-[[package]]
-name = "embedded-hal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "enum-ordinalize"
@@ -2164,19 +2128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lambda-vm-syscalls"
-version = "0.1.0"
-dependencies = [
- "embedded-alloc",
- "getrandom 0.2.16",
- "getrandom 0.3.4",
- "lazy_static",
- "rand 0.9.2",
- "riscv",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "lambdaworks-crypto"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2242,12 +2193,6 @@ dependencies = [
  "clap 4.5.53",
  "escape8259",
 ]
-
-[[package]]
-name = "linked_list_allocator"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3311,36 +3256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "riscv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05cfa3f7b30c84536a9025150d44d26b8e1cc20ddf436448d74cd9591eefb25"
-dependencies = [
- "critical-section",
- "embedded-hal",
- "paste",
- "riscv-macros",
- "riscv-pac",
-]
-
-[[package]]
-name = "riscv-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d323d13972c1b104aa036bc692cd08b822c8bbf23d79a27c526095856499799"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "riscv-pac"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
-
-[[package]]
 name = "rkyv"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3378,18 +3293,6 @@ checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlsf"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222fb240c3286247ecdee6fa5341e7cdad0ffdf8e7e401d9937f2d58482a20bf"
-dependencies = [
- "cfg-if",
- "const-default",
- "libc",
- "svgbobdoc",
 ]
 
 [[package]]
@@ -3629,7 +3532,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3881,19 +3784,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "svgbobdoc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
-dependencies = [
- "base64 0.13.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-width",
-]
 
 [[package]]
 name = "symbolic-common"
@@ -4282,12 +4172,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ members = [
   "crypto/crypto",
   "crypto/math",
   "bin/cli",
-  "syscalls",
 ]
 
 resolver = "2"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: deps deps-linux deps-macos prepare-test-data compile-programs-asm compile-programs-rust compile-bench \
 compile-programs clean-asm clean-rust clean-bench clean-shared clean test test-asm test-no-compile \
-test-asm-no-compile test-rust test-rust-no-compile
+test-asm-no-compile test-rust test-rust-no-compile test-executor
 
 UNAME := $(shell uname)
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,36 @@
+.PHONY: deps deps-linux deps-macos prepare-test-data compile-programs-asm compile-programs-rust compile-bench \
+compile-programs clean-asm clean-rust clean-bench clean-shared clean test test-asm test-no-compile \
+test-asm-no-compile test-rust test-rust-no-compile
+
 UNAME := $(shell uname)
 
-ASM_PROGRAMS_DIR=./programs/asm
-ASM_ARTIFACTS_DIR=./program_artifacts/asm
+deps:
+ifeq ($(UNAME), Linux)
+deps: deps-linux
+endif
+ifeq ($(UNAME), Darwin)
+deps: deps-macos
+endif
 
-RUST_PROGRAMS_DIR=./programs/rust
-RUST_ARTIFACTS_DIR=./program_artifacts/rust
+deps-linux:
+	@# TODO
+	@echo "not yet implemented"
+	@exit 1
 
-BENCH_PROGRAMS_DIR=./programs/bench
-BENCH_ARTIFACTS_DIR=./program_artifacts/bench
+deps-macos:
+	brew tap riscv-software-src/riscv
+	brew install riscv-software-src/riscv/riscv-gnu-toolchain
 
-SHARED_TARGET_DIR=./shared_target
+ASM_PROGRAMS_DIR=./executor/programs/asm
+ASM_ARTIFACTS_DIR=./executor/program_artifacts/asm
+
+RUST_PROGRAMS_DIR=./executor/programs/rust
+RUST_ARTIFACTS_DIR=./executor/program_artifacts/rust
+
+BENCH_PROGRAMS_DIR=./executor/programs/bench
+BENCH_ARTIFACTS_DIR=./executor/program_artifacts/bench
+
+SHARED_TARGET_DIR=./executor/shared_target
 
 ASM_PROGRAMS = $(wildcard $(ASM_PROGRAMS_DIR)/*.s)
 ARTIFACTS_ASM = $(patsubst $(ASM_PROGRAMS_DIR)/%.s, $(ASM_ARTIFACTS_DIR)/%.elf, $(ASM_PROGRAMS))
@@ -22,13 +43,11 @@ BENCH_PROGRAM_DIRS := $(dir $(wildcard $(BENCH_PROGRAMS_DIR)/*/Cargo.toml))
 BENCH_PROGRAMS := $(notdir $(basename $(BENCH_PROGRAM_DIRS:%/=%)))
 BENCH_ARTIFACTS := $(addprefix $(BENCH_ARTIFACTS_DIR)/, $(addsuffix .elf, $(BENCH_PROGRAMS)))
 
-ETHREX_FILE := tests/ethrex_hoodi.bin
+ETHREX_FILE := executor/tests/ethrex_hoodi.bin
 ETHREX_URL := https://lambda.alignedlayer.com/ethrex_hoodi.bin
 
 # Custom RV64IM target spec location
-RV64_TARGET_SPEC=$(CURDIR)/programs/riscv64im-lambda-vm-elf.json
-
-.PHONY: test prepare-test-data
+RV64_TARGET_SPEC=$(CURDIR)/executor/programs/riscv64im-lambda-vm-elf.json
 
 prepare-test-data:
 	@if [ ! -f "$(ETHREX_FILE)" ]; then \
@@ -87,35 +106,21 @@ clean-shared:
 
 clean: clean-asm clean-rust clean-bench clean-shared
 
-test: compile-programs test-no-compile
+test-executor: compile-programs test-no-compile
 
 test-asm: compile-programs-asm test-asm-no-compile
 
 test-asm-no-compile:
-	cargo test --test asm
+	cargo test -p executor --test asm
 
 test-rust: compile-programs-rust prepare-test-data
-	cargo test --test rust
+	cargo test -p executor --test rust
+
+test-rust-no-compile:
+	cargo test -p executor --test rust
 
 test-no-compile: prepare-test-data
+	cargo test -p executor
+
+test: compile-programs prepare-test-data
 	cargo test
-
-.PHONY: deps
-deps:
-ifeq ($(UNAME), Linux)
-deps: deps-linux
-endif
-ifeq ($(UNAME), Darwin)
-deps: deps-macos
-endif
-
-.PHONY: deps-linux
-deps-linux:
-	@# TODO
-	@echo "not yet implemented"
-	@exit 1
-
-.PHONY: deps-macos
-deps-macos:
-	brew tap riscv-software-src/riscv
-	brew install riscv-software-src/riscv/riscv-gnu-toolchain

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ source ~/.zshrc
 #### Install the dependencies
 
 ```sh
-cd executor
 make deps
 ```
 
@@ -89,7 +88,7 @@ make deps
 Then, you can check that the executor works by running:
 
 ```sh
-make test
+make test-executor
 ```
 
 ## Design choices
@@ -115,6 +114,10 @@ Full documentation can be found in [docs](./docs/). It is currently a work in pr
 
 ## Testing
 
+To run all tests across the project use
+
+`make test`
+
 ### ASM Tests
 
 In order to add a new asm test you should add the `.s` file under `programs/asm`
@@ -122,7 +125,7 @@ Then add the corresponding test under `tests/asm.rs`
 
 To run them you can use
 
-`make test`
+`make test-asm`
 
 This will compile them and run the tests
 
@@ -134,7 +137,7 @@ Then add the corresponding test under `tests/rust.rs`
 
 You can run it with
 
-`make test`
+`make test-rust`
 
 ## Roadmap for the virtual machine
 


### PR DESCRIPTION
* Move executor Makefile to main directory
* Fix workflows relying on Makefile location
* Update README
* Remove `syscalls` from workspace so we can compile the full project

NOTE: Hyperfine workflow is currently not working as the base branch has the Makefile on a different location, should work fine once merged