### PR TITLE
refactor(prover): Refactor trace generation to phased collection architecture

### DIFF
--- a/prover/src/tables/lt.rs
+++ b/prover/src/tables/lt.rs
@@ -120,6 +120,95 @@ impl LtOperation {
             self.lhs < self.rhs
         }
     }
+
+    /// Collects bitwise lookups for this LT operation.
+    ///
+    /// From spec lt.md:
+    /// - MSB16[lhs[2]] → lhs_msb (bits 48-63)
+    /// - MSB16[rhs[2]] → rhs_msb (bits 48-63)
+    /// - IS_HALFWORD[lhs_sub_rhs[i]] × 4 (all 4 halfwords)
+    /// - IS_HALFWORD[lhs[1]] (bits 32-47)
+    /// - IS_HALFWORD[rhs[1]] (bits 32-47)
+    pub fn collect_bitwise_lookups(
+        &self,
+    ) -> Vec<(super::bitwise::BitwiseLookup, u8, u8, u8)> {
+        use super::bitwise::BitwiseLookup;
+        let mut lookups = Vec::with_capacity(8);
+
+        // Extract halfwords
+        let lhs_1 = ((self.lhs >> 32) & 0xFFFF) as u16; // bits 32-47
+        let lhs_2 = ((self.lhs >> 48) & 0xFFFF) as u16; // bits 48-63
+
+        let rhs_1 = ((self.rhs >> 32) & 0xFFFF) as u16; // bits 32-47
+        let rhs_2 = ((self.rhs >> 48) & 0xFFFF) as u16; // bits 48-63
+
+        // Compute lhs_sub_rhs = lhs - rhs (wrapping)
+        let lhs_sub_rhs = self.lhs.wrapping_sub(self.rhs);
+        let sub_0 = (lhs_sub_rhs & 0xFFFF) as u16;
+        let sub_1 = ((lhs_sub_rhs >> 16) & 0xFFFF) as u16;
+        let sub_2 = ((lhs_sub_rhs >> 32) & 0xFFFF) as u16;
+        let sub_3 = ((lhs_sub_rhs >> 48) & 0xFFFF) as u16;
+
+        // MSB16[lhs[2]] → lhs_msb
+        lookups.push((
+            BitwiseLookup::Msb16,
+            (lhs_2 & 0xFF) as u8,
+            ((lhs_2 >> 8) & 0xFF) as u8,
+            0,
+        ));
+
+        // MSB16[rhs[2]] → rhs_msb
+        lookups.push((
+            BitwiseLookup::Msb16,
+            (rhs_2 & 0xFF) as u8,
+            ((rhs_2 >> 8) & 0xFF) as u8,
+            0,
+        ));
+
+        // IS_HALFWORD[lhs_sub_rhs[0..3]] × 4
+        lookups.push((
+            BitwiseLookup::IsHalf,
+            (sub_0 & 0xFF) as u8,
+            ((sub_0 >> 8) & 0xFF) as u8,
+            0,
+        ));
+        lookups.push((
+            BitwiseLookup::IsHalf,
+            (sub_1 & 0xFF) as u8,
+            ((sub_1 >> 8) & 0xFF) as u8,
+            0,
+        ));
+        lookups.push((
+            BitwiseLookup::IsHalf,
+            (sub_2 & 0xFF) as u8,
+            ((sub_2 >> 8) & 0xFF) as u8,
+            0,
+        ));
+        lookups.push((
+            BitwiseLookup::IsHalf,
+            (sub_3 & 0xFF) as u8,
+            ((sub_3 >> 8) & 0xFF) as u8,
+            0,
+        ));
+
+        // IS_HALFWORD[lhs[1]]
+        lookups.push((
+            BitwiseLookup::IsHalf,
+            (lhs_1 & 0xFF) as u8,
+            ((lhs_1 >> 8) & 0xFF) as u8,
+            0,
+        ));
+
+        // IS_HALFWORD[rhs[1]]
+        lookups.push((
+            BitwiseLookup::IsHalf,
+            (rhs_1 & 0xFF) as u8,
+            ((rhs_1 >> 8) & 0xFF) as u8,
+            0,
+        ));
+
+        lookups
+    }
 }
 
 /// Generates the LT trace table from a list of operations.

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -1,14 +1,30 @@
 //! Trace generation from execution logs.
 //!
-//! This module provides a single entry point for generating all trace tables
-//! from execution logs in a single pass.
+//! This module uses a phased collection approach where each table's operations
+//! are collected in explicit phases based on their dependencies.
+//!
+//! ## Architecture
+//!
+//! The trace generation follows this dependency graph:
+//!
+//! ```text
+//! PHASE 1: Logs → CPU ops
+//! PHASE 2: CPU → LT ops (SLT/BLT), Bitwise lookups
+//! PHASE 3: LT → Bitwise lookups
+//! ```
+//!
+//! Future phases (to be added):
+//! - PHASE 2+: CPU → MEMW, LOAD, SHIFT, MUL, BRANCH
+//! - PHASE 3+: LOAD → MEMW
+//! - PHASE 4+: MEMW → LT (timestamp ordering)
+//! - PHASE 5+: All tables → Bitwise lookups
 //!
 //! ## Usage
 //!
 //! ```ignore
 //! use prover::tables::trace_builder::Traces;
 //!
-//! let traces = Traces::from_logs(&logs)?;
+//! let traces = Traces::from_logs(&logs, instructions)?;
 //! // Use traces.cpu, traces.bitwise, traces.lt
 //! ```
 
@@ -17,11 +33,213 @@ use executor::vm::logs::Log;
 use executor::vm::memory::U64HashMap;
 use stark::trace::TraceTable;
 
-use super::bitwise;
+use super::bitwise::{self, BitwiseLookup};
 use super::cpu::{self, CpuOperation};
 use super::lt::{self, LtOperation};
 use super::types::{GoldilocksExtension, GoldilocksField};
 use crate::ProverError;
+
+// =============================================================================
+// Collection Context
+// =============================================================================
+
+/// Central context for collecting all operations during trace generation.
+///
+/// This struct accumulates operations from all phases. Add new fields as you
+/// implement new tables.
+pub struct CollectionContext {
+    // =========================================================================
+    // Primary operations (from logs)
+    // =========================================================================
+    /// CPU operations - one per instruction
+    pub cpu_ops: Vec<CpuOperation>,
+
+    // =========================================================================
+    // Secondary operations (from CPU)
+    // =========================================================================
+    /// LT operations for comparisons (SLT, BLT instructions)
+    pub lt_ops: Vec<LtOperation>,
+
+    // TODO: Add these fields when implementing the tables:
+    // pub memw_ops: Vec<MemwOperation>,
+    // pub load_ops: Vec<LoadOperation>,
+    // pub shift_ops: Vec<ShiftOperation>,
+    // pub mul_ops: Vec<MulOperation>,
+    // pub branch_ops: Vec<BranchOperation>,
+    // pub divrem_ops: Vec<DivRemOperation>,
+
+    // =========================================================================
+    // State trackers (for memory consistency)
+    // =========================================================================
+    // TODO: Add these when implementing MEMW:
+    // pub memory_state: MemoryState,
+    // pub register_state: RegisterState,
+
+    // =========================================================================
+    // Lookups (accumulated from all tables)
+    // =========================================================================
+    /// Bitwise lookups accumulated from all tables
+    pub bitwise_lookups: Vec<(BitwiseLookup, u8, u8, u8)>,
+}
+
+impl CollectionContext {
+    /// Creates a new empty collection context with pre-allocated capacity.
+    pub fn new(estimated_instructions: usize) -> Self {
+        Self {
+            cpu_ops: Vec::with_capacity(estimated_instructions),
+            lt_ops: Vec::with_capacity(estimated_instructions / 10 + 1),
+            bitwise_lookups: Vec::with_capacity(estimated_instructions * 4),
+        }
+    }
+}
+
+// =============================================================================
+// Phase 1: Logs → CPU
+// =============================================================================
+
+/// Processes execution logs into CPU operations.
+///
+/// This is the entry point - all other operations derive from CPU ops.
+pub fn collect_cpu_from_logs(
+    ctx: &mut CollectionContext,
+    logs: &[Log],
+    instructions: &U64HashMap<Instruction>,
+) -> Result<(), ProverError> {
+    for (i, log) in logs.iter().enumerate() {
+        // Timestamp: 4 units per instruction, starting at 4 (not 0)
+        // Starting at 4 ensures first memory access has old_timestamp(0) < timestamp(4)
+        let timestamp = (i as u64 + 1) * 4;
+
+        let instruction = instructions
+            .get(&log.current_pc)
+            .copied()
+            .ok_or(ProverError::MissingInstruction(log.current_pc))?;
+
+        let cpu_op = CpuOperation::from_log(log, timestamp, instruction);
+        ctx.cpu_ops.push(cpu_op);
+    }
+    Ok(())
+}
+
+// =============================================================================
+// Phase 2: CPU → Secondary tables
+// =============================================================================
+
+/// Collects LT operations from CPU (SLT and BLT instructions).
+///
+/// From spec cpu.md constraint A3:
+/// `LT[res[0]; arg1::DWordWL, arg2::DWordWL, signed]` with multiplicity SLT + BLT
+pub fn collect_lt_from_cpu(ctx: &mut CollectionContext) {
+    for cpu_op in &ctx.cpu_ops {
+        if cpu_op.op_slt || cpu_op.op_blt {
+            let arg1 = cpu_op.compute_arg1();
+            let arg2 = cpu_op.compute_arg2();
+            ctx.lt_ops.push(LtOperation::new(arg1, arg2, cpu_op.signed));
+        }
+    }
+}
+
+/// Collects bitwise lookups directly from CPU operations.
+///
+/// From spec cpu.md:
+/// - A5: AND_BYTE[res[i]; arg1[i], arg2[i]] × 8 (multiplicity: AND)
+/// - A6: OR_BYTE[res[i]; arg1[i], arg2[i]] × 8 (multiplicity: OR)
+/// - A7: XOR_BYTE[res[i]; arg1[i], arg2[i]] × 8 (multiplicity: XOR)
+/// - E2: MSB16[rv1_sign_bit; rv1[1]] (multiplicity: word_instr)
+/// - E5: MSB16[arg2_sign_bit; rv2[1]] (multiplicity: word_instr)
+/// - E8: MSB8[res_sign_bit; res[3]] (multiplicity: word_instr)
+/// - is_equal: ZERO[is_equal; sum(res)] (multiplicity: BEQ)
+/// - R28-R33: IS_BYTE range checks
+pub fn collect_bitwise_from_cpu(ctx: &mut CollectionContext) {
+    for cpu_op in &ctx.cpu_ops {
+        ctx.bitwise_lookups.extend(cpu_op.collect_bitwise_lookups());
+    }
+}
+
+// TODO: Add these functions when implementing the tables:
+//
+// /// Collects MEMW operations from CPU (register reads/writes, stores, PC).
+// /// From spec cpu.md: M1, M3, M5, M7, M8
+// pub fn collect_memw_from_cpu(ctx: &mut CollectionContext) { ... }
+//
+// /// Collects LOAD operations from CPU.
+// /// From spec cpu.md: M6
+// pub fn collect_load_from_cpu(ctx: &mut CollectionContext) { ... }
+//
+// /// Collects SHIFT operations from CPU.
+// /// From spec cpu.md: A8
+// pub fn collect_shift_from_cpu(ctx: &mut CollectionContext) { ... }
+//
+// /// Collects MUL operations from CPU.
+// /// From spec cpu.md: A10
+// pub fn collect_mul_from_cpu(ctx: &mut CollectionContext) { ... }
+//
+// /// Collects BRANCH operations from CPU.
+// /// From spec cpu.md: O3
+// pub fn collect_branch_from_cpu(ctx: &mut CollectionContext) { ... }
+
+// =============================================================================
+// Phase 3: LOAD → MEMW (to be implemented)
+// =============================================================================
+
+// TODO: Add when implementing LOAD:
+// /// Collects MEMW operations from LOAD (memory reads).
+// /// From spec load.md constraint 2: MEMW[res; 0, base_address, ...]
+// pub fn collect_memw_from_load(ctx: &mut CollectionContext) { ... }
+
+// =============================================================================
+// Phase 4: MEMW → LT (to be implemented)
+// =============================================================================
+
+// TODO: Add when implementing MEMW:
+// /// Collects LT operations from MEMW (timestamp ordering).
+// /// From spec memw.md constraints 7-10: LT[1; old_timestamp[i], timestamp, 0]
+// /// From spec memw.md constraints R1-R3: overflow checks
+// pub fn collect_lt_from_memw(ctx: &mut CollectionContext) { ... }
+
+// =============================================================================
+// Phase 5: All tables → Bitwise lookups
+// =============================================================================
+
+/// Collects bitwise lookups from LT operations.
+///
+/// From spec lt.md:
+/// - lt:c:lhs_msb: MSB16[lhs_msb; lhs[2]] (multiplicity: μ)
+/// - lt:c:rhs_msb: MSB16[rhs_msb; rhs[2]] (multiplicity: μ)
+/// - lt:c:range_lhs: IS_HALFWORD[lhs[1]] (multiplicity: μ)
+/// - lt:c:range_rhs: IS_HALFWORD[rhs[1]] (multiplicity: μ)
+/// - lt:c:lhs_sub_rhs_range: IS_HALFWORD[lhs_sub_rhs[i]] × 4 (multiplicity: μ)
+pub fn collect_bitwise_from_lt(ctx: &mut CollectionContext) {
+    for lt_op in &ctx.lt_ops {
+        ctx.bitwise_lookups.extend(lt_op.collect_bitwise_lookups());
+    }
+}
+
+// TODO: Add these functions when implementing the tables:
+//
+// /// Collects bitwise lookups from MEMW (IS_HALFWORD for address_add).
+// /// From spec memw.md constraint 6: IS_HALFWORD[address_add[i][j]]
+// pub fn collect_bitwise_from_memw(ctx: &mut CollectionContext) { ... }
+//
+// /// Collects bitwise lookups from LOAD (MSB8 for sign bit).
+// /// From spec load.md constraints 3-5: MSB8[sign_bit; res[k]]
+// pub fn collect_bitwise_from_load(ctx: &mut CollectionContext) { ... }
+//
+// /// Collects bitwise lookups from SHIFT.
+// /// From spec shift.md: HWSL, HWSLC, AND_BYTE, MSB16
+// pub fn collect_bitwise_from_shift(ctx: &mut CollectionContext) { ... }
+//
+// /// Collects bitwise lookups from MUL.
+// /// From spec mul.md: IS_B20 for carry
+// pub fn collect_bitwise_from_mul(ctx: &mut CollectionContext) { ... }
+//
+// /// Collects bitwise lookups from BRANCH.
+// /// From spec branch.md: IS_BYTE, AND_BYTE, IS_HALFWORD
+// pub fn collect_bitwise_from_branch(ctx: &mut CollectionContext) { ... }
+
+// =============================================================================
+// Trace Generation
+// =============================================================================
 
 /// All generated trace tables.
 pub struct Traces {
@@ -33,50 +251,92 @@ pub struct Traces {
 
     /// LT comparison trace (deduplicated operations)
     pub lt: TraceTable<GoldilocksField, GoldilocksExtension>,
+
+    // TODO: Add these fields when implementing the tables:
+    // pub memw: TraceTable<GoldilocksField, GoldilocksExtension>,
+    // pub load: TraceTable<GoldilocksField, GoldilocksExtension>,
+    // pub shift: TraceTable<GoldilocksField, GoldilocksExtension>,
+    // pub mul: TraceTable<GoldilocksField, GoldilocksExtension>,
+    // pub branch: TraceTable<GoldilocksField, GoldilocksExtension>,
 }
 
 impl Traces {
-    /// Generates all traces from execution logs in a single pass.
+    /// Generates all traces from execution logs using phased collection.
+    ///
+    /// The phases are:
+    /// 1. Logs → CPU operations
+    /// 2. CPU → LT operations, Bitwise lookups
+    /// 3. LT → Bitwise lookups
+    ///
+    /// Future phases will add MEMW, LOAD, SHIFT, MUL, BRANCH tables.
     pub fn from_logs(
         logs: &[Log],
         instructions: U64HashMap<Instruction>,
     ) -> Result<Self, ProverError> {
-        // Pre-allocate collectors
-        let mut cpu_ops = Vec::with_capacity(logs.len());
-        let mut bitwise_lookups = Vec::with_capacity(logs.len() * 4);
-        let mut lt_ops = Vec::with_capacity(logs.len() / 10 + 1);
+        let mut ctx = CollectionContext::new(logs.len());
 
-        // Single pass over logs
-        for (i, log) in logs.iter().enumerate() {
-            let timestamp = (i as u64) * 4;
-            let instruction = instructions
-                .get(&log.current_pc)
-                .copied()
-                .ok_or(ProverError::MissingInstruction(log.current_pc))?;
-            let op = CpuOperation::from_log(log, timestamp, instruction);
+        // =====================================================================
+        // PHASE 1: Logs → CPU
+        // =====================================================================
+        collect_cpu_from_logs(&mut ctx, logs, &instructions)?;
 
-            // Collect bitwise lookups from this operation
-            bitwise_lookups.extend(op.collect_bitwise_lookups());
+        // =====================================================================
+        // PHASE 2: CPU → Secondary tables
+        // Order within phase doesn't matter (all read from cpu_ops)
+        // =====================================================================
+        collect_lt_from_cpu(&mut ctx);
+        collect_bitwise_from_cpu(&mut ctx);
 
-            // Collect LT operations for SLT and BLT instructions
-            if op.op_slt || op.op_blt {
-                let arg1 = op.compute_arg1();
-                let arg2 = op.compute_arg2();
-                lt_ops.push(LtOperation::new(arg1, arg2, op.signed));
-            }
+        // TODO: Uncomment as you implement:
+        // collect_memw_from_cpu(&mut ctx);
+        // collect_load_from_cpu(&mut ctx);
+        // collect_shift_from_cpu(&mut ctx);
+        // collect_mul_from_cpu(&mut ctx);
+        // collect_branch_from_cpu(&mut ctx);
 
-            cpu_ops.push(op);
-        }
+        // =====================================================================
+        // PHASE 3: LOAD → MEMW (must be after LOAD, before MEMW→LT)
+        // =====================================================================
+        // TODO: Uncomment when implementing LOAD:
+        // collect_memw_from_load(&mut ctx);
 
-        // Generate CPU trace (handles padding internally)
-        let cpu = cpu::generate_cpu_trace(&cpu_ops);
+        // =====================================================================
+        // PHASE 4: MEMW → LT (must be after all MEMW collected)
+        // =====================================================================
+        // TODO: Uncomment when implementing MEMW:
+        // collect_lt_from_memw(&mut ctx);
+
+        // =====================================================================
+        // PHASE 5: All tables → Bitwise lookups
+        // =====================================================================
+        collect_bitwise_from_lt(&mut ctx);
+
+        // TODO: Uncomment as you implement:
+        // collect_bitwise_from_memw(&mut ctx);
+        // collect_bitwise_from_load(&mut ctx);
+        // collect_bitwise_from_shift(&mut ctx);
+        // collect_bitwise_from_mul(&mut ctx);
+        // collect_bitwise_from_branch(&mut ctx);
+
+        // =====================================================================
+        // Generate final traces from collected operations
+        // =====================================================================
+        ctx.build_traces()
+    }
+}
+
+impl CollectionContext {
+    /// Converts collected operations into final trace tables.
+    pub fn build_traces(self) -> Result<Traces, ProverError> {
+        // Generate CPU trace
+        let cpu = cpu::generate_cpu_trace(&self.cpu_ops);
+
+        // Generate LT trace (handles deduplication internally)
+        let lt = lt::generate_lt_trace(&self.lt_ops);
 
         // Generate BITWISE trace and update multiplicities
         let mut bitwise = bitwise::generate_bitwise_trace();
-        bitwise::update_multiplicities(&mut bitwise, &bitwise_lookups);
-
-        // Generate LT trace (handles deduplication and padding internally)
-        let lt = lt::generate_lt_trace(&lt_ops);
+        bitwise::update_multiplicities(&mut bitwise, &self.bitwise_lookups);
 
         Ok(Traces { cpu, bitwise, lt })
     }

--- a/prover/src/tests/trace_builder_tests.rs
+++ b/prover/src/tests/trace_builder_tests.rs
@@ -259,10 +259,11 @@ fn test_cpu_timestamps() {
 
     let traces = Traces::from_logs(&logs, instructions).unwrap();
 
-    // Check timestamps are 0, 4, 8, 12
+    // Check timestamps are 4, 8, 12, 16 (starting at 4, not 0)
+    // This ensures first memory access has old_timestamp(0) < timestamp(4)
     for i in 0..4 {
         let row = traces.cpu.main_table.get_row(i);
-        assert_eq!(row[cols::TIMESTAMP], FE::from((i * 4) as u64));
+        assert_eq!(row[cols::TIMESTAMP], FE::from(((i + 1) * 4) as u64));
     }
 }
 
@@ -308,4 +309,97 @@ fn test_mixed_instructions() {
     assert_eq!(traces.bitwise.main_table.height, bitwise::NUM_ROWS);
     // 1 SLT + 1 BLT = 2 LT ops
     assert!(traces.lt.main_table.height >= 2);
+}
+
+#[test]
+fn test_lt_bitwise_lookups_collected() {
+    // Test that LtOperation::collect_bitwise_lookups() works correctly
+    // and that LT → Bitwise lookups are collected in the trace builder
+    use crate::tables::bitwise::BitwiseLookup;
+    use crate::tables::lt::LtOperation;
+
+    // Create an LT operation with known values
+    let lhs: u64 = 0x1234_5678_9ABC_DEF0;
+    let rhs: u64 = 0x0FED_CBA9_8765_4321;
+    let lt_op = LtOperation::new(lhs, rhs, false);
+
+    // Test collect_bitwise_lookups directly
+    let lookups = lt_op.collect_bitwise_lookups();
+
+    // Should have 8 lookups: 2 MSB16 + 6 IS_HALF
+    assert_eq!(lookups.len(), 8, "LtOperation should generate 8 bitwise lookups");
+
+    // Verify MSB16 lookups for lhs[2] and rhs[2] (bits 48-63)
+    let lhs_2 = ((lhs >> 48) & 0xFFFF) as u16; // 0x1234
+    let rhs_2 = ((rhs >> 48) & 0xFFFF) as u16; // 0x0FED
+
+    // First lookup: MSB16 for lhs[2]
+    assert_eq!(lookups[0].0, BitwiseLookup::Msb16);
+    assert_eq!(lookups[0].1, (lhs_2 & 0xFF) as u8); // 0x34
+    assert_eq!(lookups[0].2, ((lhs_2 >> 8) & 0xFF) as u8); // 0x12
+
+    // Second lookup: MSB16 for rhs[2]
+    assert_eq!(lookups[1].0, BitwiseLookup::Msb16);
+    assert_eq!(lookups[1].1, (rhs_2 & 0xFF) as u8); // 0xED
+    assert_eq!(lookups[1].2, ((rhs_2 >> 8) & 0xFF) as u8); // 0x0F
+
+    // Verify IS_HALF lookups (indices 2-7)
+    for i in 2..8 {
+        assert_eq!(lookups[i].0, BitwiseLookup::IsHalf);
+    }
+}
+
+#[test]
+fn test_lt_to_bitwise_integration() {
+    // Test that LT → Bitwise lookups are properly integrated in trace builder
+    // Use a simple SLT that triggers LT lookups
+    let logs = vec![
+        make_slt_log(0x1000, 5, 10, 1), // 5 < 10 = true
+        make_add_log(0x1004, 0, 0, 0),
+        make_add_log(0x1008, 0, 0, 0),
+        make_add_log(0x100c, 0, 0, 0),
+    ];
+    let instrs = vec![
+        Instruction::Arith {
+            dst: 1,
+            src1: 2,
+            src2: 3,
+            op: ArithOp::SetLessThan,
+        },
+        Instruction::Arith {
+            dst: 1,
+            src1: 2,
+            src2: 3,
+            op: ArithOp::Add,
+        },
+        Instruction::Arith {
+            dst: 1,
+            src1: 2,
+            src2: 3,
+            op: ArithOp::Add,
+        },
+        Instruction::Arith {
+            dst: 1,
+            src1: 2,
+            src2: 3,
+            op: ArithOp::Add,
+        },
+    ];
+    let instructions = make_instructions(&logs, &instrs);
+
+    let traces = Traces::from_logs(&logs, instructions).unwrap();
+
+    // LT op: lhs=5, rhs=10, signed=false
+    // lhs_sub_rhs = 5 - 10 = 0xFFFF_FFFF_FFFF_FFFB (wrapping)
+    let lhs_sub_rhs = 5u64.wrapping_sub(10);
+    let sub_0 = (lhs_sub_rhs & 0xFFFF) as u16; // 0xFFFB
+
+    // Check that IS_HALF multiplicity was incremented for lhs_sub_rhs[0]
+    let row_idx = bitwise::row_index((sub_0 & 0xFF) as u8, ((sub_0 >> 8) & 0xFF) as u8, 0);
+    let row = traces.bitwise.main_table.get_row(row_idx);
+    assert_ne!(
+        row[bitwise::cols::MU_IS_HALF],
+        FE::zero(),
+        "IS_HALF multiplicity should be non-zero for lhs_sub_rhs[0]"
+    );
 }


### PR DESCRIPTION
  Description:
  ## Summary
  - Refactors trace generation to use a phased collection approach that supports cascading table dependencies
  - Adds `collect_bitwise_lookups()` method to `LtOperation` for LT _ Bitwise interactions
  - Adds tests for the new LT bitwise lookup collection

  ## Changes

  ### Architecture
  Introduces `CollectionContext` struct that collects all operations in explicit phases:
  - Phase 1: Logs _ CPU operations
  - Phase 2: CPU _ LT operations, CPU _ Bitwise lookups
  - Phase 5: LT _ Bitwise lookups

  This design supports future cascading dependencies (e.g., CPU _ MEMW _ LT _ Bitwise) by allowing each table to generate operations for downstream tables in the correct order.

  ### New functionality
  - `LtOperation::collect_bitwise_lookups()` generates 8 lookups per operation:
    - MSB16 _2 (for lhs_msb, rhs_msb)
    - IS_HALF _6 (for lhs_sub_rhs[0..3], lhs[1], rhs[1])

  ### Tests
  - `test_lt_bitwise_lookups_collected` - unit test for `LtOperation::collect_bitwise_lookups()`
  - `test_lt_to_bitwise_integration` - integration test for LT _ Bitwise flow
  - Fixed `test_cpu_timestamps` to expect timestamps starting at 4 (for memory consistency)

  ## Test plan
  - [x] All 166 prover tests pass
  - [x] New tests verify LT bitwise lookup generation
  - [x] Integration test verifies bitwise multiplicities are updated