### PR TITLE
CI: use actions repo for AI reviews

### DIFF
--- a/.github/workflows/pr_review_claude.yaml
+++ b/.github/workflows/pr_review_claude.yaml
@@ -1,57 +1,39 @@
-# Reference https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#automatic-pr-code-review
 name: Claude Code Review
 
 on:
   pull_request:
     types: [opened, ready_for_review]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/claude') &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    uses: yetanotherco/actions/.github/workflows/pr_review_claude.yml@main
+    with:
+      custom_prompt: |
+        1. **Security vulnerabilities** - Label by criticality (Critical/High/Medium/Low)
+           - Rust: unsafe blocks, error handling, panics, memory safety issues
+           - Cryptography: incorrect implementations, timing attacks, weak randomness
+           - VM: instruction handling, memory access, privilege escalation
 
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: read
-      id-token: write
+        2. **Potential bugs** - Logic errors, edge cases, incorrect behavior, race conditions
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+        3. **Performance issues** - Only significant: e.g. O(n²) on unbounded input, unnecessary allocations, hot path inefficiencies
 
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          show_full_output: true
-          # Will use the models latest version, reference: https://code.claude.com/docs/en/cli-reference#cli-flags
-          claude_args: |
-            --model sonnet
-            --allowedTools "Bash(gh pr:*),Bash(gh issue:*),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep"
-          prompt: |
-            You are a senior code reviewer for Lambda ZKVM, a minimalist, performant and auditable verifiable RISC-V vm written in Rust.
+        4. **Simplicity** - Prefer simple, readable code over clever abstractions
 
-            Review this PR focusing on:
-            - Code correctness and potential bugs
-            - Security vulnerabilities
-            - Performance implications
-            - Rust best practices and idiomatic patterns
-            - Memory safety and proper error handling
-            - Code readability and maintainability
-
-            Be concise and specific. Provide line references when suggesting changes.
-            If the code looks good, acknowledge it briefly.
+        Guidelines:
+        - Be concise and to the point
+        - Do NOT suggest micro-optimizations or premature abstractions
+        - Always prefer simplicity over complexity when performance gains are marginal
+        - Focus on real issues, not hypothetical improvements
+        - Be concise and actionable
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/pr_review_claude.yaml
+++ b/.github/workflows/pr_review_claude.yaml
@@ -15,7 +15,7 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/claude') &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
-    uses: yetanotherco/actions/.github/workflows/pr_review_claude.yml@main
+    uses: yetanotherco/actions/.github/workflows/pr_review_claude.yml@v1.0.0
     with:
       custom_prompt: |
         1. **Security vulnerabilities** - Label by criticality (Critical/High/Medium/Low)

--- a/.github/workflows/pr_review_codex.yaml
+++ b/.github/workflows/pr_review_codex.yaml
@@ -1,53 +1,39 @@
-# Reference: https://github.com/openai/codex-action/blob/main/README.md
 name: Codex Code Review
 
 on:
   pull_request:
     types: [opened, ready_for_review]
-
-permissions:
-  contents: read
-  pull-requests: write
+  issue_comment:
+    types: [created]
 
 jobs:
   codex-review:
-    name: Codex Code Review
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/codex') &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    uses: yetanotherco/actions/.github/workflows/pr_review_codex.yml@main
+    with:
+      custom_prompt: |
+        1. **Security vulnerabilities** - Label by criticality (Critical/High/Medium/Low)
+           - Rust: unsafe blocks, error handling, panics, memory safety issues
+           - Cryptography: incorrect implementations, timing attacks, weak randomness
+           - VM: instruction handling, memory access, privilege escalation
 
-      - name: Run Codex Code Review
-        id: codex
-        uses: openai/codex-action@v1
-        with:
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          prompt: |
-            You are a senior code reviewer for Lambda ZKVM, a minimalist, performant and auditable verifiable RISC-V vm written in Rust.
+        2. **Potential bugs** - Logic errors, edge cases, incorrect behavior, race conditions
 
-            Review this PR focusing on:
-            - Code correctness and potential bugs
-            - Security vulnerabilities
-            - Performance implications
-            - Rust best practices and idiomatic patterns
-            - Memory safety and proper error handling
-            - Code readability and maintainability
+        3. **Performance issues** - Only significant: e.g. O(n²) on unbounded input, unnecessary allocations, hot path inefficiencies
 
-            Be concise and specific. Provide line references when suggesting changes.
-            If the code looks good, acknowledge it briefly.
+        4. **Simplicity** - Prefer simple, readable code over clever abstractions
 
-      - name: Post Review Comment
-        if: steps.codex.outputs.final-message != ''
-        uses: actions/github-script@v7
-        env:
-          CODEX_REVIEW: ${{ steps.codex.outputs.final-message }}
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: `## 🤖 Codex Code Review\n\n${process.env.CODEX_REVIEW}`
-            });
+        Guidelines:
+        - Be concise and to the point
+        - Do NOT suggest micro-optimizations or premature abstractions
+        - Always prefer simplicity over complexity when performance gains are marginal
+        - Focus on real issues, not hypothetical improvements
+        - Be concise and actionable
+    secrets:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/pr_review_codex.yaml
+++ b/.github/workflows/pr_review_codex.yaml
@@ -15,7 +15,7 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/codex') &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
-    uses: yetanotherco/actions/.github/workflows/pr_review_codex.yml@main
+    uses: yetanotherco/actions/.github/workflows/pr_review_codex.yml@v1.0.0
     with:
       custom_prompt: |
         1. **Security vulnerabilities** - Label by criticality (Critical/High/Medium/Low)

--- a/.github/workflows/pr_review_kimi.yaml
+++ b/.github/workflows/pr_review_kimi.yaml
@@ -15,7 +15,7 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '/kimi') &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
-    uses: yetanotherco/actions/.github/workflows/pr_review_kimi.yml@main
+    uses: yetanotherco/actions/.github/workflows/pr_review_kimi.yml@v1.0.0
     with:
       custom_prompt: |
         1. **Security vulnerabilities** - Label by criticality (Critical/High/Medium/Low)

--- a/.github/workflows/pr_review_kimi.yaml
+++ b/.github/workflows/pr_review_kimi.yaml
@@ -3,127 +3,37 @@ name: Kimi Code Review
 on:
   pull_request:
     types: [opened, ready_for_review]
-
-permissions:
-  contents: read
-  pull-requests: write
+  issue_comment:
+    types: [created]
 
 jobs:
   kimi-review:
-    name: Kimi Code Review
-    runs-on: ubuntu-latest
-    # Only run for PRs from users with write access (not external contributors)
     if: |
-      github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/kimi') &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    uses: yetanotherco/actions/.github/workflows/pr_review_kimi.yml@main
+    with:
+      custom_prompt: |
+        1. **Security vulnerabilities** - Label by criticality (Critical/High/Medium/Low)
+           - Rust: unsafe blocks, error handling, panics, memory safety issues
+           - Cryptography: incorrect implementations, timing attacks, weak randomness
+           - VM: instruction handling, memory access, privilege escalation
 
-      - name: Get PR diff
-        id: diff
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr diff ${{ github.event.pull_request.number }} > pr_diff.txt
+        2. **Potential bugs** - Logic errors, edge cases, incorrect behavior, race conditions
 
-          TOTAL_LINES=$(wc -l < pr_diff.txt)
-          MAX_LINES=10000
+        3. **Performance issues** - Only significant: e.g. O(n²) on unbounded input, unnecessary allocations, hot path inefficiencies
 
-          # Truncate if too large (Kimi has context limits)
-          # Use line-based truncation to avoid breaking UTF-8 characters
-          head -n $MAX_LINES pr_diff.txt > pr_diff_truncated.txt
+        4. **Simplicity** - Prefer simple, readable code over clever abstractions
 
-          # Warn if truncation occurred - reviewers should know some content was not reviewed
-          if [ "$TOTAL_LINES" -gt "$MAX_LINES" ]; then
-            echo "truncated=true" >> "$GITHUB_OUTPUT"
-            echo "total_lines=$TOTAL_LINES" >> "$GITHUB_OUTPUT"
-            echo "::warning::Diff truncated from $TOTAL_LINES to $MAX_LINES lines. Some changes were not reviewed."
-          else
-            echo "truncated=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Kimi Code Review
-        id: kimi_review
-        env:
-          KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          # Mask the API key to prevent accidental exposure in logs
-          echo "::add-mask::$KIMI_API_KEY"
-
-          if [ -z "$KIMI_API_KEY" ]; then
-            echo "KIMI_API_KEY secret is not set. Skipping Kimi review."
-            exit 1
-          fi
-
-          # Use --rawfile for diff to avoid shell interpolation
-          # Use --arg for title (safely escapes user-controlled input)
-          REQUEST_BODY=$(jq -n \
-            --rawfile diff pr_diff_truncated.txt \
-            --arg title "$PR_TITLE" \
-            '{
-              "model": "moonshot-v1-128k",
-              "messages": [
-                {
-                  "role": "system",
-                  "content": "You are a senior code reviewer for Lambda ZKVM, a minimalist, performant and auditable verifiable RISC-V vm written in Rust."
-                },
-                {
-                  "role": "user",
-                  "content": ("PR Title: " + $title + "\n\nReview this PR focusing on:\n- Code correctness and potential bugs\n- Security vulnerabilities\n- Performance implications\n- Rust best practices and idiomatic patterns\n- Memory safety and proper error handling\n- Code readability and maintainability\n\nBe concise and specific. Provide line references when suggesting changes.\nIf the code looks good, acknowledge it briefly.\n\nDiff:\n" + $diff)
-                }
-              ],
-              "temperature": 0.3,
-              "max_tokens": 4096
-            }')
-
-          HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" https://api.moonshot.ai/v1/chat/completions \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer $KIMI_API_KEY" \
-            -d "$REQUEST_BODY")
-
-          HTTP_CODE=$(echo "$HTTP_RESPONSE" | tail -n1)
-          RESPONSE=$(echo "$HTTP_RESPONSE" | sed '$d')
-
-          if [ "$HTTP_CODE" != "200" ]; then
-            # Only log HTTP status code - never log raw API responses which may contain sensitive data
-            echo "Kimi API request failed with HTTP status $HTTP_CODE." > kimi_review.txt
-            echo "::error::Kimi API returned HTTP $HTTP_CODE"
-          else
-            # Check for API error without logging the message (may contain sensitive data)
-            HAS_ERROR=$(echo "$RESPONSE" | jq -e '.error.message' > /dev/null 2>&1 && echo "yes" || echo "no")
-            if [ "$HAS_ERROR" = "yes" ]; then
-              echo "Kimi API returned an error response." > kimi_review.txt
-              echo "::error::Kimi API returned an error (details omitted for security)"
-            else
-              REVIEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // "Error: Unexpected API response"')
-              echo "$REVIEW" > kimi_review.txt
-            fi
-          fi
-
-      - name: Post review comment
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TRUNCATED: ${{ steps.diff.outputs.truncated }}
-          TOTAL_LINES: ${{ steps.diff.outputs.total_lines }}
-        run: |
-          REVIEW_CONTENT=$(cat kimi_review.txt)
-
-          TRUNCATION_WARNING=""
-          if [ "$TRUNCATED" = "true" ]; then
-            TRUNCATION_WARNING="
-          > ⚠️ **Warning:** Diff was truncated from $TOTAL_LINES to 10000 lines. Some changes were not reviewed.
-          "
-          fi
-
-          gh pr comment ${{ github.event.pull_request.number }} --body "## 🤖 Kimi Code Review
-          $TRUNCATION_WARNING
-          $REVIEW_CONTENT
-
-          ---
-          *Automated review by Kimi (Moonshot AI)*"
-  
+        Guidelines:
+        - Be concise and to the point
+        - Do NOT suggest micro-optimizations or premature abstractions
+        - Always prefer simplicity over complexity when performance gains are marginal
+        - Focus on real issues, not hypothetical improvements
+        - Be concise and actionable
+    secrets:
+      KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}


### PR DESCRIPTION
This PR uses the actions from the actions repo to perform AI reviews.

Also, you can call for a review with the commands `/claude`, `/codex` and `/kimi`