### PR TITLE
 Add BRANCH table

### DIFF
--- a/prover/src/tables/branch.rs
+++ b/prover/src/tables/branch.rs
@@ -49,6 +49,7 @@ pub mod cols {
     pub const PC_1: usize = 1;
 
     // Input columns: offset (DWordWL = 2 Words, sign-extended from CPU's imm)
+    // NOTE: This offset representation differs from the one used in the spec.
     /// offset[0]: Word (bits 0-31)
     pub const OFFSET_0: usize = 2;
     /// offset[1]: Word (bits 32-63)

--- a/prover/src/tables/branch.rs
+++ b/prover/src/tables/branch.rs
@@ -1,0 +1,652 @@
+//! BRANCH table for computing next program counter for branch/jump instructions.
+//!
+//! This table computes the target address for branch and jump instructions,
+//! supporting both PC-relative branches and register-based JALR jumps.
+//!
+//! ## Inputs
+//! - `pc`: DWordWL (64-bit as [Word, Word]) - current program counter
+//! - `offset`: Word (32-bit, sign-extended for 64-bit addition)
+//! - `register`: DWordWL (64-bit) - base address for JALR
+//! - `JALR`: Bit - selector between pc (0) and register (1) as base
+//!
+//! ## Output
+//! - `next_pc_high`: Half[3] - upper 48 bits split into 3 halfwords
+//! - `next_pc_low`: Byte[2] - lower 16 bits split into 2 bytes (LSB masked)
+//!
+//! ## Auxiliary
+//! - `unmasked_low_byte`: Byte - low byte before LSB masking (for ADD constraint)
+//! - `sign_bit`: Bit - bit 31 of offset (for sign extension in ADD template)
+//!
+//! ## Virtual (embedded in constraints)
+//! - `next_pc_unmasked`: The raw addition result before masking LSB
+//! - `carry[0]`, `carry[1]`: Carries from 64-bit addition
+//!
+//! ## Bus Interactions
+//! - Sender: IS_BYTE (×1 for next_pc_low[1])
+//! - Sender: AND_BYTE (×1 for masking LSB)
+//! - Sender: IS_HALFWORD (×3 for next_pc_high[0..3])
+//! - Receiver: BRANCH (provides branch targets to CPU)
+
+use math::field::element::FieldElement;
+use math::field::traits::{IsField, IsSubFieldOf};
+use stark::constraints::transition::TransitionConstraint;
+use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing};
+use stark::table::TableView;
+use stark::trace::TraceTable;
+use stark::traits::TransitionEvaluationContext;
+
+use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16, SHIFT_32};
+
+// =========================================================================
+// Column indices for BRANCH table
+// =========================================================================
+
+/// Column definitions for the BRANCH table.
+pub mod cols {
+    // Input columns: pc (DWordWL = 2 Words)
+    /// pc[0]: Word (bits 0-31)
+    pub const PC_0: usize = 0;
+    /// pc[1]: Word (bits 32-63)
+    pub const PC_1: usize = 1;
+
+    // Input column: offset (Word, will be sign-extended)
+    /// offset: Word (32-bit signed offset)
+    pub const OFFSET: usize = 2;
+
+    // Input columns: register (DWordWL = 2 Words)
+    /// register[0]: Word (bits 0-31)
+    pub const REGISTER_0: usize = 3;
+    /// register[1]: Word (bits 32-63)
+    pub const REGISTER_1: usize = 4;
+
+    // Input column: JALR flag
+    /// JALR: Bit (1 = use register as base, 0 = use pc as base)
+    pub const JALR: usize = 5;
+
+    // Output columns: next_pc_high (Half[3])
+    /// next_pc_high[0]: Half (bits 16-31 of next_pc)
+    pub const NEXT_PC_HIGH_0: usize = 6;
+    /// next_pc_high[1]: Half (bits 32-47 of next_pc)
+    pub const NEXT_PC_HIGH_1: usize = 7;
+    /// next_pc_high[2]: Half (bits 48-63 of next_pc)
+    pub const NEXT_PC_HIGH_2: usize = 8;
+
+    // Output columns: next_pc_low (Byte[2])
+    /// next_pc_low[0]: Byte (bits 0-7 of next_pc, with LSB masked to 0)
+    pub const NEXT_PC_LOW_0: usize = 9;
+    /// next_pc_low[1]: Byte (bits 8-15 of next_pc)
+    pub const NEXT_PC_LOW_1: usize = 10;
+
+    // Auxiliary columns
+    /// unmasked_low_byte: Byte (bits 0-7 before LSB masking)
+    pub const UNMASKED_LOW_BYTE: usize = 11;
+    /// sign_bit: Bit (bit 31 of offset, for sign extension)
+    /// sign_bit = 1 if offset >= 2^31, else 0
+    pub const SIGN_BIT: usize = 12;
+
+    // Multiplicity column
+    /// μ: multiplicity for bus interactions
+    pub const MU: usize = 13;
+
+    /// Total number of columns
+    pub const NUM_COLUMNS: usize = 14;
+}
+
+// =========================================================================
+// Constants
+// =========================================================================
+
+/// 2^8 for byte combining
+const SHIFT_8: u64 = 1 << 8;
+
+/// Mask value 254 = 0xFE (clears LSB)
+const MASK_254: u64 = 254;
+
+// =========================================================================
+// Trace generation
+// =========================================================================
+
+/// A single BRANCH operation to be added to the trace.
+///
+/// Derives Hash and Eq so it can be used as a HashMap key for deduplication.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct BranchOperation {
+    /// Current program counter (64-bit)
+    pub pc: u64,
+    /// Offset from base address (32-bit, treated as signed)
+    pub offset: u32,
+    /// Register value for JALR (64-bit)
+    pub register: u64,
+    /// Whether this is a JALR instruction (uses register instead of pc)
+    pub jalr: bool,
+}
+
+impl BranchOperation {
+    /// Create a new BRANCH operation.
+    pub fn new(pc: u64, offset: u32, register: u64, jalr: bool) -> Self {
+        Self {
+            pc,
+            offset,
+            register,
+            jalr,
+        }
+    }
+
+    /// Compute the next program counter.
+    ///
+    /// For regular branches: next_pc = pc + sign_extend(offset)
+    /// For JALR: next_pc = (register + sign_extend(offset)) & !1
+    ///
+    /// The LSB is always masked to 0 per RISC-V ISA.
+    pub fn compute_next_pc(&self) -> u64 {
+        let base = if self.jalr { self.register } else { self.pc };
+        // Sign-extend offset from 32-bit to 64-bit
+        let offset_ext = self.offset as i32 as i64 as u64;
+        let unmasked = base.wrapping_add(offset_ext);
+        // Mask LSB to 0 (RISC-V requirement)
+        unmasked & !1u64
+    }
+
+    /// Compute the unmasked next_pc (before LSB masking).
+    pub fn compute_next_pc_unmasked(&self) -> u64 {
+        let base = if self.jalr { self.register } else { self.pc };
+        let offset_ext = self.offset as i32 as i64 as u64;
+        base.wrapping_add(offset_ext)
+    }
+}
+
+/// Generates the BRANCH trace table from a list of operations.
+///
+/// Duplicate operations (same pc, offset, register, jalr) are merged into a single row
+/// with their multiplicities summed. The table is then padded to the next power of 2.
+pub fn generate_branch_trace(
+    operations: &[BranchOperation],
+) -> TraceTable<GoldilocksField, GoldilocksExtension> {
+    use std::collections::HashMap;
+
+    // Deduplicate operations: (pc, offset, register, jalr) -> multiplicity
+    let mut op_map: HashMap<BranchOperation, u64> = HashMap::new();
+    for op in operations {
+        *op_map.entry(op.clone()).or_insert(0) += 1;
+    }
+
+    let unique_ops: Vec<_> = op_map.into_iter().collect();
+    let num_rows = unique_ops.len().next_power_of_two().max(4);
+    let mut data = vec![FE::zero(); num_rows * cols::NUM_COLUMNS];
+
+    for (row_idx, (op, multiplicity)) in unique_ops.iter().enumerate() {
+        let base = row_idx * cols::NUM_COLUMNS;
+
+        // Extract pc as DWordWL: [Word, Word]
+        let pc_0 = (op.pc & 0xFFFF_FFFF) as u32;
+        let pc_1 = (op.pc >> 32) as u32;
+
+        // Extract register as DWordWL: [Word, Word]
+        let register_0 = (op.register & 0xFFFF_FFFF) as u32;
+        let register_1 = (op.register >> 32) as u32;
+
+        // Compute next_pc
+        let next_pc_unmasked = op.compute_next_pc_unmasked();
+        let next_pc = op.compute_next_pc();
+
+        // Extract next_pc components
+        // next_pc_low[0]: bits 0-7 (masked)
+        // next_pc_low[1]: bits 8-15
+        // next_pc_high[0]: bits 16-31
+        // next_pc_high[1]: bits 32-47
+        // next_pc_high[2]: bits 48-63
+        let unmasked_low_byte = (next_pc_unmasked & 0xFF) as u8;
+        let next_pc_low_0 = (next_pc & 0xFF) as u8; // = unmasked_low_byte & 0xFE
+        let next_pc_low_1 = ((next_pc >> 8) & 0xFF) as u8;
+        let next_pc_high_0 = ((next_pc >> 16) & 0xFFFF) as u16;
+        let next_pc_high_1 = ((next_pc >> 32) & 0xFFFF) as u16;
+        let next_pc_high_2 = ((next_pc >> 48) & 0xFFFF) as u16;
+
+        // Sign bit: bit 31 of offset (1 if offset is negative in signed interpretation)
+        let sign_bit = if op.offset >= (1u32 << 31) { 1u64 } else { 0u64 };
+
+        // Store columns
+        data[base + cols::PC_0] = FE::from(pc_0 as u64);
+        data[base + cols::PC_1] = FE::from(pc_1 as u64);
+        data[base + cols::OFFSET] = FE::from(op.offset as u64);
+        data[base + cols::REGISTER_0] = FE::from(register_0 as u64);
+        data[base + cols::REGISTER_1] = FE::from(register_1 as u64);
+        data[base + cols::JALR] = FE::from(if op.jalr { 1u64 } else { 0u64 });
+        data[base + cols::NEXT_PC_HIGH_0] = FE::from(next_pc_high_0 as u64);
+        data[base + cols::NEXT_PC_HIGH_1] = FE::from(next_pc_high_1 as u64);
+        data[base + cols::NEXT_PC_HIGH_2] = FE::from(next_pc_high_2 as u64);
+        data[base + cols::NEXT_PC_LOW_0] = FE::from(next_pc_low_0 as u64);
+        data[base + cols::NEXT_PC_LOW_1] = FE::from(next_pc_low_1 as u64);
+        data[base + cols::UNMASKED_LOW_BYTE] = FE::from(unmasked_low_byte as u64);
+        data[base + cols::SIGN_BIT] = FE::from(sign_bit);
+        data[base + cols::MU] = FE::from(*multiplicity);
+    }
+
+    TraceTable::new_main(data, cols::NUM_COLUMNS, 1)
+}
+
+// =========================================================================
+// Bus Interactions
+// =========================================================================
+
+/// Creates all bus interactions for the BRANCH table.
+///
+/// The BRANCH table:
+/// - **Sends** IS_BYTE lookup for next_pc_low[1] range check
+/// - **Sends** AND_BYTE lookup for LSB masking (next_pc_low[0] = unmasked_low_byte & 254)
+/// - **Sends** IS_HALFWORD lookups for next_pc_high[0..3] range checks
+/// - **Receives** BRANCH lookups from CPU table
+pub fn bus_interactions() -> Vec<BusInteraction> {
+    vec![
+        // IS_BYTE[next_pc_low[1]] - range check bits 8-15
+        BusInteraction::sender(
+            BusId::IsByte,
+            Multiplicity::Column(cols::MU),
+            vec![BusValue::Packed {
+                start_column: cols::NEXT_PC_LOW_1,
+                packing: Packing::Direct,
+            }],
+        ),
+        // AND_BYTE[next_pc_low[0]; unmasked_low_byte, 254]
+        // Verifies: next_pc_low[0] = unmasked_low_byte & 0xFE
+        BusInteraction::sender(
+            BusId::AndByte,
+            Multiplicity::Column(cols::MU),
+            vec![
+                BusValue::Packed {
+                    start_column: cols::UNMASKED_LOW_BYTE,
+                    packing: Packing::Direct,
+                },
+                BusValue::constant(MASK_254),
+                BusValue::Packed {
+                    start_column: cols::NEXT_PC_LOW_0,
+                    packing: Packing::Direct,
+                },
+            ],
+        ),
+        // IS_HALFWORD[next_pc_high[0]]
+        BusInteraction::sender(
+            BusId::IsHalfword,
+            Multiplicity::Column(cols::MU),
+            vec![BusValue::Packed {
+                start_column: cols::NEXT_PC_HIGH_0,
+                packing: Packing::Direct,
+            }],
+        ),
+        // IS_HALFWORD[next_pc_high[1]]
+        BusInteraction::sender(
+            BusId::IsHalfword,
+            Multiplicity::Column(cols::MU),
+            vec![BusValue::Packed {
+                start_column: cols::NEXT_PC_HIGH_1,
+                packing: Packing::Direct,
+            }],
+        ),
+        // IS_HALFWORD[next_pc_high[2]]
+        BusInteraction::sender(
+            BusId::IsHalfword,
+            Multiplicity::Column(cols::MU),
+            vec![BusValue::Packed {
+                start_column: cols::NEXT_PC_HIGH_2,
+                packing: Packing::Direct,
+            }],
+        ),
+        // BRANCH[next_pc; pc, offset, register, JALR] (receiver)
+        // Signature: [next_pc (DWordWL), pc (DWordWL), offset (Word), register (DWordWL), JALR (Bit)]
+        BusInteraction::receiver(
+            BusId::Branch,
+            Multiplicity::Column(cols::MU),
+            vec![
+                // next_pc as DWordWL (2 words)
+                // next_pc[0] = 2^16 * next_pc_high[0] + 2^8 * next_pc_low[1] + next_pc_low[0]
+                // next_pc[1] = 2^16 * next_pc_high[2] + next_pc_high[1]
+                BusValue::linear(vec![
+                    LinearTerm::Column {
+                        coefficient: 1,
+                        column: cols::NEXT_PC_LOW_0,
+                    },
+                    LinearTerm::Column {
+                        coefficient: SHIFT_8 as i64,
+                        column: cols::NEXT_PC_LOW_1,
+                    },
+                    LinearTerm::Column {
+                        coefficient: SHIFT_16 as i64,
+                        column: cols::NEXT_PC_HIGH_0,
+                    },
+                ]),
+                BusValue::linear(vec![
+                    LinearTerm::Column {
+                        coefficient: 1,
+                        column: cols::NEXT_PC_HIGH_1,
+                    },
+                    LinearTerm::Column {
+                        coefficient: SHIFT_16 as i64,
+                        column: cols::NEXT_PC_HIGH_2,
+                    },
+                ]),
+                // pc as DWordWL
+                BusValue::Packed {
+                    start_column: cols::PC_0,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::PC_1,
+                    packing: Packing::Direct,
+                },
+                // offset
+                BusValue::Packed {
+                    start_column: cols::OFFSET,
+                    packing: Packing::Direct,
+                },
+                // register as DWordWL
+                BusValue::Packed {
+                    start_column: cols::REGISTER_0,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::REGISTER_1,
+                    packing: Packing::Direct,
+                },
+                // JALR flag
+                BusValue::Packed {
+                    start_column: cols::JALR,
+                    packing: Packing::Direct,
+                },
+            ],
+        ),
+    ]
+}
+
+// =========================================================================
+// Constraints
+// =========================================================================
+
+/// BRANCH table constraint for ADD template verification.
+///
+/// The ADD template verifies: base + offset_ext = next_pc_unmasked
+/// where base is either pc (when JALR=0) or register (when JALR=1).
+///
+/// This constraint embeds virtual carry computations and verifies:
+/// 1. IS_BIT<carry[0]> - carry from low word addition is 0 or 1
+/// 2. IS_BIT<carry[1]> - carry from high word addition is 0 or 1
+///
+/// The ADD template is computed as:
+/// - iter=0: base[0] + offset_ext[0] = next_pc_unmasked[0] + carry[0] * 2^32
+/// - iter=1: base[1] + offset_ext[1] + carry[0] = next_pc_unmasked[1] + carry[1] * 2^32
+///
+/// Where offset_ext is the 64-bit sign extension of the 32-bit offset.
+pub struct BranchConstraint {
+    /// Unique constraint identifier
+    constraint_idx: usize,
+    /// Which constraint to check
+    kind: BranchConstraintKind,
+}
+
+/// Kind of BRANCH constraint.
+#[derive(Debug, Clone, Copy)]
+pub enum BranchConstraintKind {
+    /// IS_BIT constraint on virtual carry[0]
+    Carry0IsBit,
+    /// IS_BIT constraint on virtual carry[1]
+    Carry1IsBit,
+}
+
+impl BranchConstraint {
+    /// Creates a new BRANCH constraint.
+    pub fn new(kind: BranchConstraintKind, constraint_idx: usize) -> Self {
+        Self {
+            constraint_idx,
+            kind,
+        }
+    }
+
+    /// Compute the effective base address: (1-JALR)*pc + JALR*register
+    fn compute_base<F, E>(&self, step: &TableView<F, E>) -> (FieldElement<F>, FieldElement<F>)
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        let pc_0 = step.get_main_evaluation_element(0, cols::PC_0).clone();
+        let pc_1 = step.get_main_evaluation_element(0, cols::PC_1).clone();
+        let register_0 = step.get_main_evaluation_element(0, cols::REGISTER_0).clone();
+        let register_1 = step.get_main_evaluation_element(0, cols::REGISTER_1).clone();
+        let jalr = step.get_main_evaluation_element(0, cols::JALR).clone();
+
+        let one = FieldElement::<F>::one();
+        let one_minus_jalr = &one - &jalr;
+
+        // base[0] = (1-JALR) * pc[0] + JALR * register[0]
+        let base_0 = &one_minus_jalr * &pc_0 + &jalr * &register_0;
+        // base[1] = (1-JALR) * pc[1] + JALR * register[1]
+        let base_1 = &one_minus_jalr * &pc_1 + &jalr * &register_1;
+
+        (base_0, base_1)
+    }
+
+    /// Compute virtual next_pc_unmasked as DWordWL.
+    ///
+    /// next_pc_unmasked[0] = 2^16 * next_pc_high[0] + 2^8 * next_pc_low[1] + unmasked_low_byte
+    /// next_pc_unmasked[1] = 2^16 * next_pc_high[2] + next_pc_high[1]
+    fn compute_next_pc_unmasked<F, E>(
+        &self,
+        step: &TableView<F, E>,
+    ) -> (FieldElement<F>, FieldElement<F>)
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        let unmasked_low_byte = step
+            .get_main_evaluation_element(0, cols::UNMASKED_LOW_BYTE)
+            .clone();
+        let next_pc_low_1 = step
+            .get_main_evaluation_element(0, cols::NEXT_PC_LOW_1)
+            .clone();
+        let next_pc_high_0 = step
+            .get_main_evaluation_element(0, cols::NEXT_PC_HIGH_0)
+            .clone();
+        let next_pc_high_1 = step
+            .get_main_evaluation_element(0, cols::NEXT_PC_HIGH_1)
+            .clone();
+        let next_pc_high_2 = step
+            .get_main_evaluation_element(0, cols::NEXT_PC_HIGH_2)
+            .clone();
+
+        let shift_8 = FieldElement::<F>::from(SHIFT_8);
+        let shift_16 = FieldElement::<F>::from(SHIFT_16);
+
+        // next_pc_unmasked[0] = unmasked_low_byte + 2^8 * next_pc_low[1] + 2^16 * next_pc_high[0]
+        let unmasked_0 = &unmasked_low_byte + &next_pc_low_1 * &shift_8 + &next_pc_high_0 * &shift_16;
+
+        // next_pc_unmasked[1] = next_pc_high[1] + 2^16 * next_pc_high[2]
+        let unmasked_1 = &next_pc_high_1 + &next_pc_high_2 * &shift_16;
+
+        (unmasked_0, unmasked_1)
+    }
+
+    /// Compute virtual carry[0] from the addition check.
+    ///
+    /// From ADD template iter=0:
+    /// base[0] + offset_ext[0] = next_pc_unmasked[0] + carry[0] * 2^32
+    ///
+    /// Therefore:
+    /// carry[0] = (base[0] + offset_ext[0] - next_pc_unmasked[0]) / 2^32
+    fn compute_carry_0<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        let (base_0, _base_1) = self.compute_base(step);
+        let offset = step.get_main_evaluation_element(0, cols::OFFSET).clone();
+        let (unmasked_0, _unmasked_1) = self.compute_next_pc_unmasked(step);
+
+        // carry[0] = (base[0] + offset - next_pc_unmasked[0]) / 2^32
+        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().unwrap();
+        (&base_0 + &offset - &unmasked_0) * &inv_2_32
+    }
+
+    /// Compute virtual carry[1] from the addition check.
+    ///
+    /// From ADD template iter=1:
+    /// base[1] + offset_ext[1] + carry[0] = next_pc_unmasked[1] + carry[1] * 2^32
+    ///
+    /// where offset_ext[1] = sign_bit * (2^32 - 1) for sign extension.
+    ///
+    /// carry[1] = (base[1] + offset_ext[1] + carry[0] - next_pc_unmasked[1]) / 2^32
+    fn compute_carry_1<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        let (_base_0, base_1) = self.compute_base(step);
+        let (_unmasked_0, unmasked_1) = self.compute_next_pc_unmasked(step);
+        let carry_0 = self.compute_carry_0(step);
+
+        // Get sign_bit from auxiliary column
+        let sign_bit = step
+            .get_main_evaluation_element(0, cols::SIGN_BIT)
+            .clone();
+
+        // Compute sign extension: offset_ext[1] = sign_bit * (2^32 - 1)
+        // When sign_bit = 0: offset_ext[1] = 0 (positive offset)
+        // When sign_bit = 1: offset_ext[1] = 0xFFFFFFFF (negative offset)
+        let max_u32 = FieldElement::<F>::from(0xFFFF_FFFFu64);
+        let offset_ext_1 = &sign_bit * &max_u32;
+
+        // carry[1] = (base[1] + offset_ext[1] + carry[0] - unmasked[1]) / 2^32
+        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().unwrap();
+        (&base_1 + &offset_ext_1 + &carry_0 - &unmasked_1) * &inv_2_32
+    }
+
+    /// Compute the constraint value.
+    fn compute<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        let one = FieldElement::<F>::one();
+
+        match self.kind {
+            BranchConstraintKind::Carry0IsBit => {
+                // IS_BIT<carry[0]>: carry[0] * (1 - carry[0]) = 0
+                let c0 = self.compute_carry_0(step);
+                &c0 * (&one - &c0)
+            }
+            BranchConstraintKind::Carry1IsBit => {
+                // IS_BIT<carry[1]>: carry[1] * (1 - carry[1]) = 0
+                let c1 = self.compute_carry_1(step);
+                &c1 * (&one - &c1)
+            }
+        }
+    }
+}
+
+impl TransitionConstraint<GoldilocksField, GoldilocksExtension> for BranchConstraint {
+    fn degree(&self) -> usize {
+        match self.kind {
+            // IS_BIT on virtual carry: X*(1-X) is degree 2 in the carry
+            // But carry itself is degree 2 due to JALR * register term
+            // So total is degree 4 for carry^2 terms... but simplified is degree 2
+            // Actually: base = (1-JALR)*pc + JALR*reg has degree 2 (JALR * something)
+            // carry = (base + offset - unmasked) / 2^32 has degree 2
+            // carry * (1 - carry) has degree 4
+            BranchConstraintKind::Carry0IsBit => 4,
+            BranchConstraintKind::Carry1IsBit => 4,
+        }
+    }
+
+    fn constraint_idx(&self) -> usize {
+        self.constraint_idx
+    }
+
+    fn end_exemptions(&self) -> usize {
+        0
+    }
+
+    fn evaluate(
+        &self,
+        evaluation_context: &TransitionEvaluationContext<GoldilocksField, GoldilocksExtension>,
+        transition_evaluations: &mut [FieldElement<GoldilocksExtension>],
+    ) {
+        match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values: _,
+                rap_challenges: _,
+            } => {
+                let constraint_value = self.compute(frame.get_evaluation_step(0));
+                transition_evaluations[self.constraint_idx] = constraint_value.to_extension();
+            }
+            TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values: _,
+                rap_challenges: _,
+            } => {
+                let constraint_value = self.compute(frame.get_evaluation_step(0));
+                transition_evaluations[self.constraint_idx] = constraint_value;
+            }
+        }
+    }
+}
+
+/// Creates all constraints for the BRANCH table.
+///
+/// Returns: (constraints, next_constraint_idx)
+pub fn branch_constraints(constraint_idx_start: usize) -> (Vec<BranchConstraint>, usize) {
+    let mut idx = constraint_idx_start;
+    let constraints = vec![
+        BranchConstraint::new(BranchConstraintKind::Carry0IsBit, {
+            let i = idx;
+            idx += 1;
+            i
+        }),
+        BranchConstraint::new(BranchConstraintKind::Carry1IsBit, {
+            let i = idx;
+            idx += 1;
+            i
+        }),
+    ];
+    (constraints, idx)
+}
+
+// =========================================================================
+// Helper functions for computing carries (used by trace generator and tests)
+// =========================================================================
+
+/// Compute virtual carry[0] and carry[1] for the branch addition.
+///
+/// This computes the carries for: base + sign_extend(offset) = next_pc_unmasked
+///
+/// Returns (carry_0, carry_1) where both should be 0 or 1.
+pub fn compute_carries(base: u64, offset: u32, next_pc_unmasked: u64) -> (u64, u64) {
+    // Sign-extend offset to 64 bits
+    let offset_ext = offset as i32 as i64 as u64;
+
+    // Split into DWordWL format
+    let base_lo = base & 0xFFFF_FFFF;
+    let base_hi = base >> 32;
+
+    let offset_lo = offset_ext & 0xFFFF_FFFF;
+    let offset_hi = offset_ext >> 32;
+
+    let result_lo = next_pc_unmasked & 0xFFFF_FFFF;
+    let result_hi = next_pc_unmasked >> 32;
+
+    // carry[0] = (base_lo + offset_lo - result_lo) / 2^32
+    let sum_lo = base_lo.wrapping_add(offset_lo);
+    let carry_0 = if sum_lo >= result_lo {
+        (sum_lo - result_lo) >> 32
+    } else {
+        // Underflow - shouldn't happen with correct trace
+        0
+    };
+
+    // carry[1] = (base_hi + offset_hi + carry_0 - result_hi) / 2^32
+    let sum_hi = base_hi.wrapping_add(offset_hi).wrapping_add(carry_0);
+    let carry_1 = if sum_hi >= result_hi {
+        (sum_hi - result_hi) >> 32
+    } else {
+        0
+    };
+
+    (carry_0, carry_1)
+}

--- a/prover/src/tables/branch.rs
+++ b/prover/src/tables/branch.rs
@@ -489,7 +489,9 @@ impl BranchConstraint {
         // Compute carry_0 as (base + offset - result) / 2^32 in the field.
         // This works because: base + offset = result + carry_0 * 2^32 (mod field)
         // Rearranging: carry_0 = (base + offset - result) * (2^32)^-1 (mod field)
-        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().expect("2^32 must be invertible in field");
+        let inv_2_32 = FieldElement::<F>::from(SHIFT_32)
+            .inv()
+            .expect("2^32 must be invertible in field");
         (&base_0 + &offset_0 - &unmasked_0) * &inv_2_32
     }
 
@@ -514,7 +516,9 @@ impl BranchConstraint {
         let offset_1 = step.get_main_evaluation_element(0, cols::OFFSET_1).clone();
 
         // carry[1] = (base[1] + offset[1] + carry[0] - unmasked[1]) / 2^32
-        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().expect("2^32 must be invertible in field");
+        let inv_2_32 = FieldElement::<F>::from(SHIFT_32)
+            .inv()
+            .expect("2^32 must be invertible in field");
         (&base_1 + &offset_1 + &carry_0 - &unmasked_1) * &inv_2_32
     }
 

--- a/prover/src/tables/branch.rs
+++ b/prover/src/tables/branch.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Inputs
 //! - `pc`: DWordWL (64-bit as [Word, Word]) - current program counter
-//! - `offset`: Word (32-bit, sign-extended for 64-bit addition)
+//! - `offset`: DWordWL (64-bit as [Word, Word]) - already sign-extended from CPU's imm
 //! - `register`: DWordWL (64-bit) - base address for JALR
 //! - `JALR`: Bit - selector between pc (0) and register (1) as base
 //!
@@ -15,7 +15,6 @@
 //!
 //! ## Auxiliary
 //! - `unmasked_low_byte`: Byte - low byte before LSB masking (for ADD constraint)
-//! - `sign_bit`: Bit - bit 31 of offset (for sign extension in ADD template)
 //!
 //! ## Virtual (embedded in constraints)
 //! - `next_pc_unmasked`: The raw addition result before masking LSB
@@ -49,40 +48,39 @@ pub mod cols {
     /// pc[1]: Word (bits 32-63)
     pub const PC_1: usize = 1;
 
-    // Input column: offset (Word, will be sign-extended)
-    /// offset: Word (32-bit signed offset)
-    pub const OFFSET: usize = 2;
+    // Input columns: offset (DWordWL = 2 Words, sign-extended from CPU's imm)
+    /// offset[0]: Word (bits 0-31)
+    pub const OFFSET_0: usize = 2;
+    /// offset[1]: Word (bits 32-63)
+    pub const OFFSET_1: usize = 3;
 
     // Input columns: register (DWordWL = 2 Words)
     /// register[0]: Word (bits 0-31)
-    pub const REGISTER_0: usize = 3;
+    pub const REGISTER_0: usize = 4;
     /// register[1]: Word (bits 32-63)
-    pub const REGISTER_1: usize = 4;
+    pub const REGISTER_1: usize = 5;
 
     // Input column: JALR flag
     /// JALR: Bit (1 = use register as base, 0 = use pc as base)
-    pub const JALR: usize = 5;
+    pub const JALR: usize = 6;
 
     // Output columns: next_pc_high (Half[3])
     /// next_pc_high[0]: Half (bits 16-31 of next_pc)
-    pub const NEXT_PC_HIGH_0: usize = 6;
+    pub const NEXT_PC_HIGH_0: usize = 7;
     /// next_pc_high[1]: Half (bits 32-47 of next_pc)
-    pub const NEXT_PC_HIGH_1: usize = 7;
+    pub const NEXT_PC_HIGH_1: usize = 8;
     /// next_pc_high[2]: Half (bits 48-63 of next_pc)
-    pub const NEXT_PC_HIGH_2: usize = 8;
+    pub const NEXT_PC_HIGH_2: usize = 9;
 
     // Output columns: next_pc_low (Byte[2])
     /// next_pc_low[0]: Byte (bits 0-7 of next_pc, with LSB masked to 0)
-    pub const NEXT_PC_LOW_0: usize = 9;
+    pub const NEXT_PC_LOW_0: usize = 10;
     /// next_pc_low[1]: Byte (bits 8-15 of next_pc)
-    pub const NEXT_PC_LOW_1: usize = 10;
+    pub const NEXT_PC_LOW_1: usize = 11;
 
     // Auxiliary columns
     /// unmasked_low_byte: Byte (bits 0-7 before LSB masking)
-    pub const UNMASKED_LOW_BYTE: usize = 11;
-    /// sign_bit: Bit (bit 31 of offset, for sign extension)
-    /// sign_bit = 1 if offset >= 2^31, else 0
-    pub const SIGN_BIT: usize = 12;
+    pub const UNMASKED_LOW_BYTE: usize = 12;
 
     // Multiplicity column
     /// μ: multiplicity for bus interactions
@@ -113,8 +111,8 @@ const MASK_254: u64 = 254;
 pub struct BranchOperation {
     /// Current program counter (64-bit)
     pub pc: u64,
-    /// Offset from base address (32-bit, treated as signed)
-    pub offset: u32,
+    /// Offset from base address (64-bit DWordWL, already sign-extended from CPU's imm)
+    pub offset: u64,
     /// Register value for JALR (64-bit)
     pub register: u64,
     /// Whether this is a JALR instruction (uses register instead of pc)
@@ -123,7 +121,7 @@ pub struct BranchOperation {
 
 impl BranchOperation {
     /// Create a new BRANCH operation.
-    pub fn new(pc: u64, offset: u32, register: u64, jalr: bool) -> Self {
+    pub fn new(pc: u64, offset: u64, register: u64, jalr: bool) -> Self {
         Self {
             pc,
             offset,
@@ -134,15 +132,14 @@ impl BranchOperation {
 
     /// Compute the next program counter.
     ///
-    /// For regular branches: next_pc = pc + sign_extend(offset)
-    /// For JALR: next_pc = (register + sign_extend(offset)) & !1
+    /// For regular branches: next_pc = pc + offset
+    /// For JALR: next_pc = (register + offset) & !1
     ///
     /// The LSB is always masked to 0 per RISC-V ISA.
+    /// Note: offset is already sign-extended to 64-bit by the CPU.
     pub fn compute_next_pc(&self) -> u64 {
         let base = if self.jalr { self.register } else { self.pc };
-        // Sign-extend offset from 32-bit to 64-bit
-        let offset_ext = self.offset as i32 as i64 as u64;
-        let unmasked = base.wrapping_add(offset_ext);
+        let unmasked = base.wrapping_add(self.offset);
         // Mask LSB to 0 (RISC-V requirement)
         unmasked & !1u64
     }
@@ -150,8 +147,7 @@ impl BranchOperation {
     /// Compute the unmasked next_pc (before LSB masking).
     pub fn compute_next_pc_unmasked(&self) -> u64 {
         let base = if self.jalr { self.register } else { self.pc };
-        let offset_ext = self.offset as i32 as i64 as u64;
-        base.wrapping_add(offset_ext)
+        base.wrapping_add(self.offset)
     }
 }
 
@@ -181,6 +177,10 @@ pub fn generate_branch_trace(
         let pc_0 = (op.pc & 0xFFFF_FFFF) as u32;
         let pc_1 = (op.pc >> 32) as u32;
 
+        // Extract offset as DWordWL: [Word, Word]
+        let offset_0 = (op.offset & 0xFFFF_FFFF) as u32;
+        let offset_1 = (op.offset >> 32) as u32;
+
         // Extract register as DWordWL: [Word, Word]
         let register_0 = (op.register & 0xFFFF_FFFF) as u32;
         let register_1 = (op.register >> 32) as u32;
@@ -202,13 +202,11 @@ pub fn generate_branch_trace(
         let next_pc_high_1 = ((next_pc >> 32) & 0xFFFF) as u16;
         let next_pc_high_2 = ((next_pc >> 48) & 0xFFFF) as u16;
 
-        // Sign bit: bit 31 of offset (1 if offset is negative in signed interpretation)
-        let sign_bit = if op.offset >= (1u32 << 31) { 1u64 } else { 0u64 };
-
         // Store columns
         data[base + cols::PC_0] = FE::from(pc_0 as u64);
         data[base + cols::PC_1] = FE::from(pc_1 as u64);
-        data[base + cols::OFFSET] = FE::from(op.offset as u64);
+        data[base + cols::OFFSET_0] = FE::from(offset_0 as u64);
+        data[base + cols::OFFSET_1] = FE::from(offset_1 as u64);
         data[base + cols::REGISTER_0] = FE::from(register_0 as u64);
         data[base + cols::REGISTER_1] = FE::from(register_1 as u64);
         data[base + cols::JALR] = FE::from(if op.jalr { 1u64 } else { 0u64 });
@@ -218,7 +216,6 @@ pub fn generate_branch_trace(
         data[base + cols::NEXT_PC_LOW_0] = FE::from(next_pc_low_0 as u64);
         data[base + cols::NEXT_PC_LOW_1] = FE::from(next_pc_low_1 as u64);
         data[base + cols::UNMASKED_LOW_BYTE] = FE::from(unmasked_low_byte as u64);
-        data[base + cols::SIGN_BIT] = FE::from(sign_bit);
         data[base + cols::MU] = FE::from(*multiplicity);
     }
 
@@ -292,7 +289,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
             }],
         ),
         // BRANCH[next_pc; pc, offset, register, JALR] (receiver)
-        // Signature: [next_pc (DWordWL), pc (DWordWL), offset (Word), register (DWordWL), JALR (Bit)]
+        // Signature: [next_pc (DWordWL), pc (DWordWL), offset (DWordWL), register (DWordWL), JALR (Bit)]
         BusInteraction::receiver(
             BusId::Branch,
             Multiplicity::Column(cols::MU),
@@ -333,9 +330,13 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
                     start_column: cols::PC_1,
                     packing: Packing::Direct,
                 },
-                // offset
+                // offset as DWordWL
                 BusValue::Packed {
-                    start_column: cols::OFFSET,
+                    start_column: cols::OFFSET_0,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::OFFSET_1,
                     packing: Packing::Direct,
                 },
                 // register as DWordWL
@@ -466,32 +467,32 @@ impl BranchConstraint {
     /// Compute virtual carry[0] from the addition check.
     ///
     /// From ADD template iter=0:
-    /// base[0] + offset_ext[0] = next_pc_unmasked[0] + carry[0] * 2^32
+    /// base[0] + offset[0] = next_pc_unmasked[0] + carry[0] * 2^32
     ///
     /// Therefore:
-    /// carry[0] = (base[0] + offset_ext[0] - next_pc_unmasked[0]) / 2^32
+    /// carry[0] = (base[0] + offset[0] - next_pc_unmasked[0]) / 2^32
     fn compute_carry_0<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
     where
         F: IsSubFieldOf<E>,
         E: IsField,
     {
         let (base_0, _base_1) = self.compute_base(step);
-        let offset = step.get_main_evaluation_element(0, cols::OFFSET).clone();
+        let offset_0 = step.get_main_evaluation_element(0, cols::OFFSET_0).clone();
         let (unmasked_0, _unmasked_1) = self.compute_next_pc_unmasked(step);
 
-        // carry[0] = (base[0] + offset - next_pc_unmasked[0]) / 2^32
+        // carry[0] = (base[0] + offset[0] - next_pc_unmasked[0]) / 2^32
         let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().unwrap();
-        (&base_0 + &offset - &unmasked_0) * &inv_2_32
+        (&base_0 + &offset_0 - &unmasked_0) * &inv_2_32
     }
 
     /// Compute virtual carry[1] from the addition check.
     ///
     /// From ADD template iter=1:
-    /// base[1] + offset_ext[1] + carry[0] = next_pc_unmasked[1] + carry[1] * 2^32
+    /// base[1] + offset[1] + carry[0] = next_pc_unmasked[1] + carry[1] * 2^32
     ///
-    /// where offset_ext[1] = sign_bit * (2^32 - 1) for sign extension.
+    /// With offset as DWordWL, offset[1] directly contains the sign-extended high word.
     ///
-    /// carry[1] = (base[1] + offset_ext[1] + carry[0] - next_pc_unmasked[1]) / 2^32
+    /// carry[1] = (base[1] + offset[1] + carry[0] - next_pc_unmasked[1]) / 2^32
     fn compute_carry_1<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
     where
         F: IsSubFieldOf<E>,
@@ -501,20 +502,12 @@ impl BranchConstraint {
         let (_unmasked_0, unmasked_1) = self.compute_next_pc_unmasked(step);
         let carry_0 = self.compute_carry_0(step);
 
-        // Get sign_bit from auxiliary column
-        let sign_bit = step
-            .get_main_evaluation_element(0, cols::SIGN_BIT)
-            .clone();
+        // offset[1] already contains the sign-extended high word
+        let offset_1 = step.get_main_evaluation_element(0, cols::OFFSET_1).clone();
 
-        // Compute sign extension: offset_ext[1] = sign_bit * (2^32 - 1)
-        // When sign_bit = 0: offset_ext[1] = 0 (positive offset)
-        // When sign_bit = 1: offset_ext[1] = 0xFFFFFFFF (negative offset)
-        let max_u32 = FieldElement::<F>::from(0xFFFF_FFFFu64);
-        let offset_ext_1 = &sign_bit * &max_u32;
-
-        // carry[1] = (base[1] + offset_ext[1] + carry[0] - unmasked[1]) / 2^32
+        // carry[1] = (base[1] + offset[1] + carry[0] - unmasked[1]) / 2^32
         let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().unwrap();
-        (&base_1 + &offset_ext_1 + &carry_0 - &unmasked_1) * &inv_2_32
+        (&base_1 + &offset_1 + &carry_0 - &unmasked_1) * &inv_2_32
     }
 
     /// Compute the constraint value.
@@ -614,19 +607,17 @@ pub fn branch_constraints(constraint_idx_start: usize) -> (Vec<BranchConstraint>
 
 /// Compute virtual carry[0] and carry[1] for the branch addition.
 ///
-/// This computes the carries for: base + sign_extend(offset) = next_pc_unmasked
+/// This computes the carries for: base + offset = next_pc_unmasked
+/// where offset is already sign-extended to 64 bits as DWordWL.
 ///
 /// Returns (carry_0, carry_1) where both should be 0 or 1.
-pub fn compute_carries(base: u64, offset: u32, next_pc_unmasked: u64) -> (u64, u64) {
-    // Sign-extend offset to 64 bits
-    let offset_ext = offset as i32 as i64 as u64;
-
+pub fn compute_carries(base: u64, offset: u64, next_pc_unmasked: u64) -> (u64, u64) {
     // Split into DWordWL format
     let base_lo = base & 0xFFFF_FFFF;
     let base_hi = base >> 32;
 
-    let offset_lo = offset_ext & 0xFFFF_FFFF;
-    let offset_hi = offset_ext >> 32;
+    let offset_lo = offset & 0xFFFF_FFFF;
+    let offset_hi = offset >> 32;
 
     let result_lo = next_pc_unmasked & 0xFFFF_FFFF;
     let result_hi = next_pc_unmasked >> 32;

--- a/prover/src/tables/branch.rs
+++ b/prover/src/tables/branch.rs
@@ -486,7 +486,10 @@ impl BranchConstraint {
         let (unmasked_0, _unmasked_1) = self.compute_next_pc_unmasked(step);
 
         // carry[0] = (base[0] + offset[0] - next_pc_unmasked[0]) / 2^32
-        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().unwrap();
+        // Compute carry_0 as (base + offset - result) / 2^32 in the field.
+        // This works because: base + offset = result + carry_0 * 2^32 (mod field)
+        // Rearranging: carry_0 = (base + offset - result) * (2^32)^-1 (mod field)
+        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().expect("2^32 must be invertible in field");
         (&base_0 + &offset_0 - &unmasked_0) * &inv_2_32
     }
 
@@ -511,7 +514,7 @@ impl BranchConstraint {
         let offset_1 = step.get_main_evaluation_element(0, cols::OFFSET_1).clone();
 
         // carry[1] = (base[1] + offset[1] + carry[0] - unmasked[1]) / 2^32
-        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().unwrap();
+        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().expect("2^32 must be invertible in field");
         (&base_1 + &offset_1 + &carry_0 - &unmasked_1) * &inv_2_32
     }
 
@@ -627,22 +630,11 @@ pub fn compute_carries(base: u64, offset: u64, next_pc_unmasked: u64) -> (u64, u
     let result_lo = next_pc_unmasked & 0xFFFF_FFFF;
     let result_hi = next_pc_unmasked >> 32;
 
-    // carry[0] = (base_lo + offset_lo - result_lo) / 2^32
-    let sum_lo = base_lo.wrapping_add(offset_lo);
-    let carry_0 = if sum_lo >= result_lo {
-        (sum_lo - result_lo) >> 32
-    } else {
-        // Underflow - shouldn't happen with correct trace
-        0
-    };
+    // carry[0] = (base_lo + offset_lo) >> 32
+    let carry_0 = (base_lo + offset_lo) >> 32;
 
-    // carry[1] = (base_hi + offset_hi + carry_0 - result_hi) / 2^32
-    let sum_hi = base_hi.wrapping_add(offset_hi).wrapping_add(carry_0);
-    let carry_1 = if sum_hi >= result_hi {
-        (sum_hi - result_hi) >> 32
-    } else {
-        0
-    };
+    // carry[1] = (base_hi + offset_hi + carry_0) >> 32
+    let carry_1 = (base_hi + offset_hi + carry_0) >> 32;
 
     (carry_0, carry_1)
 }

--- a/prover/src/tables/branch.rs
+++ b/prover/src/tables/branch.rs
@@ -409,8 +409,12 @@ impl BranchConstraint {
     {
         let pc_0 = step.get_main_evaluation_element(0, cols::PC_0).clone();
         let pc_1 = step.get_main_evaluation_element(0, cols::PC_1).clone();
-        let register_0 = step.get_main_evaluation_element(0, cols::REGISTER_0).clone();
-        let register_1 = step.get_main_evaluation_element(0, cols::REGISTER_1).clone();
+        let register_0 = step
+            .get_main_evaluation_element(0, cols::REGISTER_0)
+            .clone();
+        let register_1 = step
+            .get_main_evaluation_element(0, cols::REGISTER_1)
+            .clone();
         let jalr = step.get_main_evaluation_element(0, cols::JALR).clone();
 
         let one = FieldElement::<F>::one();
@@ -456,7 +460,8 @@ impl BranchConstraint {
         let shift_16 = FieldElement::<F>::from(SHIFT_16);
 
         // next_pc_unmasked[0] = unmasked_low_byte + 2^8 * next_pc_low[1] + 2^16 * next_pc_high[0]
-        let unmasked_0 = &unmasked_low_byte + &next_pc_low_1 * &shift_8 + &next_pc_high_0 * &shift_16;
+        let unmasked_0 =
+            &unmasked_low_byte + &next_pc_low_1 * &shift_8 + &next_pc_high_0 * &shift_16;
 
         // next_pc_unmasked[1] = next_pc_high[1] + 2^16 * next_pc_high[2]
         let unmasked_1 = &next_pc_high_1 + &next_pc_high_2 * &shift_16;

--- a/prover/src/tables/branch.rs
+++ b/prover/src/tables/branch.rs
@@ -623,16 +623,13 @@ pub fn branch_constraints(constraint_idx_start: usize) -> (Vec<BranchConstraint>
 /// where offset is already sign-extended to 64 bits as DWordWL.
 ///
 /// Returns (carry_0, carry_1) where both should be 0 or 1.
-pub fn compute_carries(base: u64, offset: u64, next_pc_unmasked: u64) -> (u64, u64) {
+pub fn compute_carries(base: u64, offset: u64, _next_pc_unmasked: u64) -> (u64, u64) {
     // Split into DWordWL format
     let base_lo = base & 0xFFFF_FFFF;
     let base_hi = base >> 32;
 
     let offset_lo = offset & 0xFFFF_FFFF;
     let offset_hi = offset >> 32;
-
-    let result_lo = next_pc_unmasked & 0xFFFF_FFFF;
-    let result_hi = next_pc_unmasked >> 32;
 
     // carry[0] = (base_lo + offset_lo) >> 32
     let carry_0 = (base_lo + offset_lo) >> 32;

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -837,7 +837,7 @@ fn linear_term(bit: u32, column: usize) -> LinearTerm {
 /// - AND_BYTE, OR_BYTE, XOR_BYTE: for bitwise operations (×8 each)
 ///
 /// Note: LT interaction is TODO - needs proper DWordHHW packing to match LT table receiver.
-/// Note: IS_BYTE, MSB8, ZERO, BRANCH interactions are TODO for later.
+/// Note: IS_BYTE, MSB8, ZERO interactions are TODO for later.
 pub fn bus_interactions() -> Vec<BusInteraction> {
     use super::types::packed_decode as bits;
 
@@ -1456,6 +1456,100 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
             },
             BusValue::Packed {
                 start_column: cols::MEMORY_8BYTES,
+                packing: Packing::Direct,
+            },
+        ],
+    ));
+
+    // -------------------------------------------------------------------------
+    // BRANCH interaction (for branch/jump target calculation)
+    // -------------------------------------------------------------------------
+    // CPU-CO68: BRANCH[next_pc; pc, imm, arg1::DWordWL, JALR] | branch_cond
+    //
+    // Sends to BRANCH table when branch_cond is true.
+    // Bus signature: [next_pc[0], next_pc[1], pc[0], pc[1], offset[0], offset[1], register[0], register[1], JALR]
+    // - next_pc: DWordWL (2 words) from NEXT_PC_0, NEXT_PC_1
+    // - pc: DWordWL (2 words) from PC_0, PC_1
+    // - offset: DWordWL (2 words) from IMM_0, IMM_1 (already sign-extended)
+    // - register: DWordWL (2 words) - arg1 (DWordBL: 8 bytes) repacked as 2 words
+    // - JALR: Bit flag
+    interactions.push(BusInteraction::sender(
+        BusId::Branch,
+        Multiplicity::Column(cols::BRANCH_COND),
+        vec![
+            // next_pc[0] (Word) - low 32 bits
+            BusValue::Packed {
+                start_column: cols::NEXT_PC_0,
+                packing: Packing::Direct,
+            },
+            // next_pc[1] (Word) - high 32 bits
+            BusValue::Packed {
+                start_column: cols::NEXT_PC_1,
+                packing: Packing::Direct,
+            },
+            // pc[0] (Word)
+            BusValue::Packed {
+                start_column: cols::PC_0,
+                packing: Packing::Direct,
+            },
+            // pc[1] (Word)
+            BusValue::Packed {
+                start_column: cols::PC_1,
+                packing: Packing::Direct,
+            },
+            // offset[0] = imm[0] (Word) - low 32 bits of immediate
+            BusValue::Packed {
+                start_column: cols::IMM_0,
+                packing: Packing::Direct,
+            },
+            // offset[1] = imm[1] (Word) - high 32 bits of immediate (sign-extended)
+            BusValue::Packed {
+                start_column: cols::IMM_1,
+                packing: Packing::Direct,
+            },
+            // register[0] = arg1[0..4] repacked as Word
+            // arg1_word0 = arg1[0] + 2^8*arg1[1] + 2^16*arg1[2] + 2^24*arg1[3]
+            BusValue::linear(vec![
+                LinearTerm::Column {
+                    coefficient: 1,
+                    column: cols::ARG1[0],
+                },
+                LinearTerm::Column {
+                    coefficient: 256,
+                    column: cols::ARG1[1],
+                },
+                LinearTerm::Column {
+                    coefficient: 65536,
+                    column: cols::ARG1[2],
+                },
+                LinearTerm::Column {
+                    coefficient: 16777216,
+                    column: cols::ARG1[3],
+                },
+            ]),
+            // register[1] = arg1[4..8] repacked as Word
+            // arg1_word1 = arg1[4] + 2^8*arg1[5] + 2^16*arg1[6] + 2^24*arg1[7]
+            BusValue::linear(vec![
+                LinearTerm::Column {
+                    coefficient: 1,
+                    column: cols::ARG1[4],
+                },
+                LinearTerm::Column {
+                    coefficient: 256,
+                    column: cols::ARG1[5],
+                },
+                LinearTerm::Column {
+                    coefficient: 65536,
+                    column: cols::ARG1[6],
+                },
+                LinearTerm::Column {
+                    coefficient: 16777216,
+                    column: cols::ARG1[7],
+                },
+            ]),
+            // JALR flag
+            BusValue::Packed {
+                start_column: cols::JALR,
                 packing: Packing::Direct,
             },
         ],

--- a/prover/src/tables/mod.rs
+++ b/prover/src/tables/mod.rs
@@ -17,6 +17,7 @@
 pub mod types;
 
 pub mod bitwise;
+pub mod branch;
 pub mod cpu;
 pub mod decode;
 pub mod load;

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -681,7 +681,7 @@ impl Traces {
             .map(|op| {
                 BranchOperation::new(
                     op.decode.pc,
-                    op.decode.imm,     // offset as full 64-bit DWordWL (already sign-extended)
+                    op.decode.imm, // offset as full 64-bit DWordWL (already sign-extended)
                     op.compute_arg1(), // register value must match CPU's arg1 for bus signature
                     op.decode.op_jalr,
                 )

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -32,6 +32,7 @@ use executor::vm::memory::U64HashMap;
 use stark::trace::TraceTable;
 
 use super::bitwise::{self, BitwiseOperation, BitwiseOperationType};
+use super::branch::{self, BranchOperation};
 use super::cpu::{self, CpuOperation};
 use super::decode;
 use super::load::{self, LoadOperation};
@@ -556,6 +557,68 @@ fn collect_bitwise_from_memw(memw_ops: &[MemwOperation]) -> Vec<BitwiseOperation
     bitwise_ops
 }
 
+/// Collects bitwise lookups from BRANCH operations.
+///
+/// BRANCH sends:
+/// - IS_BYTE[next_pc_low[1]] - range check bits 8-15
+/// - AND_BYTE[unmasked_low_byte, 254, next_pc_low[0]] - LSB masking
+/// - IS_HALFWORD[next_pc_high[0..3]] - range checks for bits 16-63
+///
+/// Returns: Vec of bitwise lookups
+fn collect_bitwise_from_branch(branch_ops: &[BranchOperation]) -> Vec<BitwiseOperation> {
+    let mut bitwise_ops = Vec::with_capacity(branch_ops.len() * 5);
+
+    for op in branch_ops {
+        let next_pc = op.compute_next_pc();
+        let next_pc_unmasked = op.compute_next_pc_unmasked();
+
+        // Extract next_pc components
+        let _next_pc_low_0 = (next_pc & 0xFF) as u8; // Used by constraint, not lookup
+        let next_pc_low_1 = ((next_pc >> 8) & 0xFF) as u8;
+        let next_pc_high_0 = ((next_pc >> 16) & 0xFFFF) as u16;
+        let next_pc_high_1 = ((next_pc >> 32) & 0xFFFF) as u16;
+        let next_pc_high_2 = ((next_pc >> 48) & 0xFFFF) as u16;
+        let unmasked_low_byte = (next_pc_unmasked & 0xFF) as u8;
+
+        // IS_BYTE[next_pc_low[1]] - range check for byte value
+        bitwise_ops.push(BitwiseOperation::single_byte(
+            BitwiseOperationType::IsByte,
+            next_pc_low_1,
+        ));
+
+        // AND_BYTE[unmasked_low_byte, 254] → next_pc_low[0]
+        // Verifies: next_pc_low[0] = unmasked_low_byte & 0xFE
+        bitwise_ops.push(BitwiseOperation::byte_op(
+            BitwiseOperationType::AndByte,
+            unmasked_low_byte,
+            254, // 0xFE mask
+        ));
+
+        // IS_HALFWORD[next_pc_high[0]]
+        bitwise_ops.push(BitwiseOperation::halfword(
+            BitwiseOperationType::IsHalf,
+            (next_pc_high_0 & 0xFF) as u8,
+            (next_pc_high_0 >> 8) as u8,
+        ));
+
+        // IS_HALFWORD[next_pc_high[1]]
+        bitwise_ops.push(BitwiseOperation::halfword(
+            BitwiseOperationType::IsHalf,
+            (next_pc_high_1 & 0xFF) as u8,
+            (next_pc_high_1 >> 8) as u8,
+        ));
+
+        // IS_HALFWORD[next_pc_high[2]]
+        bitwise_ops.push(BitwiseOperation::halfword(
+            BitwiseOperationType::IsHalf,
+            (next_pc_high_2 & 0xFF) as u8,
+            (next_pc_high_2 >> 8) as u8,
+        ));
+    }
+
+    bitwise_ops
+}
+
 // =============================================================================
 // Trace Generation
 // =============================================================================
@@ -579,6 +642,9 @@ pub struct Traces {
 
     /// DECODE instruction decoding table
     pub decode: TraceTable<GoldilocksField, GoldilocksExtension>,
+
+    /// BRANCH target calculation trace
+    pub branch: TraceTable<GoldilocksField, GoldilocksExtension>,
 }
 
 impl Traces {
@@ -586,9 +652,9 @@ impl Traces {
     ///
     /// The phases are:
     /// 1. Logs → CPU operations
-    /// 2. CPU ops → MEMW, LOAD, LT, Bitwise (state tracking for MEMW/LOAD)
+    /// 2. CPU ops → MEMW, LOAD, LT, Bitwise, Branch (state tracking for MEMW/LOAD)
     /// 3. MEMW → LT operations (timestamp ordering)
-    /// 4. LT, MEMW → Bitwise lookups
+    /// 4. LT, MEMW, Branch → Bitwise lookups
     /// 5. Generate all traces
     pub fn from_logs(
         logs: &[Log],
@@ -600,13 +666,27 @@ impl Traces {
         let cpu_ops = collect_cpu_ops(logs, &instructions)?;
 
         // =====================================================================
-        // PHASE 2: CPU ops → MEMW, LOAD, LT, Bitwise
+        // PHASE 2: CPU ops → MEMW, LOAD, LT, Bitwise, Branch
         // =====================================================================
         // Processes cpu_ops in order. MEMW/LOAD need state tracking, LT/Bitwise don't.
         let mut memory_state = MemoryState::new();
         let mut register_state = RegisterState::new();
         let (memw_ops, load_ops, mut lt_ops, mut bitwise_ops) =
             collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
+
+        // Collect BRANCH operations from CPU ops where branch_cond = true
+        let branch_ops: Vec<BranchOperation> = cpu_ops
+            .iter()
+            .filter(|op| op.branch_cond)
+            .map(|op| {
+                BranchOperation::new(
+                    op.decode.pc,
+                    op.decode.imm,     // offset as full 64-bit DWordWL (already sign-extended)
+                    op.compute_arg1(), // register value must match CPU's arg1 for bus signature
+                    op.decode.op_jalr,
+                )
+            })
+            .collect();
 
         // =====================================================================
         // PHASE 3: MEMW → LT (timestamp ordering and overflow checks)
@@ -618,6 +698,7 @@ impl Traces {
         // =====================================================================
         bitwise_ops.extend(collect_bitwise_from_lt(&lt_ops));
         bitwise_ops.extend(collect_bitwise_from_memw(&memw_ops));
+        bitwise_ops.extend(collect_bitwise_from_branch(&branch_ops));
 
         // =====================================================================
         // PHASE 5: Generate final traces
@@ -626,6 +707,7 @@ impl Traces {
         let lt = lt::generate_lt_trace(&lt_ops);
         let memw = memw::generate_memw_trace(&memw_ops);
         let load = load::generate_load_trace(&load_ops);
+        let branch = branch::generate_branch_trace(&branch_ops);
 
         let mut bitwise = bitwise::generate_bitwise_trace();
         bitwise::update_multiplicities(&mut bitwise, &bitwise_ops);
@@ -643,6 +725,7 @@ impl Traces {
             memw,
             load,
             decode,
+            branch,
         })
     }
 

--- a/prover/src/test_utils.rs
+++ b/prover/src/test_utils.rs
@@ -28,6 +28,9 @@ use crate::tables::bitwise::{
     BitwiseOperation, BitwiseOperationType, bus_interactions as bitwise_bus_interactions,
     cols as bitwise_cols,
 };
+use crate::tables::branch::{
+    branch_constraints, bus_interactions as branch_bus_interactions, cols as branch_cols,
+};
 use crate::tables::cpu::{
     CpuOperation, bus_interactions as cpu_bus_interactions, cols as cpu_cols,
 };
@@ -564,6 +567,29 @@ pub fn create_decode_air(proof_options: &ProofOptions) -> VmAir {
 
     AirWithBuses::new(
         decode_cols::NUM_COLUMNS,
+        auxiliary_trace_build_data,
+        proof_options,
+        1,
+        transition_constraints,
+    )
+}
+
+/// Create BRANCH AIR with constraints and bus interactions.
+///
+/// The BRANCH table computes next_pc for branch/jump instructions:
+/// - For branches (BEQ, BLT, JAL): next_pc = pc + sign_extend(offset)
+/// - For JALR: next_pc = (register + sign_extend(offset)) & ~1
+pub fn create_branch_air(proof_options: &ProofOptions) -> VmAir {
+    let (constraints, _) = branch_constraints(0);
+    let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> =
+        constraints.into_iter().map(|c| Box::new(c) as _).collect();
+
+    let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+        interactions: branch_bus_interactions(),
+    };
+
+    AirWithBuses::new(
+        branch_cols::NUM_COLUMNS,
         auxiliary_trace_build_data,
         proof_options,
         1,

--- a/prover/src/tests/branch_bus_tests.rs
+++ b/prover/src/tests/branch_bus_tests.rs
@@ -44,17 +44,19 @@ mod sender_cols {
     pub const PC_0: usize = 2;
     /// pc[1]: Word (bits 32-63)
     pub const PC_1: usize = 3;
-    /// offset: Word
-    pub const OFFSET: usize = 4;
+    /// offset[0]: Word (bits 0-31)
+    pub const OFFSET_0: usize = 4;
+    /// offset[1]: Word (bits 32-63)
+    pub const OFFSET_1: usize = 5;
     /// register[0]: Word (bits 0-31)
-    pub const REGISTER_0: usize = 5;
+    pub const REGISTER_0: usize = 6;
     /// register[1]: Word (bits 32-63)
-    pub const REGISTER_1: usize = 6;
+    pub const REGISTER_1: usize = 7;
     /// JALR flag
-    pub const JALR: usize = 7;
+    pub const JALR: usize = 8;
     /// multiplicity (1 = active row)
-    pub const MU: usize = 8;
-    pub const NUM_COLUMNS: usize = 9;
+    pub const MU: usize = 9;
+    pub const NUM_COLUMNS: usize = 10;
 }
 
 // =============================================================================
@@ -89,9 +91,13 @@ fn new_sender_air(
                     start_column: sender_cols::PC_1,
                     packing: Packing::Direct,
                 },
-                // offset
+                // offset as DWordWL
                 BusValue::Packed {
-                    start_column: sender_cols::OFFSET,
+                    start_column: sender_cols::OFFSET_0,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: sender_cols::OFFSET_1,
                     packing: Packing::Direct,
                 },
                 // register as DWordWL
@@ -166,9 +172,13 @@ fn new_receiver_air(
                     start_column: cols::PC_1,
                     packing: Packing::Direct,
                 },
-                // offset
+                // offset as DWordWL
                 BusValue::Packed {
-                    start_column: cols::OFFSET,
+                    start_column: cols::OFFSET_0,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::OFFSET_1,
                     packing: Packing::Direct,
                 },
                 // register as DWordWL
@@ -219,6 +229,10 @@ fn create_sender_trace(ops: &[BranchOperation]) -> TraceTable<F, E> {
         let pc_0 = (op.pc & 0xFFFF_FFFF) as u32;
         let pc_1 = (op.pc >> 32) as u32;
 
+        // Extract offset as DWordWL
+        let offset_0 = (op.offset & 0xFFFF_FFFF) as u32;
+        let offset_1 = (op.offset >> 32) as u32;
+
         // Extract register as DWordWL
         let register_0 = (op.register & 0xFFFF_FFFF) as u32;
         let register_1 = (op.register >> 32) as u32;
@@ -227,7 +241,8 @@ fn create_sender_trace(ops: &[BranchOperation]) -> TraceTable<F, E> {
         data[base + sender_cols::NEXT_PC_1] = FE::from(next_pc_1 as u64);
         data[base + sender_cols::PC_0] = FE::from(pc_0 as u64);
         data[base + sender_cols::PC_1] = FE::from(pc_1 as u64);
-        data[base + sender_cols::OFFSET] = FE::from(op.offset as u64);
+        data[base + sender_cols::OFFSET_0] = FE::from(offset_0 as u64);
+        data[base + sender_cols::OFFSET_1] = FE::from(offset_1 as u64);
         data[base + sender_cols::REGISTER_0] = FE::from(register_0 as u64);
         data[base + sender_cols::REGISTER_1] = FE::from(register_1 as u64);
         data[base + sender_cols::JALR] = FE::from(if op.jalr { 1u64 } else { 0u64 });
@@ -240,7 +255,7 @@ fn create_sender_trace(ops: &[BranchOperation]) -> TraceTable<F, E> {
 /// Create a receiver trace that matches sender operations (for completeness tests).
 fn create_receiver_trace(ops: &[BranchOperation]) -> TraceTable<F, E> {
     // Count multiplicities for each unique operation
-    let mut multiplicities: HashMap<(u64, u32, u64, bool), u32> = HashMap::new();
+    let mut multiplicities: HashMap<(u64, u64, u64, bool), u32> = HashMap::new();
     for op in ops {
         *multiplicities
             .entry((op.pc, op.offset, op.register, op.jalr))
@@ -265,6 +280,10 @@ fn create_receiver_trace(ops: &[BranchOperation]) -> TraceTable<F, E> {
         let pc_0 = (op.pc & 0xFFFF_FFFF) as u32;
         let pc_1 = (op.pc >> 32) as u32;
 
+        // Extract offset as DWordWL
+        let offset_0 = (op.offset & 0xFFFF_FFFF) as u32;
+        let offset_1 = (op.offset >> 32) as u32;
+
         // Extract register as DWordWL
         let register_0 = (op.register & 0xFFFF_FFFF) as u32;
         let register_1 = (op.register >> 32) as u32;
@@ -281,13 +300,11 @@ fn create_receiver_trace(ops: &[BranchOperation]) -> TraceTable<F, E> {
         let next_pc_high_1 = ((next_pc >> 32) & 0xFFFF) as u16;
         let next_pc_high_2 = ((next_pc >> 48) & 0xFFFF) as u16;
 
-        // Sign bit for offset
-        let sign_bit = if op.offset >= (1u32 << 31) { 1u64 } else { 0u64 };
-
         // Store columns
         data[base + cols::PC_0] = FE::from(pc_0 as u64);
         data[base + cols::PC_1] = FE::from(pc_1 as u64);
-        data[base + cols::OFFSET] = FE::from(op.offset as u64);
+        data[base + cols::OFFSET_0] = FE::from(offset_0 as u64);
+        data[base + cols::OFFSET_1] = FE::from(offset_1 as u64);
         data[base + cols::REGISTER_0] = FE::from(register_0 as u64);
         data[base + cols::REGISTER_1] = FE::from(register_1 as u64);
         data[base + cols::JALR] = FE::from(if op.jalr { 1u64 } else { 0u64 });
@@ -297,7 +314,6 @@ fn create_receiver_trace(ops: &[BranchOperation]) -> TraceTable<F, E> {
         data[base + cols::NEXT_PC_LOW_0] = FE::from(next_pc_low_0 as u64);
         data[base + cols::NEXT_PC_LOW_1] = FE::from(next_pc_low_1 as u64);
         data[base + cols::UNMASKED_LOW_BYTE] = FE::from(unmasked_low_byte as u64);
-        data[base + cols::SIGN_BIT] = FE::from(sign_bit);
         data[base + cols::MU] = FE::from(*mult as u64);
     }
 
@@ -334,7 +350,7 @@ fn prove_and_verify(ops: &[BranchOperation]) -> bool {
 /// Create a custom receiver trace for soundness tests.
 struct CustomBranchRow {
     pc: u64,
-    offset: u32,
+    offset: u64,
     register: u64,
     jalr: bool,
     next_pc: u64, // Can be wrong for soundness tests
@@ -350,6 +366,9 @@ fn create_custom_receiver_trace(rows: &[CustomBranchRow]) -> TraceTable<F, E> {
 
         let pc_0 = (row.pc & 0xFFFF_FFFF) as u32;
         let pc_1 = (row.pc >> 32) as u32;
+
+        let offset_0 = (row.offset & 0xFFFF_FFFF) as u32;
+        let offset_1 = (row.offset >> 32) as u32;
 
         let register_0 = (row.register & 0xFFFF_FFFF) as u32;
         let register_1 = (row.register >> 32) as u32;
@@ -368,15 +387,10 @@ fn create_custom_receiver_trace(rows: &[CustomBranchRow]) -> TraceTable<F, E> {
         let next_pc_high_1 = ((next_pc >> 32) & 0xFFFF) as u16;
         let next_pc_high_2 = ((next_pc >> 48) & 0xFFFF) as u16;
 
-        let sign_bit = if row.offset >= (1u32 << 31) {
-            1u64
-        } else {
-            0u64
-        };
-
         data[base + cols::PC_0] = FE::from(pc_0 as u64);
         data[base + cols::PC_1] = FE::from(pc_1 as u64);
-        data[base + cols::OFFSET] = FE::from(row.offset as u64);
+        data[base + cols::OFFSET_0] = FE::from(offset_0 as u64);
+        data[base + cols::OFFSET_1] = FE::from(offset_1 as u64);
         data[base + cols::REGISTER_0] = FE::from(register_0 as u64);
         data[base + cols::REGISTER_1] = FE::from(register_1 as u64);
         data[base + cols::JALR] = FE::from(if row.jalr { 1u64 } else { 0u64 });
@@ -386,7 +400,6 @@ fn create_custom_receiver_trace(rows: &[CustomBranchRow]) -> TraceTable<F, E> {
         data[base + cols::NEXT_PC_LOW_0] = FE::from(next_pc_low_0 as u64);
         data[base + cols::NEXT_PC_LOW_1] = FE::from(next_pc_low_1 as u64);
         data[base + cols::UNMASKED_LOW_BYTE] = FE::from(unmasked_low_byte as u64);
-        data[base + cols::SIGN_BIT] = FE::from(sign_bit);
         data[base + cols::MU] = FE::from(row.multiplicity as u64);
     }
 
@@ -490,8 +503,8 @@ fn test_border_max_pc() {
 
 #[test]
 fn test_border_negative_offset() {
-    // PC + negative offset (offset >= 2^31 is negative in signed interpretation)
-    let negative_4: u32 = (-4i32) as u32; // 0xFFFFFFFC
+    // PC + negative offset (sign-extended to 64-bit)
+    let negative_4: u64 = (-4i64) as u64; // 0xFFFFFFFF_FFFFFFFC
     let ops = vec![BranchOperation::new(0x1000, negative_4, 0, false)];
     // Expected: next_pc = 0x1000 + (-4) = 0x0FFC, masked to even = 0x0FFC
     assert!(prove_and_verify(&ops));
@@ -507,8 +520,8 @@ fn test_border_jalr_operation() {
 
 #[test]
 fn test_border_jalr_with_negative_offset() {
-    // JALR with negative offset
-    let negative_16: u32 = (-16i32) as u32;
+    // JALR with negative offset (sign-extended to 64-bit)
+    let negative_16: u64 = (-16i64) as u64;
     let ops = vec![BranchOperation::new(0x1000, negative_16, 0x3000, true)];
     // Expected: next_pc = 0x3000 + (-16) = 0x2FF0, masked to even = 0x2FF0
     assert!(prove_and_verify(&ops));
@@ -565,10 +578,10 @@ fn test_completeness_duplicate_lookups() {
 #[test]
 fn test_completeness_mixed_jalr_and_branch() {
     let ops = vec![
-        BranchOperation::new(0x1000, 16, 0, false),          // branch
-        BranchOperation::new(0x2000, 32, 0x8000, true),      // jalr
-        BranchOperation::new(0x3000, (-8i32) as u32, 0, false), // branch with negative offset
-        BranchOperation::new(0x4000, (-16i32) as u32, 0xA000, true), // jalr with negative offset
+        BranchOperation::new(0x1000, 16, 0, false),            // branch
+        BranchOperation::new(0x2000, 32, 0x8000, true),        // jalr
+        BranchOperation::new(0x3000, (-8i64) as u64, 0, false), // branch with negative offset
+        BranchOperation::new(0x4000, (-16i64) as u64, 0xA000, true), // jalr with negative offset
     ];
     assert!(prove_and_verify(&ops));
 }

--- a/prover/src/tests/branch_bus_tests.rs
+++ b/prover/src/tests/branch_bus_tests.rs
@@ -21,7 +21,7 @@ use stark::trace::TraceTable;
 use stark::traits::AIR;
 use stark::verifier::{IsStarkVerifier, Verifier};
 
-use crate::tables::branch::{cols, generate_branch_trace, BranchOperation};
+use crate::tables::branch::{BranchOperation, cols, generate_branch_trace};
 use crate::tables::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 
 type F = GoldilocksField;
@@ -578,8 +578,8 @@ fn test_completeness_duplicate_lookups() {
 #[test]
 fn test_completeness_mixed_jalr_and_branch() {
     let ops = vec![
-        BranchOperation::new(0x1000, 16, 0, false),            // branch
-        BranchOperation::new(0x2000, 32, 0x8000, true),        // jalr
+        BranchOperation::new(0x1000, 16, 0, false),     // branch
+        BranchOperation::new(0x2000, 32, 0x8000, true), // jalr
         BranchOperation::new(0x3000, (-8i64) as u64, 0, false), // branch with negative offset
         BranchOperation::new(0x4000, (-16i64) as u64, 0xA000, true), // jalr with negative offset
     ];

--- a/prover/src/tests/branch_bus_tests.rs
+++ b/prover/src/tests/branch_bus_tests.rs
@@ -1,0 +1,674 @@
+//! Soundness and completeness tests for BRANCH table bus interactions.
+//!
+//! These tests verify that:
+//! - Completeness: Valid lookups to BRANCH are accepted
+//! - Soundness: Invalid lookups to BRANCH are rejected
+//! - Padding: Auto-padding to power of 2 works correctly
+//! - Border cases: Edge values (0, MAX, signed boundaries) work
+
+use std::collections::HashMap;
+
+use crypto::fiat_shamir::default_transcript::DefaultTranscript;
+
+use stark::constraints::transition::TransitionConstraint;
+use stark::lookup::{
+    AirWithBuses, AuxiliaryTraceBuildData, BusInteraction, BusValue, LinearTerm, Multiplicity,
+    NullBoundaryConstraintBuilder, Packing,
+};
+use stark::proof::options::ProofOptions;
+use stark::prover::{IsStarkProver, Prover};
+use stark::trace::TraceTable;
+use stark::traits::AIR;
+use stark::verifier::{IsStarkVerifier, Verifier};
+
+use crate::tables::branch::{cols, generate_branch_trace, BranchOperation};
+use crate::tables::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
+
+type F = GoldilocksField;
+type E = GoldilocksExtension;
+
+/// Constants for shifts
+const SHIFT_8: u64 = 1 << 8;
+const SHIFT_16: u64 = 1 << 16;
+
+// =============================================================================
+// Column indices for sender (CPU-like) table
+// =============================================================================
+
+mod sender_cols {
+    /// next_pc[0]: Word (bits 0-31)
+    pub const NEXT_PC_0: usize = 0;
+    /// next_pc[1]: Word (bits 32-63)
+    pub const NEXT_PC_1: usize = 1;
+    /// pc[0]: Word (bits 0-31)
+    pub const PC_0: usize = 2;
+    /// pc[1]: Word (bits 32-63)
+    pub const PC_1: usize = 3;
+    /// offset: Word
+    pub const OFFSET: usize = 4;
+    /// register[0]: Word (bits 0-31)
+    pub const REGISTER_0: usize = 5;
+    /// register[1]: Word (bits 32-63)
+    pub const REGISTER_1: usize = 6;
+    /// JALR flag
+    pub const JALR: usize = 7;
+    /// multiplicity (1 = active row)
+    pub const MU: usize = 8;
+    pub const NUM_COLUMNS: usize = 9;
+}
+
+// =============================================================================
+// AIR definitions
+// =============================================================================
+
+fn new_sender_air(
+    proof_options: &ProofOptions,
+) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
+    let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+
+    let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+        interactions: vec![BusInteraction::sender(
+            BusId::Branch,
+            Multiplicity::Column(sender_cols::MU),
+            vec![
+                // next_pc as DWordWL (2 words)
+                BusValue::Packed {
+                    start_column: sender_cols::NEXT_PC_0,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: sender_cols::NEXT_PC_1,
+                    packing: Packing::Direct,
+                },
+                // pc as DWordWL
+                BusValue::Packed {
+                    start_column: sender_cols::PC_0,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: sender_cols::PC_1,
+                    packing: Packing::Direct,
+                },
+                // offset
+                BusValue::Packed {
+                    start_column: sender_cols::OFFSET,
+                    packing: Packing::Direct,
+                },
+                // register as DWordWL
+                BusValue::Packed {
+                    start_column: sender_cols::REGISTER_0,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: sender_cols::REGISTER_1,
+                    packing: Packing::Direct,
+                },
+                // JALR flag
+                BusValue::Packed {
+                    start_column: sender_cols::JALR,
+                    packing: Packing::Direct,
+                },
+            ],
+        )],
+    };
+
+    AirWithBuses::new(
+        sender_cols::NUM_COLUMNS,
+        auxiliary_trace_build_data,
+        proof_options,
+        1,
+        transition_constraints,
+    )
+}
+
+fn new_receiver_air(
+    proof_options: &ProofOptions,
+) -> AirWithBuses<F, E, NullBoundaryConstraintBuilder, ()> {
+    let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+
+    // Use the same bus interaction format as the BRANCH table receiver
+    let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+        interactions: vec![BusInteraction::receiver(
+            BusId::Branch,
+            Multiplicity::Column(cols::MU),
+            vec![
+                // next_pc as DWordWL (computed from high/low columns)
+                BusValue::linear(vec![
+                    LinearTerm::Column {
+                        coefficient: 1,
+                        column: cols::NEXT_PC_LOW_0,
+                    },
+                    LinearTerm::Column {
+                        coefficient: SHIFT_8 as i64,
+                        column: cols::NEXT_PC_LOW_1,
+                    },
+                    LinearTerm::Column {
+                        coefficient: SHIFT_16 as i64,
+                        column: cols::NEXT_PC_HIGH_0,
+                    },
+                ]),
+                BusValue::linear(vec![
+                    LinearTerm::Column {
+                        coefficient: 1,
+                        column: cols::NEXT_PC_HIGH_1,
+                    },
+                    LinearTerm::Column {
+                        coefficient: SHIFT_16 as i64,
+                        column: cols::NEXT_PC_HIGH_2,
+                    },
+                ]),
+                // pc as DWordWL
+                BusValue::Packed {
+                    start_column: cols::PC_0,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::PC_1,
+                    packing: Packing::Direct,
+                },
+                // offset
+                BusValue::Packed {
+                    start_column: cols::OFFSET,
+                    packing: Packing::Direct,
+                },
+                // register as DWordWL
+                BusValue::Packed {
+                    start_column: cols::REGISTER_0,
+                    packing: Packing::Direct,
+                },
+                BusValue::Packed {
+                    start_column: cols::REGISTER_1,
+                    packing: Packing::Direct,
+                },
+                // JALR flag
+                BusValue::Packed {
+                    start_column: cols::JALR,
+                    packing: Packing::Direct,
+                },
+            ],
+        )],
+    };
+
+    AirWithBuses::new(
+        cols::NUM_COLUMNS,
+        auxiliary_trace_build_data,
+        proof_options,
+        1,
+        transition_constraints,
+    )
+}
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/// Create a sender trace from BRANCH operations.
+fn create_sender_trace(ops: &[BranchOperation]) -> TraceTable<F, E> {
+    let num_rows = ops.len().next_power_of_two().max(4);
+    let mut data = vec![FE::zero(); num_rows * sender_cols::NUM_COLUMNS];
+
+    for (i, op) in ops.iter().enumerate() {
+        let base = i * sender_cols::NUM_COLUMNS;
+
+        // Compute next_pc
+        let next_pc = op.compute_next_pc();
+        let next_pc_0 = (next_pc & 0xFFFF_FFFF) as u32;
+        let next_pc_1 = (next_pc >> 32) as u32;
+
+        // Extract pc as DWordWL
+        let pc_0 = (op.pc & 0xFFFF_FFFF) as u32;
+        let pc_1 = (op.pc >> 32) as u32;
+
+        // Extract register as DWordWL
+        let register_0 = (op.register & 0xFFFF_FFFF) as u32;
+        let register_1 = (op.register >> 32) as u32;
+
+        data[base + sender_cols::NEXT_PC_0] = FE::from(next_pc_0 as u64);
+        data[base + sender_cols::NEXT_PC_1] = FE::from(next_pc_1 as u64);
+        data[base + sender_cols::PC_0] = FE::from(pc_0 as u64);
+        data[base + sender_cols::PC_1] = FE::from(pc_1 as u64);
+        data[base + sender_cols::OFFSET] = FE::from(op.offset as u64);
+        data[base + sender_cols::REGISTER_0] = FE::from(register_0 as u64);
+        data[base + sender_cols::REGISTER_1] = FE::from(register_1 as u64);
+        data[base + sender_cols::JALR] = FE::from(if op.jalr { 1u64 } else { 0u64 });
+        data[base + sender_cols::MU] = FE::one();
+    }
+
+    TraceTable::new_main(data, sender_cols::NUM_COLUMNS, 1)
+}
+
+/// Create a receiver trace that matches sender operations (for completeness tests).
+fn create_receiver_trace(ops: &[BranchOperation]) -> TraceTable<F, E> {
+    // Count multiplicities for each unique operation
+    let mut multiplicities: HashMap<(u64, u32, u64, bool), u32> = HashMap::new();
+    for op in ops {
+        *multiplicities
+            .entry((op.pc, op.offset, op.register, op.jalr))
+            .or_insert(0) += 1;
+    }
+
+    // Build operations with correct multiplicities
+    let unique_ops: Vec<(BranchOperation, u32)> = multiplicities
+        .into_iter()
+        .map(|((pc, offset, register, jalr), mult)| {
+            (BranchOperation::new(pc, offset, register, jalr), mult)
+        })
+        .collect();
+
+    let num_rows = unique_ops.len().next_power_of_two().max(4);
+    let mut data = vec![FE::zero(); num_rows * cols::NUM_COLUMNS];
+
+    for (i, (op, mult)) in unique_ops.iter().enumerate() {
+        let base = i * cols::NUM_COLUMNS;
+
+        // Extract pc as DWordWL
+        let pc_0 = (op.pc & 0xFFFF_FFFF) as u32;
+        let pc_1 = (op.pc >> 32) as u32;
+
+        // Extract register as DWordWL
+        let register_0 = (op.register & 0xFFFF_FFFF) as u32;
+        let register_1 = (op.register >> 32) as u32;
+
+        // Compute next_pc
+        let next_pc_unmasked = op.compute_next_pc_unmasked();
+        let next_pc = op.compute_next_pc();
+
+        // Extract next_pc components
+        let unmasked_low_byte = (next_pc_unmasked & 0xFF) as u8;
+        let next_pc_low_0 = (next_pc & 0xFF) as u8;
+        let next_pc_low_1 = ((next_pc >> 8) & 0xFF) as u8;
+        let next_pc_high_0 = ((next_pc >> 16) & 0xFFFF) as u16;
+        let next_pc_high_1 = ((next_pc >> 32) & 0xFFFF) as u16;
+        let next_pc_high_2 = ((next_pc >> 48) & 0xFFFF) as u16;
+
+        // Sign bit for offset
+        let sign_bit = if op.offset >= (1u32 << 31) { 1u64 } else { 0u64 };
+
+        // Store columns
+        data[base + cols::PC_0] = FE::from(pc_0 as u64);
+        data[base + cols::PC_1] = FE::from(pc_1 as u64);
+        data[base + cols::OFFSET] = FE::from(op.offset as u64);
+        data[base + cols::REGISTER_0] = FE::from(register_0 as u64);
+        data[base + cols::REGISTER_1] = FE::from(register_1 as u64);
+        data[base + cols::JALR] = FE::from(if op.jalr { 1u64 } else { 0u64 });
+        data[base + cols::NEXT_PC_HIGH_0] = FE::from(next_pc_high_0 as u64);
+        data[base + cols::NEXT_PC_HIGH_1] = FE::from(next_pc_high_1 as u64);
+        data[base + cols::NEXT_PC_HIGH_2] = FE::from(next_pc_high_2 as u64);
+        data[base + cols::NEXT_PC_LOW_0] = FE::from(next_pc_low_0 as u64);
+        data[base + cols::NEXT_PC_LOW_1] = FE::from(next_pc_low_1 as u64);
+        data[base + cols::UNMASKED_LOW_BYTE] = FE::from(unmasked_low_byte as u64);
+        data[base + cols::SIGN_BIT] = FE::from(sign_bit);
+        data[base + cols::MU] = FE::from(*mult as u64);
+    }
+
+    TraceTable::new_main(data, cols::NUM_COLUMNS, 1)
+}
+
+/// Proves and verifies sender-receiver interaction.
+fn prove_and_verify(ops: &[BranchOperation]) -> bool {
+    let mut sender_trace = create_sender_trace(ops);
+    let mut receiver_trace = create_receiver_trace(ops);
+
+    let proof_options = ProofOptions::default_test_options();
+    let sender_air = new_sender_air(&proof_options);
+    let receiver_air = new_receiver_air(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&sender_air, &mut sender_trace, &()),
+        (&receiver_air, &mut receiver_trace, &()),
+    ];
+
+    let multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&sender_air, &receiver_air];
+
+    Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[]))
+}
+
+/// Create a custom receiver trace for soundness tests.
+struct CustomBranchRow {
+    pc: u64,
+    offset: u32,
+    register: u64,
+    jalr: bool,
+    next_pc: u64, // Can be wrong for soundness tests
+    multiplicity: u32,
+}
+
+fn create_custom_receiver_trace(rows: &[CustomBranchRow]) -> TraceTable<F, E> {
+    let num_rows = rows.len().next_power_of_two().max(4);
+    let mut data = vec![FE::zero(); num_rows * cols::NUM_COLUMNS];
+
+    for (i, row) in rows.iter().enumerate() {
+        let base = i * cols::NUM_COLUMNS;
+
+        let pc_0 = (row.pc & 0xFFFF_FFFF) as u32;
+        let pc_1 = (row.pc >> 32) as u32;
+
+        let register_0 = (row.register & 0xFFFF_FFFF) as u32;
+        let register_1 = (row.register >> 32) as u32;
+
+        // Use the (possibly wrong) next_pc value
+        let next_pc = row.next_pc;
+
+        // For unmasked_low_byte, compute what it should be for correct trace
+        let op = BranchOperation::new(row.pc, row.offset, row.register, row.jalr);
+        let next_pc_unmasked = op.compute_next_pc_unmasked();
+        let unmasked_low_byte = (next_pc_unmasked & 0xFF) as u8;
+
+        let next_pc_low_0 = (next_pc & 0xFF) as u8;
+        let next_pc_low_1 = ((next_pc >> 8) & 0xFF) as u8;
+        let next_pc_high_0 = ((next_pc >> 16) & 0xFFFF) as u16;
+        let next_pc_high_1 = ((next_pc >> 32) & 0xFFFF) as u16;
+        let next_pc_high_2 = ((next_pc >> 48) & 0xFFFF) as u16;
+
+        let sign_bit = if row.offset >= (1u32 << 31) {
+            1u64
+        } else {
+            0u64
+        };
+
+        data[base + cols::PC_0] = FE::from(pc_0 as u64);
+        data[base + cols::PC_1] = FE::from(pc_1 as u64);
+        data[base + cols::OFFSET] = FE::from(row.offset as u64);
+        data[base + cols::REGISTER_0] = FE::from(register_0 as u64);
+        data[base + cols::REGISTER_1] = FE::from(register_1 as u64);
+        data[base + cols::JALR] = FE::from(if row.jalr { 1u64 } else { 0u64 });
+        data[base + cols::NEXT_PC_HIGH_0] = FE::from(next_pc_high_0 as u64);
+        data[base + cols::NEXT_PC_HIGH_1] = FE::from(next_pc_high_1 as u64);
+        data[base + cols::NEXT_PC_HIGH_2] = FE::from(next_pc_high_2 as u64);
+        data[base + cols::NEXT_PC_LOW_0] = FE::from(next_pc_low_0 as u64);
+        data[base + cols::NEXT_PC_LOW_1] = FE::from(next_pc_low_1 as u64);
+        data[base + cols::UNMASKED_LOW_BYTE] = FE::from(unmasked_low_byte as u64);
+        data[base + cols::SIGN_BIT] = FE::from(sign_bit);
+        data[base + cols::MU] = FE::from(row.multiplicity as u64);
+    }
+
+    TraceTable::new_main(data, cols::NUM_COLUMNS, 1)
+}
+
+fn prove_and_verify_custom(ops: &[BranchOperation], receiver_rows: &[CustomBranchRow]) -> bool {
+    let mut sender_trace = create_sender_trace(ops);
+    let mut receiver_trace = create_custom_receiver_trace(receiver_rows);
+
+    let proof_options = ProofOptions::default_test_options();
+    let sender_air = new_sender_air(&proof_options);
+    let receiver_air = new_receiver_air(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&sender_air, &mut sender_trace, &()),
+        (&receiver_air, &mut receiver_trace, &()),
+    ];
+
+    let multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&sender_air, &receiver_air];
+
+    Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[]))
+}
+
+// =============================================================================
+// Padding Tests
+// =============================================================================
+
+#[test]
+fn test_padding_single_row() {
+    let ops = vec![BranchOperation::new(0x1000, 4, 0, false)];
+    let trace = generate_branch_trace(&ops);
+    // 1 row -> pads to 4 (minimum for FRI)
+    assert_eq!(trace.main_table.height, 4);
+}
+
+#[test]
+fn test_padding_three_rows() {
+    let ops = vec![
+        BranchOperation::new(0x1000, 4, 0, false),
+        BranchOperation::new(0x1004, 8, 0, false),
+        BranchOperation::new(0x1008, 12, 0, false),
+    ];
+    let trace = generate_branch_trace(&ops);
+    // 3 rows -> pads to 4
+    assert_eq!(trace.main_table.height, 4);
+}
+
+#[test]
+fn test_padding_five_rows() {
+    let ops = vec![
+        BranchOperation::new(0x1000, 4, 0, false),
+        BranchOperation::new(0x1004, 8, 0, false),
+        BranchOperation::new(0x1008, 12, 0, false),
+        BranchOperation::new(0x100C, 16, 0, false),
+        BranchOperation::new(0x1010, 20, 0, false),
+    ];
+    let trace = generate_branch_trace(&ops);
+    // 5 rows -> pads to 8
+    assert_eq!(trace.main_table.height, 8);
+}
+
+#[test]
+fn test_padding_rows_have_zero_multiplicity() {
+    let ops = vec![BranchOperation::new(0x1000, 4, 0, false)];
+    let trace = generate_branch_trace(&ops);
+
+    // Check that padding rows have mu = 0
+    let data = &trace.main_table.data;
+    for row_idx in 1..4 {
+        let base = row_idx * cols::NUM_COLUMNS;
+        assert_eq!(data[base + cols::MU], FE::zero());
+    }
+}
+
+// =============================================================================
+// Border Case Tests
+// =============================================================================
+
+#[test]
+fn test_border_zero_values() {
+    // pc = 0, offset = 0, not JALR -> next_pc = 0
+    let ops = vec![BranchOperation::new(0, 0, 0, false)];
+    assert!(prove_and_verify(&ops));
+}
+
+#[test]
+fn test_border_max_pc() {
+    // Large PC value with small positive offset
+    let ops = vec![BranchOperation::new(0xFFFF_FFFF_FFFF_FFF0, 4, 0, false)];
+    assert!(prove_and_verify(&ops));
+}
+
+#[test]
+fn test_border_negative_offset() {
+    // PC + negative offset (offset >= 2^31 is negative in signed interpretation)
+    let negative_4: u32 = (-4i32) as u32; // 0xFFFFFFFC
+    let ops = vec![BranchOperation::new(0x1000, negative_4, 0, false)];
+    // Expected: next_pc = 0x1000 + (-4) = 0x0FFC, masked to even = 0x0FFC
+    assert!(prove_and_verify(&ops));
+}
+
+#[test]
+fn test_border_jalr_operation() {
+    // JALR: uses register as base instead of pc
+    let ops = vec![BranchOperation::new(0x1000, 8, 0x2000, true)];
+    // Expected: next_pc = 0x2000 + 8 = 0x2008, masked to even = 0x2008
+    assert!(prove_and_verify(&ops));
+}
+
+#[test]
+fn test_border_jalr_with_negative_offset() {
+    // JALR with negative offset
+    let negative_16: u32 = (-16i32) as u32;
+    let ops = vec![BranchOperation::new(0x1000, negative_16, 0x3000, true)];
+    // Expected: next_pc = 0x3000 + (-16) = 0x2FF0, masked to even = 0x2FF0
+    assert!(prove_and_verify(&ops));
+}
+
+#[test]
+fn test_border_odd_result_gets_masked() {
+    // Verify LSB masking: offset = 5 should result in even next_pc
+    let ops = vec![BranchOperation::new(0x1000, 5, 0, false)];
+    // Expected: unmasked = 0x1005, masked = 0x1004
+    let op = &ops[0];
+    let next_pc = op.compute_next_pc();
+    assert_eq!(next_pc & 1, 0, "LSB should be masked to 0");
+    assert!(prove_and_verify(&ops));
+}
+
+// =============================================================================
+// Completeness Tests (valid lookups should be accepted)
+// =============================================================================
+
+#[test]
+fn test_completeness_simple_branch() {
+    let ops = vec![BranchOperation::new(0x1000, 0x100, 0, false)];
+    assert!(prove_and_verify(&ops));
+}
+
+#[test]
+fn test_completeness_simple_jalr() {
+    let ops = vec![BranchOperation::new(0x1000, 0x20, 0x5000, true)];
+    assert!(prove_and_verify(&ops));
+}
+
+#[test]
+fn test_completeness_multiple_lookups() {
+    let ops = vec![
+        BranchOperation::new(0x1000, 4, 0, false),
+        BranchOperation::new(0x2000, 8, 0, false),
+        BranchOperation::new(0x3000, 12, 0x4000, true),
+    ];
+    assert!(prove_and_verify(&ops));
+}
+
+#[test]
+fn test_completeness_duplicate_lookups() {
+    // Same operation multiple times
+    let ops = vec![
+        BranchOperation::new(0x1000, 100, 0, false),
+        BranchOperation::new(0x1000, 100, 0, false),
+        BranchOperation::new(0x1000, 100, 0, false),
+    ];
+    assert!(prove_and_verify(&ops));
+}
+
+#[test]
+fn test_completeness_mixed_jalr_and_branch() {
+    let ops = vec![
+        BranchOperation::new(0x1000, 16, 0, false),          // branch
+        BranchOperation::new(0x2000, 32, 0x8000, true),      // jalr
+        BranchOperation::new(0x3000, (-8i32) as u32, 0, false), // branch with negative offset
+        BranchOperation::new(0x4000, (-16i32) as u32, 0xA000, true), // jalr with negative offset
+    ];
+    assert!(prove_and_verify(&ops));
+}
+
+// =============================================================================
+// Soundness Tests (invalid lookups should be rejected)
+// =============================================================================
+
+#[test]
+fn test_soundness_wrong_next_pc() {
+    // Sender expects next_pc = 0x1004, but receiver has wrong value
+    let ops = vec![BranchOperation::new(0x1000, 4, 0, false)];
+
+    let receiver_rows = vec![CustomBranchRow {
+        pc: 0x1000,
+        offset: 4,
+        register: 0,
+        jalr: false,
+        next_pc: 0x1008, // Wrong! Should be 0x1004
+        multiplicity: 1,
+    }];
+
+    assert!(!prove_and_verify_custom(&ops, &receiver_rows));
+}
+
+#[test]
+fn test_soundness_wrong_jalr_flag() {
+    // Sender expects JALR=false, receiver has JALR=true
+    let ops = vec![BranchOperation::new(0x1000, 4, 0, false)];
+
+    // Receiver claims it's a JALR instruction with register=0x1000
+    // This would give the same result but wrong flag
+    let receiver_rows = vec![CustomBranchRow {
+        pc: 0x1000,
+        offset: 4,
+        register: 0x1000, // Use register that would give same result
+        jalr: true,       // Wrong flag!
+        next_pc: 0x1004,
+        multiplicity: 1,
+    }];
+
+    assert!(!prove_and_verify_custom(&ops, &receiver_rows));
+}
+
+#[test]
+fn test_soundness_multiplicity_mismatch() {
+    // Sender has 2 lookups, receiver only has 1
+    let ops = vec![
+        BranchOperation::new(0x1000, 4, 0, false),
+        BranchOperation::new(0x1000, 4, 0, false),
+    ];
+
+    let op = &ops[0];
+    let receiver_rows = vec![CustomBranchRow {
+        pc: op.pc,
+        offset: op.offset,
+        register: op.register,
+        jalr: op.jalr,
+        next_pc: op.compute_next_pc(),
+        multiplicity: 1, // Should be 2!
+    }];
+
+    assert!(!prove_and_verify_custom(&ops, &receiver_rows));
+}
+
+#[test]
+fn test_soundness_missing_receiver_row() {
+    // Sender requests two different operations, receiver only has one
+    let ops = vec![
+        BranchOperation::new(0x1000, 4, 0, false),
+        BranchOperation::new(0x2000, 8, 0, false),
+    ];
+
+    let op1 = &ops[0];
+    // Only provide receiver row for first operation
+    let receiver_rows = vec![CustomBranchRow {
+        pc: op1.pc,
+        offset: op1.offset,
+        register: op1.register,
+        jalr: op1.jalr,
+        next_pc: op1.compute_next_pc(),
+        multiplicity: 1,
+    }];
+
+    assert!(!prove_and_verify_custom(&ops, &receiver_rows));
+}
+
+#[test]
+fn test_soundness_wrong_offset() {
+    // Sender expects offset=4, receiver has different offset
+    let ops = vec![BranchOperation::new(0x1000, 4, 0, false)];
+
+    let receiver_rows = vec![CustomBranchRow {
+        pc: 0x1000,
+        offset: 8, // Wrong offset!
+        register: 0,
+        jalr: false,
+        next_pc: 0x1004, // Correct next_pc for offset=4
+        multiplicity: 1,
+    }];
+
+    assert!(!prove_and_verify_custom(&ops, &receiver_rows));
+}

--- a/prover/src/tests/branch_constraints_tests.rs
+++ b/prover/src/tests/branch_constraints_tests.rs
@@ -53,7 +53,7 @@ fn test_carry_computation_simple_positive() {
     // pc = 0x1000, offset = 4 (positive)
     // next_pc = 0x1004
     let base: u64 = 0x1000;
-    let offset: u32 = 4;
+    let offset: u64 = 4;
     let next_pc_unmasked: u64 = 0x1004;
 
     let (carry_0, carry_1) = compute_carries(base, offset, next_pc_unmasked);
@@ -68,7 +68,7 @@ fn test_carry_computation_with_carry_0() {
     // pc = 0xFFFF_FFFF, offset = 1 (positive)
     // next_pc = 0x1_0000_0000
     let base: u64 = 0xFFFF_FFFF;
-    let offset: u32 = 1;
+    let offset: u64 = 1;
     let next_pc_unmasked: u64 = 0x1_0000_0000;
 
     let (carry_0, carry_1) = compute_carries(base, offset, next_pc_unmasked);
@@ -80,10 +80,10 @@ fn test_carry_computation_with_carry_0() {
 
 #[test]
 fn test_carry_computation_negative_offset() {
-    // pc = 0x1000, offset = -4 (0xFFFFFFFC)
+    // pc = 0x1000, offset = -4 (sign-extended to 64-bit)
     // next_pc = 0x0FFC (no carry since subtraction)
     let base: u64 = 0x1000;
-    let offset: u32 = (-4i32) as u32; // 0xFFFFFFFC
+    let offset: u64 = (-4i64) as u64; // 0xFFFF_FFFF_FFFF_FFFC
     let op = BranchOperation::new(base, offset, 0, false);
     let next_pc_unmasked = op.compute_next_pc_unmasked();
 
@@ -96,9 +96,9 @@ fn test_carry_computation_negative_offset() {
 
 #[test]
 fn test_carry_computation_large_negative_offset() {
-    // pc = 0x1000_0000_0000, offset = -0x1000 (large negative)
+    // pc = 0x1000_0000_0000, offset = -0x1000 (large negative, sign-extended)
     let base: u64 = 0x1000_0000_0000;
-    let offset: u32 = (-0x1000i32) as u32;
+    let offset: u64 = (-0x1000i64) as u64;
     let op = BranchOperation::new(base, offset, 0, false);
     let next_pc_unmasked = op.compute_next_pc_unmasked();
 
@@ -130,8 +130,8 @@ fn test_branch_operation_lsb_masking() {
 
 #[test]
 fn test_branch_operation_negative_offset() {
-    // -4 should be sign-extended
-    let op = BranchOperation::new(0x1000, (-4i32) as u32, 0, false);
+    // -4 sign-extended to 64-bit
+    let op = BranchOperation::new(0x1000, (-4i64) as u64, 0, false);
     assert_eq!(op.compute_next_pc(), 0x0FFC);
 }
 
@@ -145,7 +145,7 @@ fn test_branch_operation_jalr() {
 
 #[test]
 fn test_branch_operation_jalr_negative_offset() {
-    let op = BranchOperation::new(0x1000, (-16i32) as u32, 0x3000, true);
+    let op = BranchOperation::new(0x1000, (-16i64) as u64, 0x3000, true);
     // register (0x3000) + (-16) = 0x2FF0
     assert_eq!(op.compute_next_pc(), 0x2FF0);
 }

--- a/prover/src/tests/branch_constraints_tests.rs
+++ b/prover/src/tests/branch_constraints_tests.rs
@@ -1,0 +1,248 @@
+//! Tests for BRANCH table constraints.
+//!
+//! These tests verify:
+//! - Constraint formula correctness (IS_BIT on carries)
+//! - Carry computation validity
+//! - Sign extension handling
+
+use crate::tables::branch::{branch_constraints, compute_carries, BranchOperation};
+use crate::tables::types::FE;
+use stark::constraints::transition::TransitionConstraint;
+
+// =========================================================================
+// Basic Constraint Property Tests
+// =========================================================================
+
+#[test]
+fn test_branch_constraint_degree() {
+    let (constraints, _) = branch_constraints(0);
+
+    // Both carry IS_BIT constraints have degree 4
+    // (degree 2 for base computation due to JALR multiplication,
+    //  then degree 2 for IS_BIT X*(1-X), total degree 4)
+    for c in &constraints {
+        assert_eq!(c.degree(), 4);
+    }
+}
+
+#[test]
+fn test_branch_constraint_indices_unique() {
+    let (constraints, next_idx) = branch_constraints(0);
+
+    assert_eq!(constraints.len(), 2);
+    assert_eq!(constraints[0].constraint_idx(), 0);
+    assert_eq!(constraints[1].constraint_idx(), 1);
+    assert_eq!(next_idx, 2);
+}
+
+#[test]
+fn test_branch_constraint_indices_with_offset() {
+    let (constraints, next_idx) = branch_constraints(10);
+
+    assert_eq!(constraints[0].constraint_idx(), 10);
+    assert_eq!(constraints[1].constraint_idx(), 11);
+    assert_eq!(next_idx, 12);
+}
+
+// =========================================================================
+// Carry Computation Tests
+// =========================================================================
+
+#[test]
+fn test_carry_computation_simple_positive() {
+    // pc = 0x1000, offset = 4 (positive)
+    // next_pc = 0x1004
+    let base: u64 = 0x1000;
+    let offset: u32 = 4;
+    let next_pc_unmasked: u64 = 0x1004;
+
+    let (carry_0, carry_1) = compute_carries(base, offset, next_pc_unmasked);
+
+    // Small values, no carries expected
+    assert_eq!(carry_0, 0);
+    assert_eq!(carry_1, 0);
+}
+
+#[test]
+fn test_carry_computation_with_carry_0() {
+    // pc = 0xFFFF_FFFF, offset = 1 (positive)
+    // next_pc = 0x1_0000_0000
+    let base: u64 = 0xFFFF_FFFF;
+    let offset: u32 = 1;
+    let next_pc_unmasked: u64 = 0x1_0000_0000;
+
+    let (carry_0, carry_1) = compute_carries(base, offset, next_pc_unmasked);
+
+    // Overflow from low word to high word
+    assert_eq!(carry_0, 1);
+    assert_eq!(carry_1, 0);
+}
+
+#[test]
+fn test_carry_computation_negative_offset() {
+    // pc = 0x1000, offset = -4 (0xFFFFFFFC)
+    // next_pc = 0x0FFC (no carry since subtraction)
+    let base: u64 = 0x1000;
+    let offset: u32 = (-4i32) as u32; // 0xFFFFFFFC
+    let op = BranchOperation::new(base, offset, 0, false);
+    let next_pc_unmasked = op.compute_next_pc_unmasked();
+
+    let (carry_0, carry_1) = compute_carries(base, offset, next_pc_unmasked);
+
+    // With negative offset (sign-extended), carries can be 0 or 1
+    assert!(carry_0 == 0 || carry_0 == 1);
+    assert!(carry_1 == 0 || carry_1 == 1);
+}
+
+#[test]
+fn test_carry_computation_large_negative_offset() {
+    // pc = 0x1000_0000_0000, offset = -0x1000 (large negative)
+    let base: u64 = 0x1000_0000_0000;
+    let offset: u32 = (-0x1000i32) as u32;
+    let op = BranchOperation::new(base, offset, 0, false);
+    let next_pc_unmasked = op.compute_next_pc_unmasked();
+
+    let (carry_0, carry_1) = compute_carries(base, offset, next_pc_unmasked);
+
+    // Carries should be valid bits
+    assert!(carry_0 == 0 || carry_0 == 1);
+    assert!(carry_1 == 0 || carry_1 == 1);
+}
+
+// =========================================================================
+// BranchOperation Tests
+// =========================================================================
+
+#[test]
+fn test_branch_operation_simple() {
+    let op = BranchOperation::new(0x1000, 4, 0, false);
+    assert_eq!(op.compute_next_pc(), 0x1004);
+}
+
+#[test]
+fn test_branch_operation_lsb_masking() {
+    // Offset 5 should result in masked address
+    let op = BranchOperation::new(0x1000, 5, 0, false);
+    let next_pc = op.compute_next_pc();
+    assert_eq!(next_pc, 0x1004); // 0x1005 masked to 0x1004
+    assert_eq!(next_pc & 1, 0); // LSB is 0
+}
+
+#[test]
+fn test_branch_operation_negative_offset() {
+    // -4 should be sign-extended
+    let op = BranchOperation::new(0x1000, (-4i32) as u32, 0, false);
+    assert_eq!(op.compute_next_pc(), 0x0FFC);
+}
+
+#[test]
+fn test_branch_operation_jalr() {
+    // JALR uses register as base
+    let op = BranchOperation::new(0x1000, 8, 0x2000, true);
+    // Should use register (0x2000) + offset (8) = 0x2008
+    assert_eq!(op.compute_next_pc(), 0x2008);
+}
+
+#[test]
+fn test_branch_operation_jalr_negative_offset() {
+    let op = BranchOperation::new(0x1000, (-16i32) as u32, 0x3000, true);
+    // register (0x3000) + (-16) = 0x2FF0
+    assert_eq!(op.compute_next_pc(), 0x2FF0);
+}
+
+#[test]
+fn test_branch_operation_unmasked_vs_masked() {
+    let op = BranchOperation::new(0x1000, 5, 0, false);
+    let unmasked = op.compute_next_pc_unmasked();
+    let masked = op.compute_next_pc();
+
+    assert_eq!(unmasked, 0x1005);
+    assert_eq!(masked, 0x1004);
+    assert_eq!(masked, unmasked & !1);
+}
+
+// =========================================================================
+// Sign Extension Tests
+// =========================================================================
+
+#[test]
+fn test_sign_extension_positive() {
+    // Offset with MSB=0 (positive): no sign extension
+    let offset: u32 = 0x7FFF_FFFF; // Max positive 32-bit signed
+    let extended = offset as i32 as i64 as u64;
+    assert_eq!(extended >> 32, 0); // High word should be 0
+}
+
+#[test]
+fn test_sign_extension_negative() {
+    // Offset with MSB=1 (negative): sign extension fills high word
+    let offset: u32 = 0x8000_0000; // Min negative 32-bit signed
+    let extended = offset as i32 as i64 as u64;
+    assert_eq!(extended >> 32, 0xFFFF_FFFF); // High word should be all 1s
+}
+
+#[test]
+fn test_sign_extension_minus_one() {
+    // -1 in 32-bit is 0xFFFFFFFF
+    let offset: u32 = 0xFFFF_FFFF;
+    let extended = offset as i32 as i64 as u64;
+    assert_eq!(extended, 0xFFFF_FFFF_FFFF_FFFF); // Full 64-bit -1
+}
+
+// =========================================================================
+// Edge Case Tests
+// =========================================================================
+
+#[test]
+fn test_branch_zero_values() {
+    let op = BranchOperation::new(0, 0, 0, false);
+    assert_eq!(op.compute_next_pc(), 0);
+}
+
+#[test]
+fn test_branch_max_pc_small_offset() {
+    let op = BranchOperation::new(0xFFFF_FFFF_FFFF_FFF0, 4, 0, false);
+    // Should wrap around
+    let next_pc = op.compute_next_pc();
+    assert_eq!(next_pc, 0xFFFF_FFFF_FFFF_FFF4);
+}
+
+#[test]
+fn test_branch_overflow_wraps() {
+    // PC at max, positive offset causes wrap
+    let op = BranchOperation::new(0xFFFF_FFFF_FFFF_FFFE, 4, 0, false);
+    let next_pc = op.compute_next_pc();
+    // Wraps around: 0xFFFF_FFFF_FFFF_FFFE + 4 = 0x2 (mod 2^64), masked to 0x2
+    assert_eq!(next_pc, 0x2);
+}
+
+// =========================================================================
+// IS_BIT Formula Tests
+// =========================================================================
+
+#[test]
+fn test_is_bit_formula_valid_zero() {
+    // IS_BIT formula: X * (1 - X) = 0
+    // When X = 0: 0 * 1 = 0 ✓
+    let x = FE::zero();
+    let result = x * (FE::one() - x);
+    assert_eq!(result, FE::zero());
+}
+
+#[test]
+fn test_is_bit_formula_valid_one() {
+    // IS_BIT formula: X * (1 - X) = 0
+    // When X = 1: 1 * 0 = 0 ✓
+    let x = FE::one();
+    let result = x * (FE::one() - x);
+    assert_eq!(result, FE::zero());
+}
+
+#[test]
+fn test_is_bit_formula_invalid_two() {
+    // IS_BIT formula: X * (1 - X) = 0
+    // When X = 2: 2 * (-1) = -2 ≠ 0 ✗
+    let x = FE::from(2u64);
+    let result = x * (FE::one() - x);
+    assert_ne!(result, FE::zero());
+}

--- a/prover/src/tests/branch_constraints_tests.rs
+++ b/prover/src/tests/branch_constraints_tests.rs
@@ -5,7 +5,7 @@
 //! - Carry computation validity
 //! - Sign extension handling
 
-use crate::tables::branch::{branch_constraints, compute_carries, BranchOperation};
+use crate::tables::branch::{BranchOperation, branch_constraints, compute_carries};
 use crate::tables::types::FE;
 use stark::constraints::transition::TransitionConstraint;
 

--- a/prover/src/tests/cpu_tests.rs
+++ b/prover/src/tests/cpu_tests.rs
@@ -323,8 +323,9 @@ fn test_bus_interactions_count() {
     // - 1 M6 (LOAD from memory)
     // - 1 M7 (STORE to memory)
     // - 1 DECODE (instruction fetch)
-    // Total: 8 + 8 + 8 + 2 + 1 + 1 + 1 + 5 + 1 = 35
-    assert_eq!(interactions.len(), 35);
+    // - 1 BRANCH (branch/jump target calculation)
+    // Total: 8 + 8 + 8 + 2 + 1 + 1 + 1 + 5 + 1 + 1 = 36
+    assert_eq!(interactions.len(), 36);
 }
 
 #[test]

--- a/prover/src/tests/decode_tests.rs
+++ b/prover/src/tests/decode_tests.rs
@@ -876,9 +876,8 @@ fn test_decode_soundness_different_elf_rejected() {
     use crate::tables::trace_builder::Traces;
     use crate::tables::types::{GoldilocksExtension, GoldilocksField};
     use crate::test_utils::{
-        create_bitwise_air, create_branch_air, create_cpu_air,
-        create_decode_air, create_halt_air, create_load_air,
-        create_lt_air, create_memw_air,
+        create_bitwise_air, create_branch_air, create_cpu_air, create_decode_air, create_halt_air,
+        create_load_air, create_lt_air, create_memw_air,
     };
 
     type F = GoldilocksField;
@@ -1006,9 +1005,8 @@ fn test_decode_soundness_same_elf_accepted() {
     use crate::tables::trace_builder::Traces;
     use crate::tables::types::{GoldilocksExtension, GoldilocksField};
     use crate::test_utils::{
-        create_bitwise_air, create_branch_air, create_cpu_air,
-        create_decode_air, create_halt_air, create_load_air,
-        create_lt_air, create_memw_air,
+        create_bitwise_air, create_branch_air, create_cpu_air, create_decode_air, create_halt_air,
+        create_load_air, create_lt_air, create_memw_air,
     };
 
     type F = GoldilocksField;

--- a/prover/src/tests/decode_tests.rs
+++ b/prover/src/tests/decode_tests.rs
@@ -871,8 +871,8 @@ fn test_decode_soundness_different_elf_rejected() {
     use crate::tables::trace_builder::Traces;
     use crate::tables::types::{GoldilocksExtension, GoldilocksField};
     use crate::test_utils::{
-        create_bitwise_air, create_cpu_air, create_decode_air, create_load_air, create_lt_air,
-        create_memw_air,
+        create_bitwise_air, create_branch_air, create_cpu_air, create_decode_air, create_load_air,
+        create_lt_air, create_memw_air,
     };
 
     type F = GoldilocksField;
@@ -920,6 +920,7 @@ fn test_decode_soundness_different_elf_rejected() {
     let prover_lt_air = create_lt_air(&proof_options);
     let prover_memw_air = create_memw_air(&proof_options);
     let prover_load_air = create_load_air(&proof_options);
+    let prover_branch_air = create_branch_air(&proof_options);
     let prover_decode_air = create_decode_air(&proof_options).with_preprocessed(
         commitment_a, // Prover uses commitment from ELF A
         decode::NUM_PRECOMPUTED_COLS,
@@ -935,6 +936,7 @@ fn test_decode_soundness_different_elf_rejected() {
         (&prover_lt_air, &mut traces.lt, &()),
         (&prover_memw_air, &mut traces.memw, &()),
         (&prover_load_air, &mut traces.load, &()),
+        (&prover_branch_air, &mut traces.branch, &()),
         (&prover_decode_air, &mut traces.decode, &()),
     ];
 
@@ -949,6 +951,7 @@ fn test_decode_soundness_different_elf_rejected() {
     let verifier_lt_air = create_lt_air(&proof_options);
     let verifier_memw_air = create_memw_air(&proof_options);
     let verifier_load_air = create_load_air(&proof_options);
+    let verifier_branch_air = create_branch_air(&proof_options);
     let verifier_decode_air = create_decode_air(&proof_options).with_preprocessed(
         commitment_b, // Verifier uses commitment from ELF B (DIFFERENT!)
         decode::NUM_PRECOMPUTED_COLS,
@@ -960,6 +963,7 @@ fn test_decode_soundness_different_elf_rejected() {
         &verifier_lt_air,
         &verifier_memw_air,
         &verifier_load_air,
+        &verifier_branch_air,
         &verifier_decode_air,
     ];
 
@@ -992,8 +996,8 @@ fn test_decode_soundness_same_elf_accepted() {
     use crate::tables::trace_builder::Traces;
     use crate::tables::types::{GoldilocksExtension, GoldilocksField};
     use crate::test_utils::{
-        create_bitwise_air, create_cpu_air, create_decode_air, create_load_air, create_lt_air,
-        create_memw_air,
+        create_bitwise_air, create_branch_air, create_cpu_air, create_decode_air, create_load_air,
+        create_lt_air, create_memw_air,
     };
 
     type F = GoldilocksField;
@@ -1032,6 +1036,7 @@ fn test_decode_soundness_same_elf_accepted() {
     let prover_lt_air = create_lt_air(&proof_options);
     let prover_memw_air = create_memw_air(&proof_options);
     let prover_load_air = create_load_air(&proof_options);
+    let prover_branch_air = create_branch_air(&proof_options);
     let prover_decode_air = create_decode_air(&proof_options)
         .with_preprocessed(prover_commitment, decode::NUM_PRECOMPUTED_COLS);
 
@@ -1045,6 +1050,7 @@ fn test_decode_soundness_same_elf_accepted() {
         (&prover_lt_air, &mut traces.lt, &()),
         (&prover_memw_air, &mut traces.memw, &()),
         (&prover_load_air, &mut traces.load, &()),
+        (&prover_branch_air, &mut traces.branch, &()),
         (&prover_decode_air, &mut traces.decode, &()),
     ];
 
@@ -1065,6 +1071,7 @@ fn test_decode_soundness_same_elf_accepted() {
     let verifier_lt_air = create_lt_air(&proof_options);
     let verifier_memw_air = create_memw_air(&proof_options);
     let verifier_load_air = create_load_air(&proof_options);
+    let verifier_branch_air = create_branch_air(&proof_options);
     let verifier_decode_air = create_decode_air(&proof_options)
         .with_preprocessed(verifier_commitment, decode::NUM_PRECOMPUTED_COLS);
 
@@ -1074,6 +1081,7 @@ fn test_decode_soundness_same_elf_accepted() {
         &verifier_lt_air,
         &verifier_memw_air,
         &verifier_load_air,
+        &verifier_branch_air,
         &verifier_decode_air,
     ];
 

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -3,6 +3,10 @@ pub mod bitwise_bus_tests;
 #[cfg(test)]
 pub mod bitwise_tests;
 #[cfg(test)]
+pub mod branch_bus_tests;
+#[cfg(test)]
+pub mod branch_constraints_tests;
+#[cfg(test)]
 pub mod constraints_tests;
 #[cfg(test)]
 pub mod cpu_tests;

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -32,9 +32,8 @@ use crate::tables::types::{GoldilocksExtension, GoldilocksField};
 
 // Import shared utilities
 use crate::test_utils::{
-    create_bitwise_air, create_branch_air, create_cpu_air,
-    create_decode_air, create_halt_air, create_load_air,
-    create_lt_air, create_memw_air, run_asm_elf,
+    create_bitwise_air, create_branch_air, create_cpu_air, create_decode_air, create_halt_air,
+    create_load_air, create_lt_air, create_memw_air, run_asm_elf,
 };
 
 type F = GoldilocksField;

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -32,8 +32,8 @@ use crate::tables::types::{GoldilocksExtension, GoldilocksField};
 
 // Import shared utilities
 use crate::test_utils::{
-    create_bitwise_air, create_cpu_air, create_decode_air, create_load_air, create_lt_air,
-    create_memw_air, run_asm_elf,
+    create_bitwise_air, create_branch_air, create_cpu_air, create_decode_air, create_load_air,
+    create_lt_air, create_memw_air, run_asm_elf,
 };
 
 type F = GoldilocksField;
@@ -43,7 +43,7 @@ type E = GoldilocksExtension;
 // Prover test helpers
 // =============================================================================
 
-/// Run multi_prove and multi_verify for all VM tables (CPU + Bitwise + LT + MEMW + LOAD + DECODE).
+/// Run multi_prove and multi_verify for all VM tables.
 ///
 /// Uses the FULL 2^20 row bitwise table with preprocessed commitment.
 /// Returns true if verification succeeds.
@@ -54,6 +54,7 @@ fn prove_and_verify_vm(
     memw_trace: &mut TraceTable<F, E>,
     load_trace: &mut TraceTable<F, E>,
     decode_trace: &mut TraceTable<F, E>,
+    branch_trace: &mut TraceTable<F, E>,
     elf: &Elf,
 ) -> bool {
     let proof_options = ProofOptions::default_test_options();
@@ -73,6 +74,7 @@ fn prove_and_verify_vm(
             .expect("Failed to compute decode commitment"),
         decode::NUM_PRECOMPUTED_COLS,
     );
+    let branch_air = create_branch_air(&proof_options);
 
     let air_trace_pairs: Vec<(
         &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
@@ -85,6 +87,7 @@ fn prove_and_verify_vm(
         (&memw_air, memw_trace, &()),
         (&load_air, load_trace, &()),
         (&decode_air, decode_trace, &()),
+        (&branch_air, branch_trace, &()),
     ];
 
     let multi_proof =
@@ -103,6 +106,7 @@ fn prove_and_verify_vm(
         &memw_air,
         &load_air,
         &decode_air,
+        &branch_air,
     ];
 
     let result = Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[]));
@@ -112,7 +116,7 @@ fn prove_and_verify_vm(
     result
 }
 
-/// Run multi_prove and multi_verify for all VM tables (CPU + Bitwise + LT + MEMW + LOAD + DECODE).
+/// Run multi_prove and multi_verify for all VM tables.
 ///
 /// Used for fast tests where the bitwise table is a dummy that only contains
 /// the rows needed to balance the bus. NOT the full preprocessed table.
@@ -123,6 +127,7 @@ fn prove_and_verify_vm_minimal(
     memw_trace: &mut TraceTable<F, E>,
     load_trace: &mut TraceTable<F, E>,
     decode_trace: &mut TraceTable<F, E>,
+    branch_trace: &mut TraceTable<F, E>,
 ) -> bool {
     let proof_options = ProofOptions::default_test_options();
 
@@ -132,6 +137,7 @@ fn prove_and_verify_vm_minimal(
     let memw_air = create_memw_air(&proof_options);
     let load_air = create_load_air(&proof_options);
     let decode_air = create_decode_air(&proof_options);
+    let branch_air = create_branch_air(&proof_options);
 
     let air_trace_pairs: Vec<(
         &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
@@ -144,6 +150,7 @@ fn prove_and_verify_vm_minimal(
         (&memw_air, memw_trace, &()),
         (&load_air, load_trace, &()),
         (&decode_air, decode_trace, &()),
+        (&branch_air, branch_trace, &()),
     ];
 
     let multi_proof =
@@ -162,6 +169,7 @@ fn prove_and_verify_vm_minimal(
         &memw_air,
         &load_air,
         &decode_air,
+        &branch_air,
     ];
 
     Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[]))
@@ -243,7 +251,8 @@ fn test_prove_elfs_sub_fast() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "Proof verification failed for sub program (fast)"
     );
@@ -268,7 +277,8 @@ fn test_prove_elfs_sub_neg_result_fast() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "Proof verification failed for sub_neg_result program (fast)"
     );
@@ -293,7 +303,8 @@ fn test_prove_elfs_sub_underflow_fast() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "Proof verification failed for sub_underflow program (fast)"
     );
@@ -318,7 +329,8 @@ fn test_prove_elfs_subw_fast() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "Proof verification failed for subw program (fast)"
     );
@@ -344,7 +356,8 @@ fn test_prove_elfs_arith_lui_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "Proof verification failed for arith_lui_8 program"
     );
@@ -370,7 +383,8 @@ fn test_prove_elfs_arith_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "Proof verification failed for arith_8 program"
     );
@@ -399,7 +413,8 @@ fn test_prove_elfs_basic_arith_32() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "Proof verification failed for basic_arith_32 program"
     );
@@ -441,7 +456,8 @@ fn test_prove_elfs_comprehensive() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "Proof verification failed for comprehensive_test program"
     );
@@ -465,7 +481,8 @@ fn test_prove_elfs_test_add_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_add_8 failed"
     );
@@ -483,7 +500,8 @@ fn test_prove_elfs_test_sub_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_sub_8 failed"
     );
@@ -501,7 +519,8 @@ fn test_prove_elfs_test_addw_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_addw_8 failed"
     );
@@ -520,7 +539,8 @@ fn test_prove_elfs_test_subw_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_subw_8 failed"
     );
@@ -539,7 +559,8 @@ fn test_prove_elfs_test_addw_lui_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_addw_lui_8 failed"
     );
@@ -558,7 +579,8 @@ fn test_prove_elfs_test_subw_lui_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_subw_lui_8 failed"
     );
@@ -577,7 +599,8 @@ fn test_prove_elfs_test_add_neg_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_add_neg_8 failed"
     );
@@ -596,7 +619,8 @@ fn test_prove_elfs_test_sub_neg_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_sub_neg_8 failed"
     );
@@ -615,7 +639,8 @@ fn test_prove_elfs_test_mul_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_mul_8 failed"
     );
@@ -634,7 +659,8 @@ fn test_prove_elfs_test_div_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_div_8 failed"
     );
@@ -653,7 +679,8 @@ fn test_prove_elfs_test_shift_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_shift_8 failed"
     );
@@ -672,7 +699,8 @@ fn test_prove_elfs_test_bitwise_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_bitwise_8 failed"
     );
@@ -700,7 +728,8 @@ fn test_prove_elfs_test_slt_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_slt_8 failed"
     );
@@ -723,7 +752,8 @@ fn test_prove_elfs_test_xor_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_xor_8 failed"
     );
@@ -741,7 +771,8 @@ fn test_prove_elfs_test_lb_lh_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_lb_lh_8 failed"
     );
@@ -760,7 +791,8 @@ fn test_prove_elfs_test_sb_sh_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "test_sb_sh_8 failed"
     );
@@ -788,7 +820,8 @@ fn test_prove_elfs_all_branches_16() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "all_branches_16 failed"
     );
@@ -807,7 +840,8 @@ fn test_prove_elfs_all_loadstore_32() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "all_loadstore_32 failed"
     );
@@ -839,7 +873,8 @@ fn test_prove_elfs_all_instructions_64() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "all_instructions_64 failed"
     );
@@ -879,6 +914,7 @@ fn test_prove_elfs_all_instructions_64_full() {
             &mut traces.memw,
             &mut traces.load,
             &mut traces.decode,
+            &mut traces.branch,
             &elf,
         ),
         "all_instructions_64_full failed - comprehensive test with full bitwise table"
@@ -918,7 +954,8 @@ fn test_dhat_memory_profile() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.branch
         ),
         "verification failed"
     );


### PR DESCRIPTION
 ## Summary
  - Adds BRANCH table that computes `next_pc` for branch and jump instructions
  - Supports PC-relative branches (`next_pc = pc + offset`) and JALR (`next_pc = (register + offset) &
  !1`)
  - Implements RISC-V ISA LSB masking requirement via AND_BYTE bus lookup

  ## Changes
  - **New**: `prover/src/tables/branch.rs` (14 columns, 2 constraints)
  - **New**: `prover/src/tests/branch_bus_tests.rs` - completeness/soundness tests
  - **New**: `prover/src/tests/branch_constraints_tests.rs` - carry IS_BIT tests
  - **Modified**: CPU table sends to BRANCH bus when `branch_cond = 1`
  - **Modified**: trace_builder collects BRANCH ops in phase 2

  ## Bus Interactions
  | Direction | Bus | Purpose |
  |-----------|-----|---------|
  | Sender | IS_BYTE | Range check `next_pc_low[1]` |
  | Sender | AND_BYTE | LSB masking: `next_pc_low[0] = unmasked & 0xFE` |
  | Sender | IS_HALFWORD ×3 | Range check `next_pc_high[0..2]` |
  | Receiver | BRANCH | From CPU with signature `[next_pc, pc, offset, register, JALR]` |