### PR TITLE
Re organize prover

### DIFF
--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run memory profile
         run: |
-          cargo test -p prover --release --features dhat-heap \
+          cargo test -p lambda-vm-prover --release --features dhat-heap \
             test_dhat_memory_profile -- --ignored --nocapture 2>&1 | tee profile-output.txt
           # Move dhat-heap.json to root for easier access
           mv prover/dhat-heap.json ./dhat-heap.json

--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -109,9 +109,9 @@ jobs:
 
       - name: Run prover and crypto tests
         run: |
-          cargo test -p prover -p stark -p crypto --release
+          cargo test -p lambda-vm-prover -p stark -p crypto --release
 
       - name: Run comprehensive prover tests (merge queue only)
         if: github.event_name == 'merge_group'
         run: |
-          cargo test -p prover --release test_prove_elfs_all_instructions_64_full -- --ignored
+          cargo test -p lambda-vm-prover --release test_prove_elfs_all_instructions_64_full -- --ignored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,6 +2145,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "lambda-vm-prover"
+version = "0.1.0"
+dependencies = [
+ "criterion 0.5.1",
+ "crypto",
+ "dhat",
+ "env_logger",
+ "executor",
+ "lazy_static",
+ "math",
+ "rayon",
+ "stark",
+]
+
+[[package]]
 name = "lambdaworks-crypto"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,21 +3023,6 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "prover"
-version = "0.1.0"
-dependencies = [
- "criterion 0.5.1",
- "crypto",
- "dhat",
- "env_logger",
- "executor",
- "lazy_static",
- "math",
- "rayon",
- "stark",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -150,15 +150,15 @@ test: compile-programs prepare-test-data
 
 # Fast prover tests (skips ignored slow tests)
 test-fast:
-	cargo test -p prover -p stark -p executor -F stark/parallel
+	cargo test -p lambda-vm-prover -p stark -p executor -F stark/parallel
 
 # Prover tests only (fast, parallel enabled by default)
 test-prover:
-	cargo test -p prover
+	cargo test -p lambda-vm-prover
 
 # Prover tests including slow ones
 test-prover-all:
-	cargo test -p prover -- --include-ignored
+	cargo test -p lambda-vm-prover -- --include-ignored
 
 # Build all
 build:

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "prover"
+name = "lambda-vm-prover"
 version = "0.1.0"
 edition = "2024"
 

--- a/prover/benches/vm_prover_benchmark.rs
+++ b/prover/benches/vm_prover_benchmark.rs
@@ -20,11 +20,11 @@ use stark::trace::TraceTable;
 use stark::traits::AIR;
 use stark::verifier::{IsStarkVerifier, Verifier};
 
-use prover::tables::lt::generate_lt_trace;
-use prover::tables::trace_builder::Traces;
+use lambda_vm_prover::tables::lt::generate_lt_trace;
+use lambda_vm_prover::tables::trace_builder::Traces;
 
 // Import shared utilities
-use prover::test_utils::{
+use lambda_vm_lambda_vm_prover::test_utils::{
     E, F, VmAir, collect_bitwise_lookups_from_logs, collect_bitwise_lookups_from_lt,
     collect_lt_lookups_from_logs, create_bitwise_air, create_cpu_air, create_lt_air,
     generate_minimal_bitwise_trace, run_asm_elf,
@@ -62,7 +62,7 @@ fn benchmark_proof_options() -> ProofOptions {
     }
 }
 
-// Lookup collection and AIR creation functions moved to prover::test_utils module
+// Lookup collection and AIR creation functions moved to lambda_vm_prover::test_utils module
 
 fn create_airs(proof_options: &ProofOptions) -> (VmAir, VmAir, VmAir) {
     (

--- a/prover/benches/vm_prover_benchmark.rs
+++ b/prover/benches/vm_prover_benchmark.rs
@@ -24,7 +24,7 @@ use lambda_vm_prover::tables::lt::generate_lt_trace;
 use lambda_vm_prover::tables::trace_builder::Traces;
 
 // Import shared utilities
-use lambda_vm_lambda_vm_prover::test_utils::{
+use lambda_vm_prover::test_utils::{
     E, F, VmAir, collect_bitwise_lookups_from_logs, collect_bitwise_lookups_from_lt,
     collect_lt_lookups_from_logs, create_bitwise_air, create_cpu_air, create_lt_air,
     generate_minimal_bitwise_trace, run_asm_elf,

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -4,7 +4,7 @@
 //! multi-table STARK proofs (CPU, bitwise, LT, memory, load).
 //!
 //! # Example
-//! ```no_run
+//! ```ignore
 //! let elf_bytes = std::fs::read("program.elf").unwrap();
 //! let proof = lambda_vm_prover::prove(&elf_bytes).unwrap();
 //! assert!(lambda_vm_prover::verify(&proof));
@@ -131,4 +131,3 @@ pub fn prove_and_verify(elf_bytes: &[u8]) -> Result<bool, Error> {
     let proof = prove(elf_bytes)?;
     Ok(verify(&proof))
 }
-

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -32,7 +32,8 @@ use stark::verifier::{IsStarkVerifier, Verifier};
 use crate::tables::bitwise;
 use crate::tables::trace_builder::Traces;
 use crate::test_utils::{
-    E, F, create_bitwise_air, create_cpu_air, create_load_air, create_lt_air, create_memw_air,
+    E, F, create_bitwise_air, create_branch_air, create_cpu_air, create_decode_air,
+    create_halt_air, create_load_air, create_lt_air, create_memw_air,
 };
 
 use stark::proof::options::ProofOptions;
@@ -104,6 +105,9 @@ pub fn prove(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
     let lt_air = create_lt_air(&proof_options);
     let memw_air = create_memw_air(&proof_options);
     let load_air = create_load_air(&proof_options);
+    let decode_air = create_decode_air(&proof_options);
+    let branch_air = create_branch_air(&proof_options);
+    let halt_air = create_halt_air(&proof_options);
 
     let air_trace_pairs: Vec<(
         &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
@@ -115,6 +119,9 @@ pub fn prove(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
         (&lt_air, &mut traces.lt, &()),
         (&memw_air, &mut traces.memw, &()),
         (&load_air, &mut traces.load, &()),
+        (&decode_air, &mut traces.decode, &()),
+        (&branch_air, &mut traces.branch, &()),
+        (&halt_air, &mut traces.halt, &()),
     ];
 
     Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[]))
@@ -132,9 +139,20 @@ pub fn verify(proof: &MultiProof<F, E, ()>) -> bool {
     let lt_air = create_lt_air(&proof_options);
     let memw_air = create_memw_air(&proof_options);
     let load_air = create_load_air(&proof_options);
+    let decode_air = create_decode_air(&proof_options);
+    let branch_air = create_branch_air(&proof_options);
+    let halt_air = create_halt_air(&proof_options);
 
-    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
-        vec![&cpu_air, &bitwise_air, &lt_air, &memw_air, &load_air];
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> = vec![
+        &cpu_air,
+        &bitwise_air,
+        &lt_air,
+        &memw_air,
+        &load_air,
+        &decode_air,
+        &branch_air,
+        &halt_air,
+    ];
 
     Verifier::multi_verify(&airs, proof, &mut DefaultTranscript::<E>::new(&[]))
 }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -1,3 +1,15 @@
+//! STARK prover for the Lambda VM.
+//!
+//! Proves correct execution of RISC-V ELF binaries by generating
+//! multi-table STARK proofs (CPU, bitwise, LT, memory, load).
+//!
+//! # Example
+//! ```no_run
+//! let elf_bytes = std::fs::read("program.elf").unwrap();
+//! let proof = lambda_vm_prover::prove(&elf_bytes).unwrap();
+//! assert!(lambda_vm_prover::verify(&proof));
+//! ```
+
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
@@ -10,21 +22,157 @@ pub mod utils;
 
 use std::fmt;
 
+use crypto::fiat_shamir::default_transcript::DefaultTranscript;
+use executor::elf::Elf;
+use executor::vm::execution::Executor;
+use stark::prover::{IsStarkProver, Prover};
+use stark::traits::AIR;
+use stark::verifier::{IsStarkVerifier, Verifier};
+
+use crate::tables::bitwise;
+use crate::tables::trace_builder::Traces;
+use crate::test_utils::{
+    create_bitwise_air, create_cpu_air, create_load_air, create_lt_air, create_memw_air, E, F,
+};
+
+use stark::proof::options::ProofOptions;
+use stark::proof::stark::MultiProof;
+
 /// Error type for the prover crate.
 #[derive(Debug)]
-pub enum ProverError {
-    /// Instruction not found for a given PC address
-    MissingInstruction(u64),
+pub enum Error {
+    /// Failed to load ELF binary
+    ElfLoad(String),
+    /// Trace generation failed (includes missing instructions, execution errors)
+    TraceGeneration(String),
+    /// STARK proving failed
+    Prover(String),
 }
 
-impl fmt::Display for ProverError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ProverError::MissingInstruction(pc) => {
-                write!(f, "instruction not found for PC {pc:#x}")
-            }
+            Error::ElfLoad(msg) => write!(f, "ELF load error: {msg}"),
+            Error::TraceGeneration(msg) => write!(f, "trace generation error: {msg}"),
+            Error::Prover(msg) => write!(f, "proving error: {msg}"),
         }
     }
 }
 
-impl std::error::Error for ProverError {}
+impl std::error::Error for Error {}
+
+/// Prove an ELF binary execution. Returns a serializable proof.
+pub fn prove(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
+    let program = Elf::load(elf_bytes).map_err(|e| Error::ElfLoad(format!("{e}")))?;
+    let executor =
+        Executor::new(&program, vec![]).map_err(|e| Error::TraceGeneration(format!("{e}")))?;
+    let result = executor
+        .run()
+        .map_err(|e| Error::TraceGeneration(format!("{e}")))?;
+
+    let mut traces = Traces::from_logs(&result.logs, result.instructions)?;
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = create_cpu_air(&proof_options);
+    let bitwise_air = create_bitwise_air(&proof_options).with_preprocessed(
+        bitwise::preprocessed_commitment(),
+        bitwise::NUM_PRECOMPUTED_COLS,
+    );
+    let lt_air = create_lt_air(&proof_options);
+    let memw_air = create_memw_air(&proof_options);
+    let load_air = create_load_air(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut traces.cpu, &()),
+        (&bitwise_air, &mut traces.bitwise, &()),
+        (&lt_air, &mut traces.lt, &()),
+        (&memw_air, &mut traces.memw, &()),
+        (&load_air, &mut traces.load, &()),
+    ];
+
+    Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[]))
+        .map_err(|e| Error::Prover(format!("{e:?}")))
+}
+
+/// Verify a proof produced by [`prove`].
+pub fn verify(proof: &MultiProof<F, E, ()>) -> bool {
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = create_cpu_air(&proof_options);
+    let bitwise_air = create_bitwise_air(&proof_options).with_preprocessed(
+        bitwise::preprocessed_commitment(),
+        bitwise::NUM_PRECOMPUTED_COLS,
+    );
+    let lt_air = create_lt_air(&proof_options);
+    let memw_air = create_memw_air(&proof_options);
+    let load_air = create_load_air(&proof_options);
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&cpu_air, &bitwise_air, &lt_air, &memw_air, &load_air];
+
+    Verifier::multi_verify(&airs, proof, &mut DefaultTranscript::<E>::new(&[]))
+}
+
+/// Prove and verify in one call (convenience).
+pub fn prove_and_verify(elf_bytes: &[u8]) -> Result<bool, Error> {
+    let proof = prove(elf_bytes)?;
+    Ok(verify(&proof))
+}
+
+/// Prove with minimal (unsound) bitwise table — fast, for testing only.
+///
+/// The minimal table only contains rows needed to balance the bus,
+/// rather than the full 2^20 row preprocessed table.
+pub fn prove_minimal(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
+    let program = Elf::load(elf_bytes).map_err(|e| Error::ElfLoad(format!("{e}")))?;
+    let executor =
+        Executor::new(&program, vec![]).map_err(|e| Error::TraceGeneration(format!("{e}")))?;
+    let result = executor
+        .run()
+        .map_err(|e| Error::TraceGeneration(format!("{e}")))?;
+
+    let mut traces = Traces::from_logs(&result.logs, result.instructions)?;
+    traces.bitwise = bitwise::trim_zero_rows(traces.bitwise);
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = create_cpu_air(&proof_options);
+    let bitwise_air = create_bitwise_air(&proof_options);
+    let lt_air = create_lt_air(&proof_options);
+    let memw_air = create_memw_air(&proof_options);
+    let load_air = create_load_air(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut traces.cpu, &()),
+        (&bitwise_air, &mut traces.bitwise, &()),
+        (&lt_air, &mut traces.lt, &()),
+        (&memw_air, &mut traces.memw, &()),
+        (&load_air, &mut traces.load, &()),
+    ];
+
+    Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[]))
+        .map_err(|e| Error::Prover(format!("{e:?}")))
+}
+
+/// Verify a proof produced by [`prove_minimal`].
+///
+/// Unlike [`verify`], this does not check the preprocessed bitwise commitment.
+pub fn verify_minimal(proof: &MultiProof<F, E, ()>) -> bool {
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = create_cpu_air(&proof_options);
+    let bitwise_air = create_bitwise_air(&proof_options);
+    let lt_air = create_lt_air(&proof_options);
+    let memw_air = create_memw_air(&proof_options);
+    let load_air = create_load_air(&proof_options);
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&cpu_air, &bitwise_air, &lt_air, &memw_air, &load_air];
+
+    Verifier::multi_verify(&airs, proof, &mut DefaultTranscript::<E>::new(&[]))
+}

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -38,17 +38,36 @@ use crate::test_utils::{
 use stark::proof::options::ProofOptions;
 use stark::proof::stark::MultiProof;
 
+/// Specific reasons trace generation can fail.
+#[derive(Debug)]
+pub enum TraceError {
+    /// Instruction not found for a given PC address
+    MissingInstruction(u64),
+    /// Program does not contain an ECALL (halt) instruction
+    MissingHaltEcall,
+    /// Executor failed (setup or runtime error)
+    Execution(String),
+}
+
+impl fmt::Display for TraceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TraceError::MissingInstruction(pc) => write!(f, "instruction not found for PC {pc:#x}"),
+            TraceError::MissingHaltEcall => {
+                write!(f, "program does not contain an ECALL (halt) instruction")
+            }
+            TraceError::Execution(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
 /// Error type for the prover crate.
 #[derive(Debug)]
 pub enum Error {
     /// Failed to load ELF binary
     ElfLoad(String),
-    /// Instruction not found for a given PC address
-    MissingInstruction(u64),
-    /// Program does not contain an ECALL (halt) instruction
-    MissingEcall,
     /// Trace generation failed
-    TraceGeneration(String),
+    TraceGeneration(TraceError),
     /// STARK proving failed
     Prover(String),
 }
@@ -57,13 +76,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::ElfLoad(msg) => write!(f, "ELF load error: {msg}"),
-            Error::MissingInstruction(pc) => {
-                write!(f, "instruction not found for PC {pc:#x}")
-            }
-            Error::MissingEcall => {
-                write!(f, "program does not contain an ECALL (halt) instruction")
-            }
-            Error::TraceGeneration(msg) => write!(f, "trace generation error: {msg}"),
+            Error::TraceGeneration(err) => write!(f, "trace generation error: {err}"),
             Error::Prover(msg) => write!(f, "proving error: {msg}"),
         }
     }
@@ -74,11 +87,11 @@ impl std::error::Error for Error {}
 /// Prove an ELF binary execution. Returns a serializable proof.
 pub fn prove(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
     let program = Elf::load(elf_bytes).map_err(|e| Error::ElfLoad(format!("{e}")))?;
-    let executor =
-        Executor::new(&program, vec![]).map_err(|e| Error::TraceGeneration(format!("{e}")))?;
+    let executor = Executor::new(&program, vec![])
+        .map_err(|e| Error::TraceGeneration(TraceError::Execution(format!("{e}"))))?;
     let result = executor
         .run()
-        .map_err(|e| Error::TraceGeneration(format!("{e}")))?;
+        .map_err(|e| Error::TraceGeneration(TraceError::Execution(format!("{e}"))))?;
 
     let mut traces = Traces::from_logs(&result.logs, result.instructions)?;
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -32,7 +32,7 @@ use stark::verifier::{IsStarkVerifier, Verifier};
 use crate::tables::bitwise;
 use crate::tables::trace_builder::Traces;
 use crate::test_utils::{
-    create_bitwise_air, create_cpu_air, create_load_air, create_lt_air, create_memw_air, E, F,
+    E, F, create_bitwise_air, create_cpu_air, create_load_air, create_lt_air, create_memw_air,
 };
 
 use stark::proof::options::ProofOptions;

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -39,36 +39,17 @@ use crate::test_utils::{
 use stark::proof::options::ProofOptions;
 use stark::proof::stark::MultiProof;
 
-/// Specific reasons trace generation can fail.
+/// Error type for the prover crate.
 #[derive(Debug)]
-pub enum TraceError {
+pub enum Error {
+    /// Failed to load ELF binary
+    ElfLoad(String),
     /// Instruction not found for a given PC address
     MissingInstruction(u64),
     /// Program does not contain an ECALL (halt) instruction
     MissingHaltEcall,
     /// Executor failed (setup or runtime error)
     Execution(String),
-}
-
-impl fmt::Display for TraceError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            TraceError::MissingInstruction(pc) => write!(f, "instruction not found for PC {pc:#x}"),
-            TraceError::MissingHaltEcall => {
-                write!(f, "program does not contain an ECALL (halt) instruction")
-            }
-            TraceError::Execution(msg) => write!(f, "{msg}"),
-        }
-    }
-}
-
-/// Error type for the prover crate.
-#[derive(Debug)]
-pub enum Error {
-    /// Failed to load ELF binary
-    ElfLoad(String),
-    /// Trace generation failed
-    TraceGeneration(TraceError),
     /// STARK proving failed
     Prover(String),
 }
@@ -77,7 +58,11 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::ElfLoad(msg) => write!(f, "ELF load error: {msg}"),
-            Error::TraceGeneration(err) => write!(f, "trace generation error: {err}"),
+            Error::MissingInstruction(pc) => write!(f, "instruction not found for PC {pc:#x}"),
+            Error::MissingHaltEcall => {
+                write!(f, "program does not contain an ECALL (halt) instruction")
+            }
+            Error::Execution(msg) => write!(f, "execution error: {msg}"),
             Error::Prover(msg) => write!(f, "proving error: {msg}"),
         }
     }
@@ -88,11 +73,10 @@ impl std::error::Error for Error {}
 /// Prove an ELF binary execution. Returns a serializable proof.
 pub fn prove(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
     let program = Elf::load(elf_bytes).map_err(|e| Error::ElfLoad(format!("{e}")))?;
-    let executor = Executor::new(&program, vec![])
-        .map_err(|e| Error::TraceGeneration(TraceError::Execution(format!("{e}"))))?;
+    let executor = Executor::new(&program, vec![]).map_err(|e| Error::Execution(format!("{e}")))?;
     let result = executor
         .run()
-        .map_err(|e| Error::TraceGeneration(TraceError::Execution(format!("{e}"))))?;
+        .map_err(|e| Error::Execution(format!("{e}")))?;
 
     let mut traces = Traces::from_logs(&result.logs, result.instructions)?;
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -43,7 +43,11 @@ use stark::proof::stark::MultiProof;
 pub enum Error {
     /// Failed to load ELF binary
     ElfLoad(String),
-    /// Trace generation failed (includes missing instructions, execution errors)
+    /// Instruction not found for a given PC address
+    MissingInstruction(u64),
+    /// Program does not contain an ECALL (halt) instruction
+    MissingEcall,
+    /// Trace generation failed
     TraceGeneration(String),
     /// STARK proving failed
     Prover(String),
@@ -53,6 +57,12 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::ElfLoad(msg) => write!(f, "ELF load error: {msg}"),
+            Error::MissingInstruction(pc) => {
+                write!(f, "instruction not found for PC {pc:#x}")
+            }
+            Error::MissingEcall => {
+                write!(f, "program does not contain an ECALL (halt) instruction")
+            }
             Error::TraceGeneration(msg) => write!(f, "trace generation error: {msg}"),
             Error::Prover(msg) => write!(f, "proving error: {msg}"),
         }
@@ -122,57 +132,3 @@ pub fn prove_and_verify(elf_bytes: &[u8]) -> Result<bool, Error> {
     Ok(verify(&proof))
 }
 
-/// Prove with minimal (unsound) bitwise table — fast, for testing only.
-///
-/// The minimal table only contains rows needed to balance the bus,
-/// rather than the full 2^20 row preprocessed table.
-pub fn prove_minimal(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
-    let program = Elf::load(elf_bytes).map_err(|e| Error::ElfLoad(format!("{e}")))?;
-    let executor =
-        Executor::new(&program, vec![]).map_err(|e| Error::TraceGeneration(format!("{e}")))?;
-    let result = executor
-        .run()
-        .map_err(|e| Error::TraceGeneration(format!("{e}")))?;
-
-    let mut traces = Traces::from_logs(&result.logs, result.instructions)?;
-    traces.bitwise = bitwise::trim_zero_rows(traces.bitwise);
-
-    let proof_options = ProofOptions::default_test_options();
-    let cpu_air = create_cpu_air(&proof_options);
-    let bitwise_air = create_bitwise_air(&proof_options);
-    let lt_air = create_lt_air(&proof_options);
-    let memw_air = create_memw_air(&proof_options);
-    let load_air = create_load_air(&proof_options);
-
-    let air_trace_pairs: Vec<(
-        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
-        _,
-        _,
-    )> = vec![
-        (&cpu_air, &mut traces.cpu, &()),
-        (&bitwise_air, &mut traces.bitwise, &()),
-        (&lt_air, &mut traces.lt, &()),
-        (&memw_air, &mut traces.memw, &()),
-        (&load_air, &mut traces.load, &()),
-    ];
-
-    Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[]))
-        .map_err(|e| Error::Prover(format!("{e:?}")))
-}
-
-/// Verify a proof produced by [`prove_minimal`].
-///
-/// Unlike [`verify`], this does not check the preprocessed bitwise commitment.
-pub fn verify_minimal(proof: &MultiProof<F, E, ()>) -> bool {
-    let proof_options = ProofOptions::default_test_options();
-    let cpu_air = create_cpu_air(&proof_options);
-    let bitwise_air = create_bitwise_air(&proof_options);
-    let lt_air = create_lt_air(&proof_options);
-    let memw_air = create_memw_air(&proof_options);
-    let load_air = create_load_air(&proof_options);
-
-    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
-        vec![&cpu_air, &bitwise_air, &lt_air, &memw_air, &load_air];
-
-    Verifier::multi_verify(&airs, proof, &mut DefaultTranscript::<E>::new(&[]))
-}

--- a/prover/src/tables/bitwise.rs
+++ b/prover/src/tables/bitwise.rs
@@ -420,7 +420,8 @@ pub fn update_multiplicities(
 /// - Bus interaction balancing (sends = receives)
 /// - Constraint satisfaction
 /// - LogUp protocol correctness
-pub fn trim_zero_rows(
+#[cfg(test)]
+pub(crate) fn trim_zero_rows(
     trace: TraceTable<GoldilocksField, GoldilocksExtension>,
 ) -> TraceTable<GoldilocksField, GoldilocksExtension> {
     use super::types::FE;

--- a/prover/src/tables/bitwise.rs
+++ b/prover/src/tables/bitwise.rs
@@ -420,7 +420,6 @@ pub fn update_multiplicities(
 /// - Bus interaction balancing (sends = receives)
 /// - Constraint satisfaction
 /// - LogUp protocol correctness
-#[cfg(test)]
 pub fn trim_zero_rows(
     trace: TraceTable<GoldilocksField, GoldilocksExtension>,
 ) -> TraceTable<GoldilocksField, GoldilocksExtension> {

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -53,7 +53,7 @@
 //! - ECALL: for system calls
 
 use super::types::{BusId, DecodeEntry, FE, GoldilocksExtension, GoldilocksField};
-use crate::{Error, TraceError};
+use crate::Error;
 use executor::vm::{instruction::decoding::Instruction, logs::Log, memory::U64HashMap};
 use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing};
 use stark::trace::TraceTable;
@@ -789,9 +789,7 @@ pub fn generate_cpu_trace_from_logs(
     for (i, log) in logs.iter().enumerate() {
         let instruction = *instructions
             .get(&log.current_pc)
-            .ok_or(Error::TraceGeneration(TraceError::MissingInstruction(
-                log.current_pc,
-            )))?;
+            .ok_or(Error::MissingInstruction(log.current_pc))?;
         operations.push(CpuOperation::from_log_and_instruction(
             log,
             (i as u64) * 4,
@@ -820,9 +818,7 @@ pub fn collect_bitwise_ops_from_logs(
     for (i, log) in logs.iter().enumerate() {
         let instruction = *instructions
             .get(&log.current_pc)
-            .ok_or(Error::TraceGeneration(TraceError::MissingInstruction(
-                log.current_pc,
-            )))?;
+            .ok_or(Error::MissingInstruction(log.current_pc))?;
         operations.push(CpuOperation::from_log_and_instruction(
             log,
             (i as u64) * 4,

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -53,7 +53,7 @@
 //! - ECALL: for system calls
 
 use super::types::{BusId, DecodeEntry, FE, GoldilocksExtension, GoldilocksField};
-use crate::Error;
+use crate::{Error, TraceError};
 use executor::vm::{instruction::decoding::Instruction, logs::Log, memory::U64HashMap};
 use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing};
 use stark::trace::TraceTable;
@@ -789,7 +789,9 @@ pub fn generate_cpu_trace_from_logs(
     for (i, log) in logs.iter().enumerate() {
         let instruction = *instructions
             .get(&log.current_pc)
-            .ok_or(Error::MissingInstruction(log.current_pc))?;
+            .ok_or(Error::TraceGeneration(TraceError::MissingInstruction(
+                log.current_pc,
+            )))?;
         operations.push(CpuOperation::from_log_and_instruction(
             log,
             (i as u64) * 4,
@@ -818,7 +820,9 @@ pub fn collect_bitwise_ops_from_logs(
     for (i, log) in logs.iter().enumerate() {
         let instruction = *instructions
             .get(&log.current_pc)
-            .ok_or(Error::MissingInstruction(log.current_pc))?;
+            .ok_or(Error::TraceGeneration(TraceError::MissingInstruction(
+                log.current_pc,
+            )))?;
         operations.push(CpuOperation::from_log_and_instruction(
             log,
             (i as u64) * 4,

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -789,10 +789,7 @@ pub fn generate_cpu_trace_from_logs(
     for (i, log) in logs.iter().enumerate() {
         let instruction = *instructions
             .get(&log.current_pc)
-            .ok_or(Error::TraceGeneration(format!(
-                "instruction not found for PC {:#x}",
-                log.current_pc
-            )))?;
+            .ok_or(Error::MissingInstruction(log.current_pc))?;
         operations.push(CpuOperation::from_log_and_instruction(
             log,
             (i as u64) * 4,
@@ -821,10 +818,7 @@ pub fn collect_bitwise_ops_from_logs(
     for (i, log) in logs.iter().enumerate() {
         let instruction = *instructions
             .get(&log.current_pc)
-            .ok_or(Error::TraceGeneration(format!(
-                "instruction not found for PC {:#x}",
-                log.current_pc
-            )))?;
+            .ok_or(Error::MissingInstruction(log.current_pc))?;
         operations.push(CpuOperation::from_log_and_instruction(
             log,
             (i as u64) * 4,

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -53,7 +53,7 @@
 //! - ECALL: for system calls
 
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
-use crate::ProverError;
+use crate::Error;
 use executor::vm::{
     instruction::decoding::{ArithOp, Comparison, Instruction, LoadStoreWidth},
     logs::Log,
@@ -1041,12 +1041,12 @@ pub fn generate_cpu_trace(
 pub fn generate_cpu_trace_from_logs(
     logs: &[Log],
     instructions: &U64HashMap<Instruction>,
-) -> Result<TraceTable<GoldilocksField, GoldilocksExtension>, ProverError> {
+) -> Result<TraceTable<GoldilocksField, GoldilocksExtension>, Error> {
     let mut operations = Vec::with_capacity(logs.len());
     for (i, log) in logs.iter().enumerate() {
         let instruction = *instructions
             .get(&log.current_pc)
-            .ok_or(ProverError::MissingInstruction(log.current_pc))?;
+            .ok_or(Error::TraceGeneration(format!("instruction not found for PC {:#x}", log.current_pc)))?;
         operations.push(CpuOperation::from_log(log, (i as u64) * 4, instruction));
     }
     Ok(generate_cpu_trace(&operations))
@@ -1066,12 +1066,12 @@ pub fn collect_bitwise_ops(operations: &[CpuOperation]) -> Vec<super::bitwise::B
 pub fn collect_bitwise_ops_from_logs(
     logs: &[Log],
     instructions: &U64HashMap<Instruction>,
-) -> Result<Vec<super::bitwise::BitwiseOperation>, ProverError> {
+) -> Result<Vec<super::bitwise::BitwiseOperation>, Error> {
     let mut operations = Vec::with_capacity(logs.len());
     for (i, log) in logs.iter().enumerate() {
         let instruction = *instructions
             .get(&log.current_pc)
-            .ok_or(ProverError::MissingInstruction(log.current_pc))?;
+            .ok_or(Error::TraceGeneration(format!("instruction not found for PC {:#x}", log.current_pc)))?;
         operations.push(CpuOperation::from_log(log, (i as u64) * 4, instruction));
     }
     Ok(collect_bitwise_ops(&operations))

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -54,11 +54,7 @@
 
 use super::types::{BusId, DecodeEntry, FE, GoldilocksExtension, GoldilocksField};
 use crate::Error;
-use executor::vm::{
-    instruction::decoding::Instruction,
-    logs::Log,
-    memory::U64HashMap,
-};
+use executor::vm::{instruction::decoding::Instruction, logs::Log, memory::U64HashMap};
 use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing};
 use stark::trace::TraceTable;
 
@@ -793,7 +789,10 @@ pub fn generate_cpu_trace_from_logs(
     for (i, log) in logs.iter().enumerate() {
         let instruction = *instructions
             .get(&log.current_pc)
-            .ok_or(Error::TraceGeneration(format!("instruction not found for PC {:#x}", log.current_pc)))?;
+            .ok_or(Error::TraceGeneration(format!(
+                "instruction not found for PC {:#x}",
+                log.current_pc
+            )))?;
         operations.push(CpuOperation::from_log_and_instruction(
             log,
             (i as u64) * 4,
@@ -822,7 +821,10 @@ pub fn collect_bitwise_ops_from_logs(
     for (i, log) in logs.iter().enumerate() {
         let instruction = *instructions
             .get(&log.current_pc)
-            .ok_or(Error::TraceGeneration(format!("instruction not found for PC {:#x}", log.current_pc)))?;
+            .ok_or(Error::TraceGeneration(format!(
+                "instruction not found for PC {:#x}",
+                log.current_pc
+            )))?;
         operations.push(CpuOperation::from_log_and_instruction(
             log,
             (i as u64) * 4,

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -166,10 +166,14 @@ fn collect_cpu_ops(
     // for the first access to any register/memory location (where old_timestamp=0).
     for (i, log) in logs.iter().enumerate() {
         let timestamp = (i as u64) * 4 + 4;
-        let instruction = instructions
-            .get(&log.current_pc)
-            .copied()
-            .ok_or(Error::TraceGeneration(format!("instruction not found for PC {:#x}", log.current_pc)))?;
+        let instruction =
+            instructions
+                .get(&log.current_pc)
+                .copied()
+                .ok_or(Error::TraceGeneration(format!(
+                    "instruction not found for PC {:#x}",
+                    log.current_pc
+                )))?;
 
         let op = CpuOperation::from_log_and_instruction(log, timestamp, instruction);
         cpu_ops.push(op);
@@ -660,10 +664,7 @@ impl Traces {
     /// 3. MEMW → LT operations (timestamp ordering)
     /// 4. LT, MEMW, Branch → Bitwise lookups
     /// 5. Generate all traces
-    pub fn from_logs(
-        logs: &[Log],
-        instructions: U64HashMap<Instruction>,
-    ) -> Result<Self, Error> {
+    pub fn from_logs(logs: &[Log], instructions: U64HashMap<Instruction>) -> Result<Self, Error> {
         // =====================================================================
         // PHASE 1: Logs → CPU operations
         // =====================================================================
@@ -709,11 +710,14 @@ impl Traces {
         // =====================================================================
 
         // Extract halt timestamp from the last ECALL instruction
-        let halt_op = cpu_ops
-            .iter()
-            .rev()
-            .find(|op| op.decode.op_ecall)
-            .ok_or(Error::TraceGeneration("program does not contain an ECALL (halt) instruction".to_string()))?;
+        let halt_op =
+            cpu_ops
+                .iter()
+                .rev()
+                .find(|op| op.decode.op_ecall)
+                .ok_or(Error::TraceGeneration(
+                    "program does not contain an ECALL (halt) instruction".to_string(),
+                ))?;
         let halt_trace = halt::generate_halt_trace(halt_op.timestamp);
 
         let cpu = cpu::generate_cpu_trace(&cpu_ops);

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -40,7 +40,7 @@ use super::load::{self, LoadOperation};
 use super::lt::{self, LtOperation};
 use super::memw::{self, MemwOperation};
 use super::types::{GoldilocksExtension, GoldilocksField};
-use crate::Error;
+use crate::{Error, TraceError};
 
 // =============================================================================
 // Memory and Register State Tracking
@@ -166,10 +166,13 @@ fn collect_cpu_ops(
     // for the first access to any register/memory location (where old_timestamp=0).
     for (i, log) in logs.iter().enumerate() {
         let timestamp = (i as u64) * 4 + 4;
-        let instruction = instructions
-            .get(&log.current_pc)
-            .copied()
-            .ok_or(Error::MissingInstruction(log.current_pc))?;
+        let instruction =
+            instructions
+                .get(&log.current_pc)
+                .copied()
+                .ok_or(Error::TraceGeneration(TraceError::MissingInstruction(
+                    log.current_pc,
+                )))?;
 
         let op = CpuOperation::from_log_and_instruction(log, timestamp, instruction);
         cpu_ops.push(op);
@@ -710,7 +713,7 @@ impl Traces {
             .iter()
             .rev()
             .find(|op| op.decode.op_ecall)
-            .ok_or(Error::MissingEcall)?;
+            .ok_or(Error::TraceGeneration(TraceError::MissingHaltEcall))?;
         let halt_trace = halt::generate_halt_trace(halt_op.timestamp);
 
         let cpu = cpu::generate_cpu_trace(&cpu_ops);

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -18,7 +18,7 @@
 //! ## Usage
 //!
 //! ```ignore
-//! use prover::tables::trace_builder::Traces;
+//! use lambda_vm_prover::tables::trace_builder::Traces;
 //!
 //! let traces = Traces::from_logs(&logs, instructions)?;
 //! // Use traces.cpu, traces.bitwise, traces.lt, traces.memw, traces.load
@@ -37,7 +37,7 @@ use super::load::{self, LoadOperation};
 use super::lt::{self, LtOperation};
 use super::memw::{self, MemwOperation};
 use super::types::{GoldilocksExtension, GoldilocksField};
-use crate::ProverError;
+use crate::Error;
 
 // =============================================================================
 // Memory and Register State Tracking
@@ -156,7 +156,7 @@ fn pack_register_value(value: u64) -> [u64; 8] {
 fn collect_cpu_ops(
     logs: &[Log],
     instructions: &U64HashMap<Instruction>,
-) -> Result<Vec<CpuOperation>, ProverError> {
+) -> Result<Vec<CpuOperation>, Error> {
     let mut cpu_ops = Vec::with_capacity(logs.len());
 
     // Timestamps start at 4 (not 0) to ensure old_timestamp < timestamp holds
@@ -166,7 +166,7 @@ fn collect_cpu_ops(
         let instruction = instructions
             .get(&log.current_pc)
             .copied()
-            .ok_or(ProverError::MissingInstruction(log.current_pc))?;
+            .ok_or(Error::TraceGeneration(format!("instruction not found for PC {:#x}", log.current_pc)))?;
 
         let op = CpuOperation::from_log(log, timestamp, instruction);
         cpu_ops.push(op);
@@ -587,7 +587,7 @@ impl Traces {
     pub fn from_logs(
         logs: &[Log],
         instructions: U64HashMap<Instruction>,
-    ) -> Result<Self, ProverError> {
+    ) -> Result<Self, Error> {
         // =====================================================================
         // PHASE 1: Logs → CPU operations
         // =====================================================================
@@ -658,7 +658,7 @@ impl Traces {
     pub fn from_logs_trimmed(
         logs: &[Log],
         instructions: U64HashMap<Instruction>,
-    ) -> Result<Self, ProverError> {
+    ) -> Result<Self, Error> {
         // Generate full traces (including full 2^20 bitwise table with multiplicities)
         let mut traces = Self::from_logs(logs, instructions)?;
 
@@ -675,7 +675,7 @@ impl Traces {
     pub fn from_logs_minimal(
         logs: &[Log],
         instructions: U64HashMap<Instruction>,
-    ) -> Result<Self, ProverError> {
+    ) -> Result<Self, Error> {
         Self::from_logs_trimmed(logs, instructions)
     }
 }

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -166,14 +166,10 @@ fn collect_cpu_ops(
     // for the first access to any register/memory location (where old_timestamp=0).
     for (i, log) in logs.iter().enumerate() {
         let timestamp = (i as u64) * 4 + 4;
-        let instruction =
-            instructions
-                .get(&log.current_pc)
-                .copied()
-                .ok_or(Error::TraceGeneration(format!(
-                    "instruction not found for PC {:#x}",
-                    log.current_pc
-                )))?;
+        let instruction = instructions
+            .get(&log.current_pc)
+            .copied()
+            .ok_or(Error::MissingInstruction(log.current_pc))?;
 
         let op = CpuOperation::from_log_and_instruction(log, timestamp, instruction);
         cpu_ops.push(op);
@@ -710,14 +706,11 @@ impl Traces {
         // =====================================================================
 
         // Extract halt timestamp from the last ECALL instruction
-        let halt_op =
-            cpu_ops
-                .iter()
-                .rev()
-                .find(|op| op.decode.op_ecall)
-                .ok_or(Error::TraceGeneration(
-                    "program does not contain an ECALL (halt) instruction".to_string(),
-                ))?;
+        let halt_op = cpu_ops
+            .iter()
+            .rev()
+            .find(|op| op.decode.op_ecall)
+            .ok_or(Error::MissingEcall)?;
         let halt_trace = halt::generate_halt_trace(halt_op.timestamp);
 
         let cpu = cpu::generate_cpu_trace(&cpu_ops);

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -40,7 +40,7 @@ use super::load::{self, LoadOperation};
 use super::lt::{self, LtOperation};
 use super::memw::{self, MemwOperation};
 use super::types::{GoldilocksExtension, GoldilocksField};
-use crate::{Error, TraceError};
+use crate::Error;
 
 // =============================================================================
 // Memory and Register State Tracking
@@ -166,13 +166,10 @@ fn collect_cpu_ops(
     // for the first access to any register/memory location (where old_timestamp=0).
     for (i, log) in logs.iter().enumerate() {
         let timestamp = (i as u64) * 4 + 4;
-        let instruction =
-            instructions
-                .get(&log.current_pc)
-                .copied()
-                .ok_or(Error::TraceGeneration(TraceError::MissingInstruction(
-                    log.current_pc,
-                )))?;
+        let instruction = instructions
+            .get(&log.current_pc)
+            .copied()
+            .ok_or(Error::MissingInstruction(log.current_pc))?;
 
         let op = CpuOperation::from_log_and_instruction(log, timestamp, instruction);
         cpu_ops.push(op);
@@ -713,7 +710,7 @@ impl Traces {
             .iter()
             .rev()
             .find(|op| op.decode.op_ecall)
-            .ok_or(Error::TraceGeneration(TraceError::MissingHaltEcall))?;
+            .ok_or(Error::MissingHaltEcall)?;
         let halt_trace = halt::generate_halt_trace(halt_op.timestamp);
 
         let cpu = cpu::generate_cpu_trace(&cpu_ops);

--- a/tooling/loc/src/main.rs
+++ b/tooling/loc/src/main.rs
@@ -14,6 +14,7 @@ const EXCLUDED: &[&str] = &[
     "*test_utils*",
     "*bench*",
     "*benches*",
+    "*examples*",
 ];
 
 fn count_crates_loc(crates_path: &PathBuf, config: &Config) -> Vec<(String, usize)> {


### PR DESCRIPTION
  - Refactored ProverError to Error with5 clean variants
  
  - Added public API functions (prove, prove_minimal, prove_and_verify, verify, verify_minimal) and crate-level documentation to lib.rs
  
  - Restructured CpuOperation — flattened decode fields inline instead of nesting a DecodeEntry
  
  - Excluded examples/ from LOC counting in tooling/loc