### PR TITLE
feat(math): add From<i64> for Goldilocks field elements

### DIFF
--- a/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/extensions_goldilocks.rs
@@ -171,6 +171,20 @@ impl Fp2E {
     pub fn conjugate(&self) -> Self {
         Self::new([self.value()[0], -self.value()[1]])
     }
+
+    /// Create a field element from an i64.
+    /// Negative values are converted to their field equivalents: -x becomes p - x.
+    pub fn from_i64(value: i64) -> Self {
+        Self::from(value)
+    }
+}
+
+/// From overloading for i64 (Fp2 Goldilocks extension-specific).
+/// Negative values are converted to their field equivalents.
+impl From<i64> for Fp2E {
+    fn from(value: i64) -> Self {
+        Self::new([FpE::from(value), FpE::zero()])
+    }
 }
 
 // =====================================================
@@ -358,6 +372,22 @@ impl IsSubFieldOf<Degree3GoldilocksExtensionField> for GoldilocksField {
 /// Field element type for the cubic extension of native Goldilocks
 pub type Fp3E = FieldElement<Degree3GoldilocksExtensionField>;
 
+impl Fp3E {
+    /// Create a field element from an i64.
+    /// Negative values are converted to their field equivalents: -x becomes p - x.
+    pub fn from_i64(value: i64) -> Self {
+        Self::from(value)
+    }
+}
+
+/// From overloading for i64 (Fp3 Goldilocks extension-specific).
+/// Negative values are converted to their field equivalents.
+impl From<i64> for Fp3E {
+    fn from(value: i64) -> Self {
+        Self::new([FpE::from(value), FpE::zero(), FpE::zero()])
+    }
+}
+
 // =====================================================
 // TRAIT IMPLEMENTATIONS FOR PROVER/VERIFIER
 // =====================================================
@@ -509,5 +539,64 @@ mod tests {
         let a = FpE::from(5u64);
         let result = mul_by_7(&a);
         assert_eq!(result, FpE::from(35u64));
+    }
+
+    // =========================================================================
+    // Tests for From<i64> implementations
+    // =========================================================================
+
+    #[test]
+    fn test_fp2_from_i64_positive() {
+        let fe = Fp2E::from(42i64);
+        assert_eq!(fe.value()[0], FpE::from(42u64));
+        assert_eq!(fe.value()[1], FpE::zero());
+    }
+
+    #[test]
+    fn test_fp2_from_i64_negative() {
+        // -1 in the base field embedded into Fp2
+        let fe = Fp2E::from(-1i64);
+        let expected = Fp2E::new([FpE::from(-1i64), FpE::zero()]);
+        assert_eq!(fe, expected);
+
+        // Verify: -1 + 1 = 0
+        let one = Fp2E::one();
+        assert_eq!(fe + one, Fp2E::zero());
+    }
+
+    #[test]
+    fn test_fp2_from_i64_arithmetic() {
+        let five = Fp2E::from(5i64);
+        let ten = Fp2E::from(10i64);
+        let minus_five = Fp2E::from(-5i64);
+        assert_eq!(five - ten, minus_five);
+    }
+
+    #[test]
+    fn test_fp3_from_i64_positive() {
+        let fe = Fp3E::from(42i64);
+        assert_eq!(fe.value()[0], FpE::from(42u64));
+        assert_eq!(fe.value()[1], FpE::zero());
+        assert_eq!(fe.value()[2], FpE::zero());
+    }
+
+    #[test]
+    fn test_fp3_from_i64_negative() {
+        // -1 in the base field embedded into Fp3
+        let fe = Fp3E::from(-1i64);
+        let expected = Fp3E::new([FpE::from(-1i64), FpE::zero(), FpE::zero()]);
+        assert_eq!(fe, expected);
+
+        // Verify: -1 + 1 = 0
+        let one = Fp3E::one();
+        assert_eq!(fe + one, Fp3E::zero());
+    }
+
+    #[test]
+    fn test_fp3_from_i64_arithmetic() {
+        let five = Fp3E::from(5i64);
+        let ten = Fp3E::from(10i64);
+        let minus_five = Fp3E::from(-5i64);
+        assert_eq!(five - ten, minus_five);
     }
 }

--- a/crypto/math/src/field/fields/fft_friendly/u64_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/u64_goldilocks.rs
@@ -284,6 +284,25 @@ impl GoldilocksElement {
     pub fn to_bytes_be(&self) -> [u8; 8] {
         self.to_canonical_u64().to_be_bytes()
     }
+
+    /// Create a field element from an i64.
+    /// Negative values are converted to their field equivalents: -x becomes p - x.
+    pub fn from_i64(value: i64) -> Self {
+        Self::from(value)
+    }
+}
+
+/// From overloading for i64 (Goldilocks-specific).
+/// Negative values are converted to their field equivalents: -x becomes p - x.
+impl From<i64> for GoldilocksElement {
+    fn from(value: i64) -> Self {
+        if value >= 0 {
+            Self::from(value as u64)
+        } else {
+            // For negative values: -x ≡ p - x (mod p)
+            -Self::from(value.unsigned_abs())
+        }
+    }
 }
 
 // =====================================================
@@ -474,5 +493,97 @@ mod tests {
                 a
             );
         }
+    }
+
+    // =========================================================================
+    // Tests for From<i64> implementation
+    // =========================================================================
+
+    #[test]
+    fn test_from_i64_positive() {
+        // Positive i64 values should work like u64
+        let fe_from_i64 = GoldilocksElement::from(42i64);
+        let fe_from_u64 = GoldilocksElement::from(42u64);
+        assert_eq!(fe_from_i64, fe_from_u64);
+    }
+
+    #[test]
+    fn test_from_i64_zero() {
+        let fe = GoldilocksElement::from(0i64);
+        assert_eq!(fe, GoldilocksElement::zero());
+    }
+
+    #[test]
+    fn test_from_i64_negative_one() {
+        // -1 should equal p - 1
+        let fe = GoldilocksElement::from(-1i64);
+        let expected = GoldilocksElement::from(GOLDILOCKS_PRIME - 1);
+        assert_eq!(fe, expected);
+
+        // Also verify: -1 + 1 = 0
+        let one = GoldilocksElement::one();
+        assert_eq!(fe + one, GoldilocksElement::zero());
+    }
+
+    #[test]
+    fn test_from_i64_negative_values() {
+        // -x should equal p - x, which means x + (-x) = 0
+        for x in [1i64, 5, 100, 1000, 123456789] {
+            let pos = GoldilocksElement::from(x);
+            let neg = GoldilocksElement::from(-x);
+            assert_eq!(pos + neg, GoldilocksElement::zero(), "Failed for x = {}", x);
+        }
+    }
+
+    #[test]
+    fn test_from_i64_negative_equals_negation() {
+        // FE::from(-x) should equal -FE::from(x)
+        for x in [1i64, 42, 1000, 999999] {
+            let from_neg = GoldilocksElement::from(-x);
+            let neg_from = -GoldilocksElement::from(x);
+            assert_eq!(from_neg, neg_from, "Failed for x = {}", x);
+        }
+    }
+
+    #[test]
+    fn test_from_i64_arithmetic() {
+        // Test that arithmetic works correctly with i64-created elements
+        // 5 - 10 = -5
+        let five = GoldilocksElement::from(5i64);
+        let ten = GoldilocksElement::from(10i64);
+        let minus_five = GoldilocksElement::from(-5i64);
+
+        assert_eq!(five - ten, minus_five);
+    }
+
+    #[test]
+    fn test_from_i64_large_negative() {
+        // Test with larger negative values
+        let large_neg = GoldilocksElement::from(-1_000_000_000i64);
+        let large_pos = GoldilocksElement::from(1_000_000_000i64);
+
+        // They should sum to zero
+        assert_eq!(large_neg + large_pos, GoldilocksElement::zero());
+
+        // And the negative should equal the negation of positive
+        assert_eq!(large_neg, -large_pos);
+    }
+
+    #[test]
+    fn test_from_i64_min_value() {
+        // Test with i64::MIN - this is a valid field element
+        let min_val = GoldilocksElement::from(i64::MIN);
+        // i64::MIN = -2^63, so this should be p - 2^63
+        let expected_val = GOLDILOCKS_PRIME - (1u64 << 63);
+        let expected = GoldilocksElement::from(expected_val);
+        assert_eq!(min_val, expected);
+    }
+
+    #[test]
+    fn test_from_i64_max_value() {
+        // Test with i64::MAX
+        let max_val = GoldilocksElement::from(i64::MAX);
+        let expected = GoldilocksElement::from(i64::MAX as u64);
+        assert_eq!(max_val, expected);
     }
 }


### PR DESCRIPTION
Add From<i64> implementation for GoldilocksElement and its extensions (Fp2E, Fp3E). This allows creating field elements from signed integers, which is commonly used in the virtual machine.

Negative values are converted to their field equivalents: -x becomes p - x.

Changes:
- Add From<i64> for GoldilocksElement with from_i64() method
- Add From<i64> for Fp2E (quadratic extension)
- Add From<i64> for Fp3E (cubic extension)
- Add comprehensive tests for all implementations