### PR TITLE
spec: `NEG` template

### DIFF
--- a/spec/book.typ
+++ b/spec/book.typ
@@ -11,7 +11,7 @@
     ("variables.typ", [Variables], <vars>),
     ("is_bit.typ", [IS_BIT template], <isbit>),
     ("add.typ", [ADD/SUB template], <add>),
-    ("neg.typ", [NEG template], <meg>),
+    ("neg.typ", [NEG template], <neg>),
     ("decode.typ", [DECODE table], <decode>),
     ("cpu.typ", [CPU chip], <cpu>),
     ("shift.typ", [SHIFT chip], <shift>),

--- a/spec/book.typ
+++ b/spec/book.typ
@@ -11,6 +11,7 @@
     ("variables.typ", [Variables], <vars>),
     ("is_bit.typ", [IS_BIT template], <isbit>),
     ("add.typ", [ADD/SUB template], <add>),
+    ("neg.typ", [NEG template], <meg>),
     ("decode.typ", [DECODE table], <decode>),
     ("cpu.typ", [CPU chip], <cpu>),
     ("shift.typ", [SHIFT chip], <shift>),

--- a/spec/expr.typ
+++ b/spec/expr.typ
@@ -153,7 +153,7 @@
       let (val, idxs) = flat_idxs(e)
       $#rec(PREC.idx, val)_(#idxs.map(idx => rec(PREC.idx, idx)).join($, $))$
     },
-    "not": (pp, rec, e) => mwrap($1 - #rec(PREC.not, e.at(1))$, pp < PREC.not),
+    "not": (pp, rec, e) => mwrap(rec(PREC.not, 1) + $ - #rec(PREC.not, e.at(1))$, pp < PREC.not),
     "+": (pp, rec, e) => mwrap($#e.slice(1).map(rec.with(PREC.add)).join($+$)$, pp < PREC.add),
     "sum": (pp, rec, e) => {
       assert(e.len() == 4, message: "invalid sum:" + repr(e))

--- a/spec/expr.typ
+++ b/spec/expr.typ
@@ -92,7 +92,7 @@
 #let expr_to_code = make_expr_formatter(
   (
     "idx": (pp, rec, e) => rec(PREC.MIN, e.at(1)) + `[` + rec(PREC.MAX, e.at(2)) + `]`,
-    "not": (pp, rec, e) => cwrap(`1 - ` + rec(PREC.not, e.at(1)), pp < PREC.not),
+    "not": (pp, rec, e) => cwrap(rec(PREC.not, 1) + ` - ` + rec(PREC.not, e.at(1)), pp < PREC.not),
     "+": (pp, rec, e) => cwrap(e.slice(1).map(rec.with(PREC.add)).join(` + `), pp < PREC.add),
     "sum": (pp, rec, e) => assert(false, message: "sum is unsupported in code."),
     "*": (pp, rec, e) => {

--- a/spec/neg.typ
+++ b/spec/neg.typ
@@ -33,13 +33,7 @@ where `cond` is a bit value (i.e., lies in ${0, 1}$)  described by an expression
 
 == Constraints
 For `neg` to equal $-#`x`$, both values must add to $0 mod 2^64$.
-Zooming in on the addition, we find that the carry values of adding the limbs must both equal to $1$, except when $#`x` = 0$, in which case they should both be $0$.
-
-To this end, we require $#`carry`_0$ is $1$, unless $#`x` = 0$ (@neg:c:carry) and
-that both limbs of `carry` are identical (@neg:c:identical_carry ensuring).
-Of course, both constraints are conditional on $#`cond` = 1$.
-Lastly, note that this @neg:c:carry implicitly enforces that $#`carry`_0 in {0, 1}$, while @neg:c:identical_carry ensures $#`carry`_1$ must also be binary.
-
+This is constrained through the following:
 #render_constraint_table(chip, config)
 
 == Note

--- a/spec/neg.typ
+++ b/spec/neg.typ
@@ -32,9 +32,33 @@ where `cond` is a bit value (i.e., lies in ${0, 1}$)  described by an expression
 #render_chip_assumptions(chip, config)
 
 == Constraints
-For `neg` to equal $-#`x`$, both values must add to $0 mod 2^64$.
-This is constrained through the following:
+We constrain this equality using two constraints:
 #render_constraint_table(chip, config)
+The constraints force the `carry` values to be fixed.
+Writing `carry`'s definition, we then find that
+$
+  #`neg`_0 &= 2^32 dot #`carry`_0 - (#`x as DWordWL`)_0
+ = cases(
+  2^32 - (#`x as DWordWL`)_0 & "if" (#`x as DWordWL`)_0 != 0,
+  0 & "if" (#`x as DWordWL`)_0 = 0
+ ),\
+  #`neg`_1 &= 2^32 dot #`carry`_1 - (#`x as DWordWL`)_1 - #`carry`_0 = cases(
+  2^32 - (#`x as DWordWL`)_1 - 1 & "if" #`x` != 0,
+  0 & "if" #`x` = 0
+ )
+$
+Clearly, $#`neg` = 0$ when $#`x` = 0$ (and `cond` is set); for non-zero `x`, it holds that
+$
+  #`neg` 
+  &= #`neg`_0 + 2^32 dot #`neg`_1 \
+  &= (2^32 - (#`x as DWordWL`)_0) + 2^32 dot (2^32 - (#`x as DWordWL`)_1 - 1) \
+  &= 2^32 - (#`x as DWordWL`)_0 + 2^64 - 2^32 dot (#`x as DWordWL`)_1 - 2^32\
+  &= 2^64 - ((#`x as DWordWL`)_0 + 2^32 dot (#`x as DWordWL`)_1) \
+  &= 2^64 - #`x`\
+  &equiv -x mod 2^64
+$
+when `cond` is set.
+When `cond` is not set, the two lookups are not executed, allowing `neg` to take any value.
 
 == Note
 It is worth noting that this construction does _not_ require the limbs of `neg` to be range checked, 

--- a/spec/neg.typ
+++ b/spec/neg.typ
@@ -47,18 +47,30 @@ $
   0 & "if" #`x` = 0
  )
 $
-Clearly, $#`neg` = 0$ when $#`x` = 0$ (and `cond` is set); for non-zero `x`, it holds that
+Clearly, $#`neg` = 0$ when $#`x` = 0$ (and `cond` is set).
+For non-zero `x`, we distinguish two cases.
+When $(#`x as DWordWL`)_0 = 0$,
 $
   #`neg` 
-  &= #`neg`_0 + 2^32 dot #`neg`_1 \
-  &= (2^32 - (#`x as DWordWL`)_0) + 2^32 dot (2^32 - (#`x as DWordWL`)_1 - 1) \
-  &= 2^32 - (#`x as DWordWL`)_0 + 2^64 - 2^32 dot (#`x as DWordWL`)_1 - 2^32\
+  &= 2^32 dot #`neg`_1 + #`neg`_0\
+  &= 2^32 dot (2^32 - (#`x as DWordWL`)_1) + 0\
+  &= 2^32 dot (2^32 - (#`x as DWordWL`)_1) + (#`x as DWordWL`)_0\
+  &= 2^64 - (2^32 dot (#`x as DWordWL`)_1 + (#`x as DWordWL`)_0)\
+  &= 2^64 - #`x`\
+  &equiv -x mod 2^64,
+$
+while when $(#`x as DWordWL`)_0 != 0$,
+$
+  #`neg` 
+  &= 2^32 dot #`neg`_1 + #`neg`_0\
+  &= 2^32 dot (2^32 - (#`x as DWordWL`)_1 - 1) + (2^32 - (#`x as DWordWL`)_0)  \
+  &= 2^64 - 2^32 dot (#`x as DWordWL`)_1 - 2^32 + 2^32 - (#`x as DWordWL`)_0  \
   &= 2^64 - ((#`x as DWordWL`)_0 + 2^32 dot (#`x as DWordWL`)_1) \
   &= 2^64 - #`x`\
   &equiv -x mod 2^64
 $
 when `cond` is set.
-When `cond` is not set, the two lookups are not executed, allowing `neg` to take any value.
+When `cond` is not set, the two lookups are not executed, allowing `neg` to take any value in either case.
 
 == Note
 It is worth noting that this construction does _not_ require the limbs of `neg` to be range checked, 

--- a/spec/neg.typ
+++ b/spec/neg.typ
@@ -1,0 +1,48 @@
+#import "/book.typ": book-page, et
+#import "/src.typ": load_config, load_chip
+#import "/chip.typ": render_chip_column_table, render_chip_assumptions, render_constraint_table
+
+#let config = load_config()
+#let chip = load_chip("src/neg.toml", config)
+#show: book-page(chip.name)
+
+#let neg = raw(chip.name)
+
+#let highlighted_code(code) = {
+  box(
+    inset: (left: 4pt, right: 4pt), 
+    outset: (top: 4pt, bottom: 4pt), 
+    radius: 2pt,
+    fill: luma(230), 
+    raw(code))
+}
+
+#neg is a constraint template that is used to assert that $#`neg` = -#`x`$, under the condition that `cond` is non-zero.
+
+== Notation
+The #neg constraint template has the following interface:
+#block(radius: 5pt, width: 100%, inset: 1.5em, fill: luma(230), raw("cond => NEG<neg; x>"))
+where `cond` is a bit value (i.e., lies in ${0, 1}$)  described by an expression _of degree at most $1$_.
+#highlighted_code("NEG<neg; x>") can be used to denote the _unconditional_ application of the #neg template to `x` and `neg` (which is equivalent to $#`cond` = 1$).
+
+== Variables
+#render_chip_column_table(chip, config)
+
+== Assumptions
+#render_chip_assumptions(chip, config)
+
+== Constraints
+For `neg` to equal $-#`x`$, both values must add to $0 mod 2^64$.
+Zooming in on the addition, we find that the carry values of adding the limbs must both equal to $1$, except when $#`x` = 0$, in which case they should both be $0$.
+
+To this end, we require $#`carry`_0$ is $1$, unless $#`x` = 0$ (@neg:c:carry) and
+that both limbs of `carry` are identical (@neg:c:identical_carry ensuring).
+Of course, both constraints are conditional on $#`cond` = 1$.
+Lastly, note that this @neg:c:carry implicitly enforces that $#`carry`_0 in {0, 1}$, while @neg:c:identical_carry ensures $#`carry`_1$ must also be binary.
+
+#render_constraint_table(chip, config)
+
+== Note
+It is worth noting that this construction does _not_ require the limbs of `neg` to be range checked, 
+thus allowing it be represented by the unrangecheckable `DWordWL` rather than a `DWordHL`.
+The input value `x` is still assumed to be range-checked, however.

--- a/spec/src/neg.toml
+++ b/spec/src/neg.toml
@@ -26,8 +26,8 @@ def = {idx="i", polys=[
 
 
 [[assumptions]]
-desc = "`IS_WORD[x[i]]`"
-iter = ["i", 0, 1]
+desc = "`IS_HALF[x[i]]`"
+iter = ["i", 0, 3]
 
 [[assumptions]]
 desc = "`IS_BIT<cond>`"

--- a/spec/src/neg.toml
+++ b/spec/src/neg.toml
@@ -1,0 +1,52 @@
+name = "NEG"
+
+[[variables.input]]
+name = "x"
+type = "DWordWL"
+desc = "value to compute negation of"
+
+[[variables.input]]
+name = "cond"
+type = "BaseField"
+desc = "condition on whether to negate x"
+
+[[variables.output]]
+name = "neg"
+type = "DWordWL"
+desc = "negation of `x` if $#`cond` != 0$; unconstrained otherwise."
+
+[[variables.virtual]]
+name = "carry"
+type = ["Bit", 2]
+desc = "carries of the addition $#`neg` + #`x`$."
+def = {idx="i", polys=[
+    {iter=0, poly=["*", ["^", 2, -32], ["+", ["idx", "x", 0], ["idx", "neg", 0]]]},
+    {iter=1, poly=["*", ["^", 2, -32], ["+", ["idx", "x", 1], ["idx", "neg", 1], ["idx", "carry", 0]]]}
+]}
+
+
+[[assumptions]]
+desc = "`IS_WORD[x[i]]`"
+iter = ["i", 0, 1]
+
+[[assumptions]]
+desc = "`IS_BIT<cond>`"
+
+
+[[constraint_groups]]
+name = "all"
+
+[[constraints.all]]
+kind = "arith"
+constraint = "$#`cond` => #`carry`_0 = #`carry`_1$"
+poly = ["*", "cond", ["-", ["idx", "carry", 0], ["idx", "carry", 1]]]
+ref = "neg:c:identical_carry"
+
+[[constraints.all]]
+kind = "template"
+tag = "IsZero"
+input = [["+", ["idx", "x", 0], ["idx", "x", 1]]]
+output = ["not", ["idx", "carry", 0]]
+multiplicity = "cond"
+ref = "neg:c:carry"
+

--- a/spec/src/neg.toml
+++ b/spec/src/neg.toml
@@ -1,14 +1,14 @@
 name = "NEG"
 
+[[variables.condition]]
+name = "cond"
+type = "Bit"
+desc = "condition on whether to negate x"
+
 [[variables.input]]
 name = "x"
 type = "DWordHL"
 desc = "value to compute negation of"
-
-[[variables.input]]
-name = "cond"
-type = "BaseField"
-desc = "condition on whether to negate x"
 
 [[variables.output]]
 name = "neg"

--- a/spec/src/neg.toml
+++ b/spec/src/neg.toml
@@ -2,7 +2,7 @@ name = "NEG"
 
 [[variables.input]]
 name = "x"
-type = "DWordWL"
+type = "DWordHL"
 desc = "value to compute negation of"
 
 [[variables.input]]
@@ -20,8 +20,8 @@ name = "carry"
 type = ["Bit", 2]
 desc = "carries of the addition $#`neg` + #`x`$."
 def = {idx="i", polys=[
-    {iter=0, poly=["*", ["^", 2, -32], ["+", ["idx", "x", 0], ["idx", "neg", 0]]]},
-    {iter=1, poly=["*", ["^", 2, -32], ["+", ["idx", "x", 1], ["idx", "neg", 1], ["idx", "carry", 0]]]}
+    {iter=0, poly=["*", ["^", 2, -32], ["+", ["idx", ["cast", "x", "DWordWL"], 0], ["idx", "neg", 0]]]},
+    {iter=1, poly=["*", ["^", 2, -32], ["+", ["idx", ["cast", "x", "DWordWL"], 1], ["idx", "neg", 1], ["idx", "carry", 0]]]}
 ]}
 
 
@@ -37,16 +37,17 @@ desc = "`IS_BIT<cond>`"
 name = "all"
 
 [[constraints.all]]
-kind = "arith"
-constraint = "$#`cond` => #`carry`_0 = #`carry`_1$"
-poly = ["*", "cond", ["-", ["idx", "carry", 0], ["idx", "carry", 1]]]
-ref = "neg:c:identical_carry"
-
-[[constraints.all]]
-kind = "template"
-tag = "IsZero"
+kind = "interaction"
+tag = "ZERO"
 input = [["+", ["idx", "x", 0], ["idx", "x", 1]]]
 output = ["not", ["idx", "carry", 0]]
 multiplicity = "cond"
-ref = "neg:c:carry"
+ref = "neg:c:carry_0"
 
+[[constraints.all]]
+kind = "interaction"
+tag = "ZERO"
+input = [["+", ["idx", "x", 0], ["idx", "x", 1], ["idx", "x", 2], ["idx", "x", 3]]]
+output = ["not", ["idx", "carry", 1]]
+multiplicity = "cond"
+ref = "neg:c:carry_1"


### PR DESCRIPTION
This PR introduces the `NEG` template.

The upside to using this template rather than having a conditional `ADD`/`SUB`, is that this template does _not_ require the output value to be range checked.
It thus allows for the construction of absolute values, where the result fits in the non-rangecheckable `DWordWL`.