### PR TITLE
Update setup and dependencies sections

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -14,24 +14,3 @@ runs:
       uses: dtolnay/rust-toolchain@nightly
       with:
         components: rust-src
-
-    # Custom lambda toolchain - commented out, not recreated for 64-bit yet
-    # - name: Cache Rust toolchain
-    #   id: cache-rust
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: ~/lambda_rust
-    #     key: lambda-rust-toolchain-v1
-    #
-    # - name: Download Rust
-    #   if: steps.cache-rust.outputs.cache-hit != 'true'
-    #   shell: bash
-    #   run: |
-    #     cd $HOME
-    #     wget https://lambda.alignedlayer.com/lambda_rust.tar.gz
-    #     tar -xzvf lambda_rust.tar.gz
-    #     rm lambda_rust.tar.gz
-    #
-    # - name: Add Rust to PATH
-    #   shell: bash
-    #   run: echo "$HOME/lambda_rust/usr/local/bin" >> $GITHUB_PATH

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Right now, this is a project under development and experimentation and must not 
 
 ### Dependencies
 
-- Our Rust fork with support for our riscv target
+- Rust nightly with `rust-src` component
 - Risc-V toolchain (To run executor tests)
 
 ### Dev dependencies
@@ -19,66 +19,19 @@ Right now, this is a project under development and experimentation and must not 
 
 ### Setup executor
 
-#### Install Our Rust Fork
+#### Install Rust
 
-First remove rust if you already have it installed
-
-```sh
-rustup self uninstall
-```
-
-You can install it from source or use our pre-installed binaries
-
-##### Install from source
+Install Rust using [rustup](https://rustup.rs/):
 
 ```sh
-git clone https://github.com/yetanotherco/rust.git
-cd rust
-```
-Add `bootstrap.toml` file:
-
-```toml
-profile = "dist"
-change-id = 149355
-rust.lld = true
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-Export the directory where you want rust to be installed
+Then install the nightly toolchain with the `rust-src` component (required for building `std` for the custom RISC-V target):
 
 ```sh
-export DESTDIR=<Your_rust_destiny_dir>
-```
-
-Run the rust installation
-```sh
-./x.py build && ./x.py install
-```
-
-##### Download pre-installed binaries
-
-For mac
-
-```sh
-wget lambda.alignedlayer.com/lambda_rust_mac.zip
-```
-
-For linux
-
-```sh
-wget https://lambda.alignedlayer.com/lambda_rust.tar.gz
-```
-
-Then unzip it.
-
-Note that your system may prevent execution because the binaries were compiled on another machine. You may need to grant explicit permission to run them.
-
-##### Add to path
-
-Add the rust directory to your path
-
-```sh
-export PATH="/<your_rust_path>/usr/local/bin:$PATH"
-source ~/.zshrc
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
 ```
 
 #### Compile sysroot

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Right now, this is a project under development and experimentation and must not 
 ### Dependencies
 
 - Rust nightly with `rust-src` component
-- Risc-V toolchain (To run executor tests)
 
 ### Dev dependencies
 


### PR DESCRIPTION
Removes outdated Rust fork setup sections and replaces them with Rust nightly setup.
Removes Risc-V dependency.
Removes commented jobs that used the Rust fork.