### PR TITLE
fix: run memory profile on main to create baselines

### DIFF
--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -8,6 +8,8 @@ on:
       - 'crypto/**'
       - 'executor/**'
       - '.github/workflows/memory-profile.yml'
+
+  # Run memory profiling on main to create baselines for PR comparisons
   push:
     branches: [main]
     paths:

--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -8,6 +8,13 @@ on:
       - 'crypto/**'
       - 'executor/**'
       - '.github/workflows/memory-profile.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'prover/**'
+      - 'crypto/**'
+      - 'executor/**'
+      - '.github/workflows/memory-profile.yml'
 
 jobs:
   profile:
@@ -177,6 +184,7 @@ jobs:
           fi
 
       - name: Comment on PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
The memory-profile workflow only ran on pull_request events, so baseline artifacts were never created on main. PRs couldn't compare their memory usage against main because no baseline existed.

Add push trigger for main branch so that when PRs are merged, the workflow runs and creates baseline artifacts for future PR comparisons. Also make the PR comment step conditional since it only applies to PRs.