### PR TITLE
fix(executor): stable Rust compatibility

### DIFF
--- a/executor/programs/bench/hashmap/Cargo.toml
+++ b/executor/programs/bench/hashmap/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "hashmap"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 lambda-vm-syscalls = { path = "../../../../syscalls" }

--- a/executor/programs/bench/keccak/Cargo.toml
+++ b/executor/programs/bench/keccak/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "keccak"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 lambda-vm-syscalls = { path = "../../../../syscalls" }

--- a/executor/src/vm/execution.rs
+++ b/executor/src/vm/execution.rs
@@ -155,7 +155,7 @@ impl InstructionCache {
         };
 
         let byte_offset = pc - segment.base_addr;
-        if !byte_offset.is_multiple_of(4) {
+        if byte_offset % 4 != 0 {
             return None;
         }
         segment.instructions.get((byte_offset / 4) as usize)


### PR DESCRIPTION
## Summary

Fixes stable Rust compatibility issues in PR #229.

### Changes

- **Edition 2024 → 2021**: The benchmark programs (`hashmap`, `keccak`) specified `edition = "2024"` which doesn't exist yet. Changed to `edition = "2021"`.

- **`is_multiple_of` → modulo operator**: The `is_multiple_of` method requires the nightly feature `int_roundings`. Replaced with standard modulo operator for stable Rust compatibility.

## Test plan

- [ ] Verify benchmark programs compile with stable Rust
- [ ] Run executor tests to ensure alignment check still works