### PR TITLE
ci: add warmup for hyperfine benchmarks

### DIFF
--- a/.github/workflows/hyperfine.yaml
+++ b/.github/workflows/hyperfine.yaml
@@ -147,7 +147,7 @@ jobs:
           fi
           find target_programs -name '*.elf' -exec basename -s .elf '{}' '+' | \
           sort | xargs -I '{program}' \
-          hyperfine -N -r 10 --export-markdown "target_programs/{program}.md" \
+          hyperfine -N -w 5 -r 10 --export-markdown "target_programs/{program}.md" \
           -L bin "$BINS" -n "{bin} {program}" \
           -s "cat ./bench-bin/cli-{bin} target_programs/{program}.elf" \
           "./bench-bin/cli-{bin} target_programs/{program}.elf"


### PR DESCRIPTION
Set warmup runs for hyperfine workflow to get more stable benchmark results