### PR TITLE
Add MUL table

### DIFF
--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -317,6 +317,16 @@ pub enum LinearTerm {
         /// The column index to read from
         column: usize,
     },
+    /// coefficient * column_value (unsigned, for large field elements like inverses)
+    ///
+    /// Use this when the coefficient is a large field element (e.g., 2^-32 mod p)
+    /// that doesn't fit in i64.
+    ColumnUnsigned {
+        /// The multiplier as an unsigned value (for large field elements)
+        coefficient: u64,
+        /// The column index to read from
+        column: usize,
+    },
     /// A constant value to add (signed to support subtraction)
     Constant(i64),
 }
@@ -391,6 +401,7 @@ impl BusValue {
                 .iter()
                 .filter_map(|term| match term {
                     LinearTerm::Column { column, .. } => Some(*column),
+                    LinearTerm::ColumnUnsigned { column, .. } => Some(*column),
                     LinearTerm::Constant(_) => None,
                 })
                 .collect(),
@@ -432,6 +443,14 @@ impl BusValue {
                             } else {
                                 -FieldElement::<E>::from((-*coefficient) as u64)
                             };
+                            result += get_column(*column) * coeff;
+                        }
+                        LinearTerm::ColumnUnsigned {
+                            coefficient,
+                            column,
+                        } => {
+                            // Unsigned coefficient (for large field elements)
+                            let coeff = FieldElement::<E>::from(*coefficient);
                             result += get_column(*column) * coeff;
                         }
                         LinearTerm::Constant(value) => {
@@ -955,6 +974,13 @@ fn build_logup_term_column<F, E>(
                             };
                             result += &main_segment_cols[*column][row] * coeff;
                         }
+                        LinearTerm::ColumnUnsigned {
+                            coefficient,
+                            column,
+                        } => {
+                            let coeff = FieldElement::<F>::from(*coefficient);
+                            result += &main_segment_cols[*column][row] * coeff;
+                        }
                         LinearTerm::Constant(value) => {
                             if *value >= 0 {
                                 result += FieldElement::<F>::from(*value as u64);
@@ -1115,6 +1141,13 @@ where
                                 } else {
                                     -FieldElement::<A>::from((-*coefficient) as u64)
                                 };
+                                result += step.get_main_evaluation_element(0, *column) * coeff;
+                            }
+                            LinearTerm::ColumnUnsigned {
+                                coefficient,
+                                column,
+                            } => {
+                                let coeff = FieldElement::<A>::from(*coefficient);
                                 result += step.get_main_evaluation_element(0, *column) * coeff;
                             }
                             LinearTerm::Constant(value) => {

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -33,7 +33,7 @@ use crate::tables::bitwise;
 use crate::tables::trace_builder::Traces;
 use crate::test_utils::{
     E, F, create_bitwise_air, create_branch_air, create_cpu_air, create_decode_air,
-    create_halt_air, create_load_air, create_lt_air, create_memw_air,
+    create_halt_air, create_load_air, create_lt_air, create_memw_air, create_mul_air,
 };
 
 use stark::proof::options::ProofOptions;
@@ -90,6 +90,7 @@ pub fn prove(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
     let memw_air = create_memw_air(&proof_options);
     let load_air = create_load_air(&proof_options);
     let decode_air = create_decode_air(&proof_options);
+    let mul_air = create_mul_air(&proof_options);
     let branch_air = create_branch_air(&proof_options);
     let halt_air = create_halt_air(&proof_options);
 
@@ -104,6 +105,7 @@ pub fn prove(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
         (&memw_air, &mut traces.memw, &()),
         (&load_air, &mut traces.load, &()),
         (&decode_air, &mut traces.decode, &()),
+        (&mul_air, &mut traces.mul, &()),
         (&branch_air, &mut traces.branch, &()),
         (&halt_air, &mut traces.halt, &()),
     ];
@@ -124,6 +126,7 @@ pub fn verify(proof: &MultiProof<F, E, ()>) -> bool {
     let memw_air = create_memw_air(&proof_options);
     let load_air = create_load_air(&proof_options);
     let decode_air = create_decode_air(&proof_options);
+    let mul_air = create_mul_air(&proof_options);
     let branch_air = create_branch_air(&proof_options);
     let halt_air = create_halt_air(&proof_options);
 
@@ -134,6 +137,7 @@ pub fn verify(proof: &MultiProof<F, E, ()>) -> bool {
         &memw_air,
         &load_air,
         &decode_air,
+        &mul_air,
         &branch_air,
         &halt_air,
     ];

--- a/prover/src/tables/bitwise.rs
+++ b/prover/src/tables/bitwise.rs
@@ -533,6 +533,13 @@ impl BitwiseOperation {
     pub fn shift_op(lookup_type: BitwiseOperationType, x: u8, y: u8, z: u8) -> Self {
         Self::new(lookup_type, x, y, z)
     }
+
+    /// Create an IS_B20 operation for 20-bit range checks.
+    /// Value is packed as: x + 256*y + 65536*z (where z is 4 bits).
+    pub fn b20(x: u8, y: u8, z: u8) -> Self {
+        debug_assert!(z < 16, "z must be 4-bit value for IS_B20");
+        Self::new(BitwiseOperationType::IsB20, x, y, z)
+    }
 }
 
 // =========================================================================

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -1132,6 +1132,57 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         ],
     ));
 
+    // -------------------------------------------------------------------------
+    // MUL interaction (for MUL, MULH, MULHSU, MULHU)
+    // -------------------------------------------------------------------------
+    // MUL[arg1, signed, arg2, mp_selector, rvd, muldiv_selector] per spec CPU-CA44
+    // multiplicity = MUL
+    //
+    // The MUL table expects DWordHL (4 halfwords), but CPU has DWordBL (8 bytes).
+    // Both pack to 2 words (lo32, hi32), so the signatures match for the same values.
+    //
+    // rhs_signed = mp_selector per spec:
+    // - MUL/MULH: mp_selector=1 (both operands signed)
+    // - MULHU/MULHSU: mp_selector=0 (rhs unsigned)
+    //
+    // muldiv_selector distinguishes lo (0) from hi (1) result
+    interactions.push(BusInteraction::sender(
+        BusId::Mul,
+        Multiplicity::Column(cols::MUL),
+        vec![
+            // arg1 (lhs) as DWordBL (8 bytes → 2 elements)
+            BusValue::Packed {
+                start_column: cols::ARG1[0],
+                packing: Packing::DWordBL,
+            },
+            // lhs_signed = signed
+            BusValue::Packed {
+                start_column: cols::SIGNED,
+                packing: Packing::Direct,
+            },
+            // arg2 (rhs) as DWordBL (8 bytes → 2 elements)
+            BusValue::Packed {
+                start_column: cols::ARG2[0],
+                packing: Packing::DWordBL,
+            },
+            // rhs_signed = mp_selector
+            BusValue::Packed {
+                start_column: cols::MP_SELECTOR,
+                packing: Packing::Direct,
+            },
+            // result (rvd) as DWordWL (2 words → 2 elements)
+            BusValue::Packed {
+                start_column: cols::RVD_0,
+                packing: Packing::DWordWL,
+            },
+            // muldiv_selector: 0=lo (MUL), 1=hi (MULH/MULHSU/MULHU)
+            BusValue::Packed {
+                start_column: cols::MULDIV_SELECTOR,
+                packing: Packing::Direct,
+            },
+        ],
+    ));
+
     // =========================================================================
     // MEMW and LOAD bus interactions (M1, M3, M5, M6, M7)
     // =========================================================================

--- a/prover/src/tables/mod.rs
+++ b/prover/src/tables/mod.rs
@@ -22,6 +22,7 @@ pub mod decode;
 pub mod load;
 pub mod lt;
 pub mod memw;
+pub mod mul;
 pub mod trace_builder;
 
 pub use types::BusId;

--- a/prover/src/tables/mul.rs
+++ b/prover/src/tables/mul.rs
@@ -39,7 +39,11 @@ use stark::table::TableView;
 use stark::trace::TraceTable;
 use stark::traits::TransitionEvaluationContext;
 
-use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16};
+use super::types::{
+    BusId, FE, GoldilocksExtension, GoldilocksField, INV_2_32, INV_2_64, INV_2_96, INV_2_128,
+    NEG_INV_2_16, NEG_INV_2_32, NEG_INV_2_48, NEG_INV_2_64, NEG_INV_2_80, NEG_INV_2_96,
+    NEG_INV_2_112, NEG_INV_2_128, SHIFT_16,
+};
 
 // =========================================================================
 // Column indices for MUL table
@@ -426,17 +430,78 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
 
     // -------------------------------------------------------------------------
     // IS_B20 lookups for carry range checks (multiplicity: mu_lo + mu_hi)
+    // Carries are virtual columns computed as linear combinations:
+    //   carry[0] = 2^-32 * (raw_product[0] - res[0])
+    //   carry[i] = 2^-32 * (raw_product[i] + carry[i-1] - res[i])
+    // where res = [lo_word0, lo_word1, hi_word0, hi_word1]
     // -------------------------------------------------------------------------
-    for col in [cols::CARRY_0, cols::CARRY_1, cols::CARRY_2, cols::CARRY_3] {
-        interactions.push(BusInteraction::sender(
-            BusId::IsB20,
-            Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
-            vec![BusValue::Packed {
-                start_column: col,
-                packing: Packing::Direct,
-            }],
-        ));
-    }
+
+    // carry[0] = 2^-32 * raw_product[0] - 2^-32 * lo[0] - 2^-16 * lo[1]
+    interactions.push(BusInteraction::sender(
+        BusId::IsB20,
+        Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
+        vec![BusValue::linear(vec![
+            LinearTerm::ColumnUnsigned { coefficient: INV_2_32, column: cols::RAW_PRODUCT_0 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_32, column: cols::LO_0 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_16, column: cols::LO_1 },
+        ])],
+    ));
+
+    // carry[1] = 2^-32 * raw_product[1] + 2^-64 * raw_product[0]
+    //          - 2^-64 * lo[0] - 2^-48 * lo[1] - 2^-32 * lo[2] - 2^-16 * lo[3]
+    interactions.push(BusInteraction::sender(
+        BusId::IsB20,
+        Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
+        vec![BusValue::linear(vec![
+            LinearTerm::ColumnUnsigned { coefficient: INV_2_32, column: cols::RAW_PRODUCT_1 },
+            LinearTerm::ColumnUnsigned { coefficient: INV_2_64, column: cols::RAW_PRODUCT_0 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_64, column: cols::LO_0 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_48, column: cols::LO_1 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_32, column: cols::LO_2 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_16, column: cols::LO_3 },
+        ])],
+    ));
+
+    // carry[2] = 2^-32 * raw_product[2] + 2^-64 * raw_product[1] + 2^-96 * raw_product[0]
+    //          - 2^-96 * lo[0] - 2^-80 * lo[1] - 2^-64 * lo[2] - 2^-48 * lo[3]
+    //          - 2^-32 * hi[0] - 2^-16 * hi[1]
+    interactions.push(BusInteraction::sender(
+        BusId::IsB20,
+        Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
+        vec![BusValue::linear(vec![
+            LinearTerm::ColumnUnsigned { coefficient: INV_2_32, column: cols::RAW_PRODUCT_2 },
+            LinearTerm::ColumnUnsigned { coefficient: INV_2_64, column: cols::RAW_PRODUCT_1 },
+            LinearTerm::ColumnUnsigned { coefficient: INV_2_96, column: cols::RAW_PRODUCT_0 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_96, column: cols::LO_0 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_80, column: cols::LO_1 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_64, column: cols::LO_2 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_48, column: cols::LO_3 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_32, column: cols::HI_0 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_16, column: cols::HI_1 },
+        ])],
+    ));
+
+    // carry[3] = 2^-32 * raw_product[3] + 2^-64 * raw_product[2] + 2^-96 * raw_product[1] + 2^-128 * raw_product[0]
+    //          - 2^-128 * lo[0] - 2^-112 * lo[1] - 2^-96 * lo[2] - 2^-80 * lo[3]
+    //          - 2^-64 * hi[0] - 2^-48 * hi[1] - 2^-32 * hi[2] - 2^-16 * hi[3]
+    interactions.push(BusInteraction::sender(
+        BusId::IsB20,
+        Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
+        vec![BusValue::linear(vec![
+            LinearTerm::ColumnUnsigned { coefficient: INV_2_32, column: cols::RAW_PRODUCT_3 },
+            LinearTerm::ColumnUnsigned { coefficient: INV_2_64, column: cols::RAW_PRODUCT_2 },
+            LinearTerm::ColumnUnsigned { coefficient: INV_2_96, column: cols::RAW_PRODUCT_1 },
+            LinearTerm::ColumnUnsigned { coefficient: INV_2_128, column: cols::RAW_PRODUCT_0 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_128, column: cols::LO_0 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_112, column: cols::LO_1 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_96, column: cols::LO_2 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_80, column: cols::LO_3 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_64, column: cols::HI_0 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_48, column: cols::HI_1 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_32, column: cols::HI_2 },
+            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_16, column: cols::HI_3 },
+        ])],
+    ));
 
     // -------------------------------------------------------------------------
     // MUL receiver for lo result

--- a/prover/src/tables/mul.rs
+++ b/prover/src/tables/mul.rs
@@ -441,9 +441,18 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         BusId::IsB20,
         Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
         vec![BusValue::linear(vec![
-            LinearTerm::ColumnUnsigned { coefficient: INV_2_32, column: cols::RAW_PRODUCT_0 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_32, column: cols::LO_0 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_16, column: cols::LO_1 },
+            LinearTerm::ColumnUnsigned {
+                coefficient: INV_2_32,
+                column: cols::RAW_PRODUCT_0,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_32,
+                column: cols::LO_0,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_16,
+                column: cols::LO_1,
+            },
         ])],
     ));
 
@@ -453,12 +462,30 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         BusId::IsB20,
         Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
         vec![BusValue::linear(vec![
-            LinearTerm::ColumnUnsigned { coefficient: INV_2_32, column: cols::RAW_PRODUCT_1 },
-            LinearTerm::ColumnUnsigned { coefficient: INV_2_64, column: cols::RAW_PRODUCT_0 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_64, column: cols::LO_0 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_48, column: cols::LO_1 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_32, column: cols::LO_2 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_16, column: cols::LO_3 },
+            LinearTerm::ColumnUnsigned {
+                coefficient: INV_2_32,
+                column: cols::RAW_PRODUCT_1,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: INV_2_64,
+                column: cols::RAW_PRODUCT_0,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_64,
+                column: cols::LO_0,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_48,
+                column: cols::LO_1,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_32,
+                column: cols::LO_2,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_16,
+                column: cols::LO_3,
+            },
         ])],
     ));
 
@@ -469,15 +496,42 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         BusId::IsB20,
         Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
         vec![BusValue::linear(vec![
-            LinearTerm::ColumnUnsigned { coefficient: INV_2_32, column: cols::RAW_PRODUCT_2 },
-            LinearTerm::ColumnUnsigned { coefficient: INV_2_64, column: cols::RAW_PRODUCT_1 },
-            LinearTerm::ColumnUnsigned { coefficient: INV_2_96, column: cols::RAW_PRODUCT_0 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_96, column: cols::LO_0 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_80, column: cols::LO_1 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_64, column: cols::LO_2 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_48, column: cols::LO_3 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_32, column: cols::HI_0 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_16, column: cols::HI_1 },
+            LinearTerm::ColumnUnsigned {
+                coefficient: INV_2_32,
+                column: cols::RAW_PRODUCT_2,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: INV_2_64,
+                column: cols::RAW_PRODUCT_1,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: INV_2_96,
+                column: cols::RAW_PRODUCT_0,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_96,
+                column: cols::LO_0,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_80,
+                column: cols::LO_1,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_64,
+                column: cols::LO_2,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_48,
+                column: cols::LO_3,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_32,
+                column: cols::HI_0,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_16,
+                column: cols::HI_1,
+            },
         ])],
     ));
 
@@ -488,18 +542,54 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         BusId::IsB20,
         Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
         vec![BusValue::linear(vec![
-            LinearTerm::ColumnUnsigned { coefficient: INV_2_32, column: cols::RAW_PRODUCT_3 },
-            LinearTerm::ColumnUnsigned { coefficient: INV_2_64, column: cols::RAW_PRODUCT_2 },
-            LinearTerm::ColumnUnsigned { coefficient: INV_2_96, column: cols::RAW_PRODUCT_1 },
-            LinearTerm::ColumnUnsigned { coefficient: INV_2_128, column: cols::RAW_PRODUCT_0 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_128, column: cols::LO_0 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_112, column: cols::LO_1 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_96, column: cols::LO_2 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_80, column: cols::LO_3 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_64, column: cols::HI_0 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_48, column: cols::HI_1 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_32, column: cols::HI_2 },
-            LinearTerm::ColumnUnsigned { coefficient: NEG_INV_2_16, column: cols::HI_3 },
+            LinearTerm::ColumnUnsigned {
+                coefficient: INV_2_32,
+                column: cols::RAW_PRODUCT_3,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: INV_2_64,
+                column: cols::RAW_PRODUCT_2,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: INV_2_96,
+                column: cols::RAW_PRODUCT_1,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: INV_2_128,
+                column: cols::RAW_PRODUCT_0,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_128,
+                column: cols::LO_0,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_112,
+                column: cols::LO_1,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_96,
+                column: cols::LO_2,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_80,
+                column: cols::LO_3,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_64,
+                column: cols::HI_0,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_48,
+                column: cols::HI_1,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_32,
+                column: cols::HI_2,
+            },
+            LinearTerm::ColumnUnsigned {
+                coefficient: NEG_INV_2_16,
+                column: cols::HI_3,
+            },
         ])],
     ));
 
@@ -621,7 +711,9 @@ impl MulConstraint {
         match self.kind {
             MulConstraintKind::LhsSign => {
                 // (1 - lhs_signed) * lhs_is_negative = 0
-                let lhs_signed = step.get_main_evaluation_element(0, cols::LHS_SIGNED).clone();
+                let lhs_signed = step
+                    .get_main_evaluation_element(0, cols::LHS_SIGNED)
+                    .clone();
                 let lhs_is_neg = step
                     .get_main_evaluation_element(0, cols::LHS_IS_NEGATIVE)
                     .clone();
@@ -630,7 +722,9 @@ impl MulConstraint {
             }
             MulConstraintKind::RhsSign => {
                 // (1 - rhs_signed) * rhs_is_negative = 0
-                let rhs_signed = step.get_main_evaluation_element(0, cols::RHS_SIGNED).clone();
+                let rhs_signed = step
+                    .get_main_evaluation_element(0, cols::RHS_SIGNED)
+                    .clone();
                 let rhs_is_neg = step
                     .get_main_evaluation_element(0, cols::RHS_IS_NEGATIVE)
                     .clone();
@@ -806,12 +900,7 @@ pub fn mul_constraints(constraint_idx_start: usize) -> (Vec<MulConstraint>, usiz
 /// This is used by tests to verify the reduce-and-carry logic.
 pub fn compute_carries(lo: u64, hi: u64, raw_products: &[u64; 4]) -> [u64; 4] {
     // res[0..4] = [lo_word0, lo_word1, hi_word0, hi_word1]
-    let res = [
-        lo & 0xFFFF_FFFF,
-        lo >> 32,
-        hi & 0xFFFF_FFFF,
-        hi >> 32,
-    ];
+    let res = [lo & 0xFFFF_FFFF, lo >> 32, hi & 0xFFFF_FFFF, hi >> 32];
 
     let mut carries = [0u64; 4];
 

--- a/prover/src/tables/mul.rs
+++ b/prover/src/tables/mul.rs
@@ -1,0 +1,766 @@
+//! MUL table for 64x64 -> 128-bit multiplication.
+//!
+//! This table computes the full 128-bit product of two 64-bit operands,
+//! supporting both signed and unsigned multiplication.
+//!
+//! ## Inputs
+//! - `lhs`: DWordHL (64-bit as 4 halfwords) - left operand
+//! - `lhs_signed`: Bit - whether to treat lhs as signed
+//! - `rhs`: DWordHL (64-bit as 4 halfwords) - right operand
+//! - `rhs_signed`: Bit - whether to treat rhs as signed
+//!
+//! ## Outputs
+//! - `lo`: DWordHL (64-bit) - lower 64 bits of 128-bit product
+//! - `hi`: DWordHL (64-bit) - upper 64 bits of 128-bit product
+//!
+//! ## Auxiliary
+//! - `lhs_is_negative`: Bit - sign of lhs (when signed)
+//! - `rhs_is_negative`: Bit - sign of rhs (when signed)
+//! - `raw_product[0..4]`: B51 - intermediate convolution values
+//!
+//! ## Virtual (embedded in constraints)
+//! - `lhs_ext[0..8]`: Sign-extended lhs (8 halfwords)
+//! - `rhs_ext[0..8]`: Sign-extended rhs (8 halfwords)
+//! - `carry[0..4]`: Carries from reduce-and-carry operation
+//!
+//! ## Bus Interactions
+//! - Sender: MSB16 (×2 for sign extraction)
+//! - Sender: IS_HALF (×8 for lo/hi range checks)
+//! - Sender: IS_B20 (×4 for carry range checks)
+//! - Receiver: MUL (×2 for lo and hi results)
+
+use std::collections::HashMap;
+
+use math::field::element::FieldElement;
+use math::field::traits::{IsField, IsSubFieldOf};
+use stark::constraints::transition::TransitionConstraint;
+use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing};
+use stark::table::TableView;
+use stark::trace::TraceTable;
+use stark::traits::TransitionEvaluationContext;
+
+use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16};
+
+// =========================================================================
+// Column indices for MUL table
+// =========================================================================
+
+/// Column definitions for the MUL table.
+pub mod cols {
+    // Input columns: lhs (DWordHL = 4 halfwords)
+    /// lhs[0]: Half (bits 0-15)
+    pub const LHS_0: usize = 0;
+    /// lhs[1]: Half (bits 16-31)
+    pub const LHS_1: usize = 1;
+    /// lhs[2]: Half (bits 32-47)
+    pub const LHS_2: usize = 2;
+    /// lhs[3]: Half (bits 48-63)
+    pub const LHS_3: usize = 3;
+
+    /// lhs_signed: Bit (1 = signed, 0 = unsigned)
+    pub const LHS_SIGNED: usize = 4;
+
+    // Input columns: rhs (DWordHL = 4 halfwords)
+    /// rhs[0]: Half (bits 0-15)
+    pub const RHS_0: usize = 5;
+    /// rhs[1]: Half (bits 16-31)
+    pub const RHS_1: usize = 6;
+    /// rhs[2]: Half (bits 32-47)
+    pub const RHS_2: usize = 7;
+    /// rhs[3]: Half (bits 48-63)
+    pub const RHS_3: usize = 8;
+
+    /// rhs_signed: Bit (1 = signed, 0 = unsigned)
+    pub const RHS_SIGNED: usize = 9;
+
+    // Output columns: lo (DWordHL = 4 halfwords)
+    /// lo[0]: Half (bits 0-15 of lower 64-bit product)
+    pub const LO_0: usize = 10;
+    /// lo[1]: Half (bits 16-31)
+    pub const LO_1: usize = 11;
+    /// lo[2]: Half (bits 32-47)
+    pub const LO_2: usize = 12;
+    /// lo[3]: Half (bits 48-63)
+    pub const LO_3: usize = 13;
+
+    // Output columns: hi (DWordHL = 4 halfwords)
+    /// hi[0]: Half (bits 0-15 of upper 64-bit product)
+    pub const HI_0: usize = 14;
+    /// hi[1]: Half (bits 16-31)
+    pub const HI_1: usize = 15;
+    /// hi[2]: Half (bits 32-47)
+    pub const HI_2: usize = 16;
+    /// hi[3]: Half (bits 48-63)
+    pub const HI_3: usize = 17;
+
+    // Auxiliary columns
+    /// lhs_is_negative: Bit (1 if lhs is negative when signed)
+    pub const LHS_IS_NEGATIVE: usize = 18;
+    /// rhs_is_negative: Bit (1 if rhs is negative when signed)
+    pub const RHS_IS_NEGATIVE: usize = 19;
+
+    // Raw product columns (B51 = fits in 51 bits)
+    /// raw_product[0]: Intermediate convolution value
+    pub const RAW_PRODUCT_0: usize = 20;
+    /// raw_product[1]: Intermediate convolution value
+    pub const RAW_PRODUCT_1: usize = 21;
+    /// raw_product[2]: Intermediate convolution value
+    pub const RAW_PRODUCT_2: usize = 22;
+    /// raw_product[3]: Intermediate convolution value
+    pub const RAW_PRODUCT_3: usize = 23;
+
+    // Multiplicity columns
+    /// μ_lo: multiplicity for lo result lookups
+    pub const MU_LO: usize = 24;
+    /// μ_hi: multiplicity for hi result lookups
+    pub const MU_HI: usize = 25;
+
+    /// Total number of columns
+    pub const NUM_COLUMNS: usize = 26;
+}
+
+// =========================================================================
+// Constants
+// =========================================================================
+
+/// Sign extension fill value: 0xFFFF (all 1s for 16 bits)
+const SIGN_FILL: u64 = 0xFFFF;
+
+// =========================================================================
+// MulOperation struct
+// =========================================================================
+
+/// A single MUL operation to be added to the trace.
+///
+/// Derives Hash and Eq for HashMap-based deduplication.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct MulOperation {
+    /// Left operand (64-bit)
+    pub lhs: u64,
+    /// Whether lhs is treated as signed
+    pub lhs_signed: bool,
+    /// Right operand (64-bit)
+    pub rhs: u64,
+    /// Whether rhs is treated as signed
+    pub rhs_signed: bool,
+}
+
+/// Multiplicities for a MUL operation (separate for lo and hi lookups).
+#[derive(Debug, Clone, Default)]
+pub struct MulMultiplicities {
+    /// Count of lookups requesting lo result
+    pub mu_lo: u64,
+    /// Count of lookups requesting hi result
+    pub mu_hi: u64,
+}
+
+impl MulOperation {
+    /// Create a new MUL operation.
+    pub fn new(lhs: u64, lhs_signed: bool, rhs: u64, rhs_signed: bool) -> Self {
+        Self {
+            lhs,
+            lhs_signed,
+            rhs,
+            rhs_signed,
+        }
+    }
+
+    /// Compute the full 128-bit product.
+    ///
+    /// Returns (lo, hi) where:
+    /// - lo = lower 64 bits of product
+    /// - hi = upper 64 bits of product
+    pub fn compute_product(&self) -> (u64, u64) {
+        // Convert to 128-bit based on signedness
+        let a: i128 = if self.lhs_signed {
+            self.lhs as i64 as i128
+        } else {
+            self.lhs as u128 as i128
+        };
+
+        let b: i128 = if self.rhs_signed {
+            self.rhs as i64 as i128
+        } else {
+            self.rhs as u128 as i128
+        };
+
+        let product = a.wrapping_mul(b);
+        let lo = product as u64;
+        let hi = (product >> 64) as u64;
+
+        (lo, hi)
+    }
+
+    /// Check if lhs is negative (when treated as signed).
+    pub fn lhs_is_negative(&self) -> bool {
+        self.lhs_signed && (self.lhs as i64) < 0
+    }
+
+    /// Check if rhs is negative (when treated as signed).
+    pub fn rhs_is_negative(&self) -> bool {
+        self.rhs_signed && (self.rhs as i64) < 0
+    }
+
+    /// Get sign-extended lhs as 8 halfwords.
+    ///
+    /// lhs_ext[0..4] = lhs halfwords
+    /// lhs_ext[4..8] = 0xFFFF if negative, 0 otherwise
+    pub fn lhs_extended(&self) -> [u64; 8] {
+        let fill = if self.lhs_is_negative() { SIGN_FILL } else { 0 };
+        [
+            self.lhs & 0xFFFF,
+            (self.lhs >> 16) & 0xFFFF,
+            (self.lhs >> 32) & 0xFFFF,
+            (self.lhs >> 48) & 0xFFFF,
+            fill,
+            fill,
+            fill,
+            fill,
+        ]
+    }
+
+    /// Get sign-extended rhs as 8 halfwords.
+    pub fn rhs_extended(&self) -> [u64; 8] {
+        let fill = if self.rhs_is_negative() { SIGN_FILL } else { 0 };
+        [
+            self.rhs & 0xFFFF,
+            (self.rhs >> 16) & 0xFFFF,
+            (self.rhs >> 32) & 0xFFFF,
+            (self.rhs >> 48) & 0xFFFF,
+            fill,
+            fill,
+            fill,
+            fill,
+        ]
+    }
+
+    /// Compute the raw_product values (convolution intermediates).
+    ///
+    /// raw_product[i] = Σ_k=0^1 2^(16k) × Σ_j=0^(2i+k) lhs_ext[j] × rhs_ext[2i+k-j]
+    #[allow(clippy::needless_range_loop)]
+    pub fn compute_raw_products(&self) -> [u64; 4] {
+        let lhs_ext = self.lhs_extended();
+        let rhs_ext = self.rhs_extended();
+
+        let mut raw = [0u64; 4];
+
+        for i in 0..4 {
+            let mut sum: u128 = 0;
+
+            for k in 0..=1 {
+                let idx = 2 * i + k;
+                if idx < 8 {
+                    for j in 0..=idx {
+                        if j < 8 && (idx - j) < 8 {
+                            let term = (lhs_ext[j] as u128) * (rhs_ext[idx - j] as u128);
+                            sum += term << (16 * k);
+                        }
+                    }
+                }
+            }
+
+            raw[i] = sum as u64;
+        }
+
+        raw
+    }
+}
+
+// =========================================================================
+// Trace generation
+// =========================================================================
+
+/// Generates the MUL trace table from a list of operations.
+///
+/// Operations are deduplicated by (lhs, lhs_signed, rhs, rhs_signed).
+/// Each unique operation tracks separate multiplicities for lo and hi lookups.
+///
+/// # Arguments
+/// * `operations` - List of (MulOperation, wants_hi) pairs
+pub fn generate_mul_trace(
+    operations: &[(MulOperation, bool)],
+) -> TraceTable<GoldilocksField, GoldilocksExtension> {
+    // Deduplicate: (lhs, lhs_signed, rhs, rhs_signed) -> (mu_lo, mu_hi)
+    let mut op_map: HashMap<MulOperation, MulMultiplicities> = HashMap::new();
+
+    for (op, wants_hi) in operations {
+        let entry = op_map.entry(op.clone()).or_default();
+        if *wants_hi {
+            entry.mu_hi += 1;
+        } else {
+            entry.mu_lo += 1;
+        }
+    }
+
+    let unique_ops: Vec<_> = op_map.into_iter().collect();
+    let num_rows = unique_ops.len().next_power_of_two().max(4);
+    let mut data = vec![FE::zero(); num_rows * cols::NUM_COLUMNS];
+
+    for (row_idx, (op, multiplicities)) in unique_ops.iter().enumerate() {
+        let base = row_idx * cols::NUM_COLUMNS;
+
+        // Compute product
+        let (lo, hi) = op.compute_product();
+
+        // Fill lhs as DWordHL (4 halfwords)
+        data[base + cols::LHS_0] = FE::from(op.lhs & 0xFFFF);
+        data[base + cols::LHS_1] = FE::from((op.lhs >> 16) & 0xFFFF);
+        data[base + cols::LHS_2] = FE::from((op.lhs >> 32) & 0xFFFF);
+        data[base + cols::LHS_3] = FE::from((op.lhs >> 48) & 0xFFFF);
+        data[base + cols::LHS_SIGNED] = FE::from(op.lhs_signed as u64);
+
+        // Fill rhs as DWordHL (4 halfwords)
+        data[base + cols::RHS_0] = FE::from(op.rhs & 0xFFFF);
+        data[base + cols::RHS_1] = FE::from((op.rhs >> 16) & 0xFFFF);
+        data[base + cols::RHS_2] = FE::from((op.rhs >> 32) & 0xFFFF);
+        data[base + cols::RHS_3] = FE::from((op.rhs >> 48) & 0xFFFF);
+        data[base + cols::RHS_SIGNED] = FE::from(op.rhs_signed as u64);
+
+        // Fill lo as DWordHL (4 halfwords)
+        data[base + cols::LO_0] = FE::from(lo & 0xFFFF);
+        data[base + cols::LO_1] = FE::from((lo >> 16) & 0xFFFF);
+        data[base + cols::LO_2] = FE::from((lo >> 32) & 0xFFFF);
+        data[base + cols::LO_3] = FE::from((lo >> 48) & 0xFFFF);
+
+        // Fill hi as DWordHL (4 halfwords)
+        data[base + cols::HI_0] = FE::from(hi & 0xFFFF);
+        data[base + cols::HI_1] = FE::from((hi >> 16) & 0xFFFF);
+        data[base + cols::HI_2] = FE::from((hi >> 32) & 0xFFFF);
+        data[base + cols::HI_3] = FE::from((hi >> 48) & 0xFFFF);
+
+        // Fill auxiliary columns
+        data[base + cols::LHS_IS_NEGATIVE] = FE::from(op.lhs_is_negative() as u64);
+        data[base + cols::RHS_IS_NEGATIVE] = FE::from(op.rhs_is_negative() as u64);
+
+        // Fill raw_product columns
+        let raw = op.compute_raw_products();
+        data[base + cols::RAW_PRODUCT_0] = FE::from(raw[0]);
+        data[base + cols::RAW_PRODUCT_1] = FE::from(raw[1]);
+        data[base + cols::RAW_PRODUCT_2] = FE::from(raw[2]);
+        data[base + cols::RAW_PRODUCT_3] = FE::from(raw[3]);
+
+        // Fill multiplicities
+        data[base + cols::MU_LO] = FE::from(multiplicities.mu_lo);
+        data[base + cols::MU_HI] = FE::from(multiplicities.mu_hi);
+    }
+
+    TraceTable::new_main(data, cols::NUM_COLUMNS, 1)
+}
+
+// =========================================================================
+// Bus Interactions
+// =========================================================================
+
+/// Creates all bus interactions for the MUL table.
+///
+/// The MUL table:
+/// - **Sends** MSB16 lookups for sign bit extraction (×2)
+/// - **Sends** IS_HALF lookups for lo/hi range checks (×8)
+/// - **Sends** IS_B20 lookups for carry range checks (×4)
+/// - **Receives** MUL lookups from CPU table (×2: lo and hi)
+pub fn bus_interactions() -> Vec<BusInteraction> {
+    let mut interactions = Vec::new();
+
+    // -------------------------------------------------------------------------
+    // MSB16 lookups for sign bit extraction
+    // -------------------------------------------------------------------------
+    // MSB16[lhs[3]] -> lhs_is_negative (when lhs_signed=1)
+    interactions.push(BusInteraction::sender(
+        BusId::Msb16,
+        Multiplicity::Column(cols::LHS_SIGNED),
+        vec![
+            BusValue::Packed {
+                start_column: cols::LHS_3,
+                packing: Packing::Direct,
+            },
+            BusValue::Packed {
+                start_column: cols::LHS_IS_NEGATIVE,
+                packing: Packing::Direct,
+            },
+        ],
+    ));
+
+    // MSB16[rhs[3]] -> rhs_is_negative (when rhs_signed=1)
+    interactions.push(BusInteraction::sender(
+        BusId::Msb16,
+        Multiplicity::Column(cols::RHS_SIGNED),
+        vec![
+            BusValue::Packed {
+                start_column: cols::RHS_3,
+                packing: Packing::Direct,
+            },
+            BusValue::Packed {
+                start_column: cols::RHS_IS_NEGATIVE,
+                packing: Packing::Direct,
+            },
+        ],
+    ));
+
+    // -------------------------------------------------------------------------
+    // IS_HALF lookups for lo range checks (multiplicity: mu_lo + mu_hi)
+    // -------------------------------------------------------------------------
+    for col in [cols::LO_0, cols::LO_1, cols::LO_2, cols::LO_3] {
+        interactions.push(BusInteraction::sender(
+            BusId::IsHalfword,
+            Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
+            vec![BusValue::Packed {
+                start_column: col,
+                packing: Packing::Direct,
+            }],
+        ));
+    }
+
+    // -------------------------------------------------------------------------
+    // IS_HALF lookups for hi range checks (multiplicity: mu_lo + mu_hi)
+    // -------------------------------------------------------------------------
+    for col in [cols::HI_0, cols::HI_1, cols::HI_2, cols::HI_3] {
+        interactions.push(BusInteraction::sender(
+            BusId::IsHalfword,
+            Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
+            vec![BusValue::Packed {
+                start_column: col,
+                packing: Packing::Direct,
+            }],
+        ));
+    }
+
+    // -------------------------------------------------------------------------
+    // IS_B20 lookups for carry range checks (multiplicity: mu_lo + mu_hi)
+    // -------------------------------------------------------------------------
+    for col in [cols::CARRY_0, cols::CARRY_1, cols::CARRY_2, cols::CARRY_3] {
+        interactions.push(BusInteraction::sender(
+            BusId::IsB20,
+            Multiplicity::Sum(cols::MU_LO, cols::MU_HI),
+            vec![BusValue::Packed {
+                start_column: col,
+                packing: Packing::Direct,
+            }],
+        ));
+    }
+
+    // -------------------------------------------------------------------------
+    // MUL receiver for lo result
+    // -------------------------------------------------------------------------
+    // MUL[lhs, lhs_signed, rhs, rhs_signed, lo, 0] per spec MUL-C7
+    interactions.push(BusInteraction::receiver(
+        BusId::Mul,
+        Multiplicity::Column(cols::MU_LO),
+        vec![
+            // lhs as DWordHL (4 halfwords -> 2 words)
+            BusValue::Packed {
+                start_column: cols::LHS_0,
+                packing: Packing::DWordHL,
+            },
+            // lhs_signed
+            BusValue::Packed {
+                start_column: cols::LHS_SIGNED,
+                packing: Packing::Direct,
+            },
+            // rhs as DWordHL
+            BusValue::Packed {
+                start_column: cols::RHS_0,
+                packing: Packing::DWordHL,
+            },
+            // rhs_signed
+            BusValue::Packed {
+                start_column: cols::RHS_SIGNED,
+                packing: Packing::Direct,
+            },
+            // lo as DWordHL (result)
+            BusValue::Packed {
+                start_column: cols::LO_0,
+                packing: Packing::DWordHL,
+            },
+            // muldiv_selector = 0 (lo)
+            BusValue::constant(0),
+        ],
+    ));
+
+    // -------------------------------------------------------------------------
+    // MUL receiver for hi result
+    // -------------------------------------------------------------------------
+    // MUL[lhs, lhs_signed, rhs, rhs_signed, hi, 1] per spec MUL-C8
+    interactions.push(BusInteraction::receiver(
+        BusId::Mul,
+        Multiplicity::Column(cols::MU_HI),
+        vec![
+            // lhs as DWordHL
+            BusValue::Packed {
+                start_column: cols::LHS_0,
+                packing: Packing::DWordHL,
+            },
+            // lhs_signed
+            BusValue::Packed {
+                start_column: cols::LHS_SIGNED,
+                packing: Packing::Direct,
+            },
+            // rhs as DWordHL
+            BusValue::Packed {
+                start_column: cols::RHS_0,
+                packing: Packing::DWordHL,
+            },
+            // rhs_signed
+            BusValue::Packed {
+                start_column: cols::RHS_SIGNED,
+                packing: Packing::Direct,
+            },
+            // hi as DWordHL (result)
+            BusValue::Packed {
+                start_column: cols::HI_0,
+                packing: Packing::DWordHL,
+            },
+            // muldiv_selector = 1 (hi)
+            BusValue::constant(1),
+        ],
+    ));
+
+    interactions
+}
+
+// =========================================================================
+// Constraints
+// =========================================================================
+
+/// MUL table constraint kinds.
+#[derive(Debug, Clone, Copy)]
+pub enum MulConstraintKind {
+    /// SIGN constraint for lhs: (1 - lhs_signed) * lhs_is_negative = 0
+    LhsSign,
+    /// SIGN constraint for rhs: (1 - rhs_signed) * rhs_is_negative = 0
+    RhsSign,
+    /// Raw product convolution formula for index i
+    RawProduct(usize),
+}
+
+/// MUL table constraint.
+pub struct MulConstraint {
+    constraint_idx: usize,
+    kind: MulConstraintKind,
+}
+
+impl MulConstraint {
+    /// Create a new MUL constraint.
+    pub fn new(kind: MulConstraintKind, constraint_idx: usize) -> Self {
+        Self {
+            constraint_idx,
+            kind,
+        }
+    }
+
+    /// Compute the constraint value.
+    fn compute<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        match self.kind {
+            MulConstraintKind::LhsSign => {
+                // (1 - lhs_signed) * lhs_is_negative = 0
+                let lhs_signed = step.get_main_evaluation_element(0, cols::LHS_SIGNED).clone();
+                let lhs_is_neg = step
+                    .get_main_evaluation_element(0, cols::LHS_IS_NEGATIVE)
+                    .clone();
+                let one = FieldElement::<F>::one();
+                (&one - &lhs_signed) * &lhs_is_neg
+            }
+            MulConstraintKind::RhsSign => {
+                // (1 - rhs_signed) * rhs_is_negative = 0
+                let rhs_signed = step.get_main_evaluation_element(0, cols::RHS_SIGNED).clone();
+                let rhs_is_neg = step
+                    .get_main_evaluation_element(0, cols::RHS_IS_NEGATIVE)
+                    .clone();
+                let one = FieldElement::<F>::one();
+                (&one - &rhs_signed) * &rhs_is_neg
+            }
+            MulConstraintKind::RawProduct(i) => {
+                // raw_product[i] = convolution formula
+                // This requires computing the sign-extended values and convolution
+                self.compute_raw_product_constraint(i, step)
+            }
+        }
+    }
+
+    /// Compute raw_product constraint for index i.
+    ///
+    /// raw_product[i] = Σ_k=0^1 2^(16k) × Σ_j=0^(2i+k) lhs_ext[j] × rhs_ext[2i+k-j]
+    fn compute_raw_product_constraint<F, E>(
+        &self,
+        i: usize,
+        step: &TableView<F, E>,
+    ) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        // Get lhs halfwords
+        let lhs: [FieldElement<F>; 4] = [
+            step.get_main_evaluation_element(0, cols::LHS_0).clone(),
+            step.get_main_evaluation_element(0, cols::LHS_1).clone(),
+            step.get_main_evaluation_element(0, cols::LHS_2).clone(),
+            step.get_main_evaluation_element(0, cols::LHS_3).clone(),
+        ];
+
+        // Get rhs halfwords
+        let rhs: [FieldElement<F>; 4] = [
+            step.get_main_evaluation_element(0, cols::RHS_0).clone(),
+            step.get_main_evaluation_element(0, cols::RHS_1).clone(),
+            step.get_main_evaluation_element(0, cols::RHS_2).clone(),
+            step.get_main_evaluation_element(0, cols::RHS_3).clone(),
+        ];
+
+        // Get sign bits
+        let lhs_is_neg = step
+            .get_main_evaluation_element(0, cols::LHS_IS_NEGATIVE)
+            .clone();
+        let rhs_is_neg = step
+            .get_main_evaluation_element(0, cols::RHS_IS_NEGATIVE)
+            .clone();
+
+        // Build sign-extended values
+        let sign_fill = FieldElement::<F>::from(SIGN_FILL);
+        let mut lhs_ext: [FieldElement<F>; 8] = std::array::from_fn(|_| FieldElement::zero());
+        let mut rhs_ext: [FieldElement<F>; 8] = std::array::from_fn(|_| FieldElement::zero());
+
+        lhs_ext[..4].clone_from_slice(&lhs);
+        rhs_ext[..4].clone_from_slice(&rhs);
+        for j in 4..8 {
+            lhs_ext[j] = &sign_fill * &lhs_is_neg;
+            rhs_ext[j] = &sign_fill * &rhs_is_neg;
+        }
+
+        // Compute convolution sum
+        let shift_16 = FieldElement::<F>::from(SHIFT_16);
+        let mut sum = FieldElement::<F>::zero();
+
+        for k in 0..=1u32 {
+            let idx = 2 * i + k as usize;
+            if idx < 8 {
+                let mut inner_sum = FieldElement::<F>::zero();
+                for j in 0..=idx {
+                    if j < 8 && (idx - j) < 8 {
+                        inner_sum = &inner_sum + &(&lhs_ext[j] * &rhs_ext[idx - j]);
+                    }
+                }
+                // Multiply by 2^(16*k)
+                if k == 0 {
+                    sum = &sum + &inner_sum;
+                } else {
+                    sum = &sum + &(&inner_sum * &shift_16);
+                }
+            }
+        }
+
+        // Constraint: raw_product[i] - sum = 0
+        let raw_col = match i {
+            0 => cols::RAW_PRODUCT_0,
+            1 => cols::RAW_PRODUCT_1,
+            2 => cols::RAW_PRODUCT_2,
+            3 => cols::RAW_PRODUCT_3,
+            _ => unreachable!(),
+        };
+        let raw_product = step.get_main_evaluation_element(0, raw_col).clone();
+
+        raw_product - sum
+    }
+}
+
+impl TransitionConstraint<GoldilocksField, GoldilocksExtension> for MulConstraint {
+    fn degree(&self) -> usize {
+        match self.kind {
+            // (1 - signed) * is_negative is degree 2
+            MulConstraintKind::LhsSign | MulConstraintKind::RhsSign => 2,
+            // Raw product: lhs_ext[j] * rhs_ext[idx-j] where each may involve
+            // sign_fill * is_negative (degree 1), so product is degree 2
+            // But we're summing many degree-2 terms, still degree 2
+            MulConstraintKind::RawProduct(_) => 2,
+        }
+    }
+
+    fn constraint_idx(&self) -> usize {
+        self.constraint_idx
+    }
+
+    fn end_exemptions(&self) -> usize {
+        0
+    }
+
+    fn evaluate(
+        &self,
+        evaluation_context: &TransitionEvaluationContext<GoldilocksField, GoldilocksExtension>,
+        transition_evaluations: &mut [FieldElement<GoldilocksExtension>],
+    ) {
+        match evaluation_context {
+            TransitionEvaluationContext::Prover {
+                frame,
+                periodic_values: _,
+                rap_challenges: _,
+            } => {
+                let constraint_value = self.compute(frame.get_evaluation_step(0));
+                transition_evaluations[self.constraint_idx] = constraint_value.to_extension();
+            }
+            TransitionEvaluationContext::Verifier {
+                frame,
+                periodic_values: _,
+                rap_challenges: _,
+            } => {
+                let constraint_value = self.compute(frame.get_evaluation_step(0));
+                transition_evaluations[self.constraint_idx] = constraint_value;
+            }
+        }
+    }
+}
+
+/// Creates all constraints for the MUL table.
+///
+/// Returns: (constraints, next_constraint_idx)
+pub fn mul_constraints(constraint_idx_start: usize) -> (Vec<MulConstraint>, usize) {
+    let mut idx = constraint_idx_start;
+    let mut constraints = Vec::new();
+
+    // SIGN constraints
+    constraints.push(MulConstraint::new(MulConstraintKind::LhsSign, idx));
+    idx += 1;
+    constraints.push(MulConstraint::new(MulConstraintKind::RhsSign, idx));
+    idx += 1;
+
+    // Raw product constraints for i in 0..4
+    for i in 0..4 {
+        constraints.push(MulConstraint::new(MulConstraintKind::RawProduct(i), idx));
+        idx += 1;
+    }
+
+    (constraints, idx)
+}
+
+// =========================================================================
+// Helper functions
+// =========================================================================
+
+/// Compute the virtual carry values for verification.
+///
+/// This is used by tests to verify the reduce-and-carry logic.
+pub fn compute_carries(lo: u64, hi: u64, raw_products: &[u64; 4]) -> [u64; 4] {
+    // res[0..4] = [lo_word0, lo_word1, hi_word0, hi_word1]
+    let res = [
+        lo & 0xFFFF_FFFF,
+        lo >> 32,
+        hi & 0xFFFF_FFFF,
+        hi >> 32,
+    ];
+
+    let mut carries = [0u64; 4];
+
+    // carry[0] = (raw_product[0] - res[0]) / 2^32
+    let diff0 = raw_products[0].wrapping_sub(res[0]);
+    carries[0] = diff0 >> 32;
+
+    // carry[i] = (raw_product[i] + carry[i-1] - res[i]) / 2^32
+    for i in 1..4 {
+        let sum = raw_products[i]
+            .wrapping_add(carries[i - 1])
+            .wrapping_sub(res[i]);
+        carries[i] = sum >> 32;
+    }
+
+    carries
+}

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -766,7 +766,10 @@ impl Traces {
                 let rhs_signed = op.decode.mp_selector;
                 let rhs = op.compute_arg2();
                 let wants_hi = op.decode.muldiv_selector;
-                (MulOperation::new(lhs, lhs_signed, rhs, rhs_signed), wants_hi)
+                (
+                    MulOperation::new(lhs, lhs_signed, rhs, rhs_signed),
+                    wants_hi,
+                )
             })
             .collect();
 

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -37,6 +37,7 @@ use super::decode;
 use super::load::{self, LoadOperation};
 use super::lt::{self, LtOperation};
 use super::memw::{self, MemwOperation};
+use super::mul::{self, MulOperation};
 use super::types::{GoldilocksExtension, GoldilocksField};
 use crate::ProverError;
 
@@ -532,6 +533,78 @@ fn collect_bitwise_from_lt(lt_ops: &[LtOperation]) -> Vec<BitwiseOperation> {
     bitwise_ops
 }
 
+/// Collects bitwise lookups from MUL operations (MSB16 for sign bits).
+///
+/// MUL sends MSB16 lookups when signed=1 to extract sign bits,
+/// IS_HALF lookups for lo/hi range checks, and IS_B20 lookups for carry range checks.
+///
+/// Returns: Vec of bitwise lookups
+fn collect_bitwise_from_mul(mul_ops: &[(MulOperation, bool)]) -> Vec<BitwiseOperation> {
+    // MSB16: up to 2 per op, IS_HALF: 8 per op (4 lo + 4 hi), IS_B20: 4 per op (carries)
+    let mut bitwise_ops = Vec::with_capacity(mul_ops.len() * 14);
+
+    for (op, _wants_hi) in mul_ops {
+        // MSB16[lhs[3]] when lhs_signed=1
+        if op.lhs_signed {
+            let lhs_3 = ((op.lhs >> 48) & 0xFFFF) as u16;
+            bitwise_ops.push(BitwiseOperation::halfword(
+                BitwiseOperationType::Msb16,
+                (lhs_3 & 0xFF) as u8,
+                (lhs_3 >> 8) as u8,
+            ));
+        }
+
+        // MSB16[rhs[3]] when rhs_signed=1
+        if op.rhs_signed {
+            let rhs_3 = ((op.rhs >> 48) & 0xFFFF) as u16;
+            bitwise_ops.push(BitwiseOperation::halfword(
+                BitwiseOperationType::Msb16,
+                (rhs_3 & 0xFF) as u8,
+                (rhs_3 >> 8) as u8,
+            ));
+        }
+
+        // IS_HALF for lo[0..4] and hi[0..4] with multiplicity 1 per operation
+        // MUL table sends with mu_sum = mu_lo + mu_hi; since we iterate original ops,
+        // each operation contributes 1 to the sum.
+        let (lo, hi) = op.compute_product();
+
+        // IS_HALF for lo halfwords
+        for shift in [0, 16, 32, 48] {
+            let half = ((lo >> shift) & 0xFFFF) as u16;
+            bitwise_ops.push(BitwiseOperation::halfword(
+                BitwiseOperationType::IsHalf,
+                (half & 0xFF) as u8,
+                (half >> 8) as u8,
+            ));
+        }
+
+        // IS_HALF for hi halfwords
+        for shift in [0, 16, 32, 48] {
+            let half = ((hi >> shift) & 0xFFFF) as u16;
+            bitwise_ops.push(BitwiseOperation::halfword(
+                BitwiseOperationType::IsHalf,
+                (half & 0xFF) as u8,
+                (half >> 8) as u8,
+            ));
+        }
+
+        // IS_B20 for carry[0..4] range checks
+        let raw_products = op.compute_raw_products();
+        let carries = mul::compute_carries(lo, hi, &raw_products);
+        for carry in carries {
+            // IS_B20 takes a 20-bit value packed as X + 256*Y + 65536*Z
+            // where X, Y are bytes and Z is a 4-bit nibble
+            let x = (carry & 0xFF) as u8;
+            let y = ((carry >> 8) & 0xFF) as u8;
+            let z = ((carry >> 16) & 0xF) as u8;
+            bitwise_ops.push(BitwiseOperation::b20(x, y, z));
+        }
+    }
+
+    bitwise_ops
+}
+
 /// Collects IS_HALFWORD lookups from MEMW address_add columns.
 ///
 /// Returns: Vec of bitwise lookups
@@ -579,6 +652,9 @@ pub struct Traces {
 
     /// DECODE instruction decoding table
     pub decode: TraceTable<GoldilocksField, GoldilocksExtension>,
+
+    /// MUL multiplication trace
+    pub mul: TraceTable<GoldilocksField, GoldilocksExtension>,
 }
 
 impl Traces {
@@ -608,6 +684,22 @@ impl Traces {
         let (memw_ops, load_ops, mut lt_ops, mut bitwise_ops) =
             collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
 
+        // Collect MUL operations from CPU ops where op_mul = true
+        let mul_ops: Vec<(MulOperation, bool)> = cpu_ops
+            .iter()
+            .filter(|op| op.decode.op_mul)
+            .map(|op| {
+                let lhs = op.compute_arg1();
+                let lhs_signed = op.decode.signed;
+                // rhs_signed = mp_selector per spec CPU-CA44:
+                // MUL/MULH have mp_selector=1 (both signed), MULHU/MULHSU have mp_selector=0 (rhs unsigned)
+                let rhs_signed = op.decode.mp_selector;
+                let rhs = op.compute_arg2();
+                let wants_hi = op.decode.muldiv_selector;
+                (MulOperation::new(lhs, lhs_signed, rhs, rhs_signed), wants_hi)
+            })
+            .collect();
+
         // =====================================================================
         // PHASE 3: MEMW → LT (timestamp ordering and overflow checks)
         // =====================================================================
@@ -618,6 +710,7 @@ impl Traces {
         // =====================================================================
         bitwise_ops.extend(collect_bitwise_from_lt(&lt_ops));
         bitwise_ops.extend(collect_bitwise_from_memw(&memw_ops));
+        bitwise_ops.extend(collect_bitwise_from_mul(&mul_ops));
 
         // =====================================================================
         // PHASE 5: Generate final traces
@@ -626,6 +719,7 @@ impl Traces {
         let lt = lt::generate_lt_trace(&lt_ops);
         let memw = memw::generate_memw_trace(&memw_ops);
         let load = load::generate_load_trace(&load_ops);
+        let mul = mul::generate_mul_trace(&mul_ops);
 
         let mut bitwise = bitwise::generate_bitwise_trace();
         bitwise::update_multiplicities(&mut bitwise, &bitwise_ops);
@@ -643,6 +737,7 @@ impl Traces {
             memw,
             load,
             decode,
+            mul,
         })
     }
 

--- a/prover/src/tables/types.rs
+++ b/prover/src/tables/types.rs
@@ -672,12 +672,13 @@ impl DecodeEntry {
             ArithOp::MulHigh => {
                 entry.op_mul = true;
                 entry.muldiv_selector = true;
+                entry.mp_selector = true; // both operands signed for MULH
                 entry.signed = true;
             }
             ArithOp::MulHighSignedUnsigned => {
                 entry.op_mul = true;
                 entry.muldiv_selector = true;
-                entry.mp_selector = true;
+                // mp_selector = false (default): rhs is unsigned for MULHSU
                 entry.signed = true;
             }
             ArithOp::MulHighUnsigned => {

--- a/prover/src/tables/types.rs
+++ b/prover/src/tables/types.rs
@@ -122,22 +122,38 @@ pub const SHIFT_16: u64 = 1 << 16;
 /// 2^32 for word combining
 pub const SHIFT_32: u64 = 1 << 32;
 
-/// 2^(-32) mod p for carry extraction in 64-bit addition
-/// In Babybear field: p = 2^31 - 2^27 + 1
-/// We need to find x such that x * 2^32 ≡ 1 (mod p)
-pub const INV_2_32: u64 = {
-    // 2^32 mod p = 2^32 mod (2^31 - 2^27 + 1)
-    // 2^32 = 2 * 2^31 = 2 * (p + 2^27 - 1) = 2p + 2^28 - 2 ≡ 2^28 - 2 (mod p)
-    // We need the inverse of (2^28 - 2) mod p
-    // For now, this is a placeholder - compute at runtime or verify
-    1
-};
+// Field inverses for Goldilocks prime p = 2^64 - 2^32 + 1
+// Used for virtual carry computation in MUL table
+//
+// Only the constants actually used in mul.rs are defined here:
+// - Positive: INV_2_32, INV_2_64, INV_2_96, INV_2_128 (for raw_product terms)
+// - Negative: NEG_INV_2_* (for lo/hi terms which are subtracted)
 
-/// 2^(-16) mod p for halfword operations
-pub const INV_2_16: u64 = {
-    // Placeholder - compute at runtime or verify
-    1
-};
+/// 2^(-32) mod p
+pub const INV_2_32: u64 = 18446744065119617026;
+/// 2^(-64) mod p
+pub const INV_2_64: u64 = 18446744065119617025;
+/// 2^(-96) mod p
+pub const INV_2_96: u64 = 18446744069414584320;
+/// 2^(-128) mod p
+pub const INV_2_128: u64 = 4294967295;
+
+/// -(2^-16) mod p = p - 2^(-16)
+pub const NEG_INV_2_16: u64 = 281474976645120;
+/// -(2^-32) mod p = p - 2^(-32)
+pub const NEG_INV_2_32: u64 = 4294967295;
+/// -(2^-48) mod p = p - 2^(-48)
+pub const NEG_INV_2_48: u64 = 281474976710656;
+/// -(2^-64) mod p = p - 2^(-64)
+pub const NEG_INV_2_64: u64 = 4294967296;
+/// -(2^-80) mod p = p - 2^(-80)
+pub const NEG_INV_2_80: u64 = 65536;
+/// -(2^-96) mod p = p - 2^(-96)
+pub const NEG_INV_2_96: u64 = 1;
+/// -(2^-112) mod p = p - 2^(-112)
+pub const NEG_INV_2_112: u64 = 18446462594437939201;
+/// -(2^-128) mod p = p - 2^(-128)
+pub const NEG_INV_2_128: u64 = 18446744065119617026;
 
 // =========================================================================
 // Column index helpers

--- a/prover/src/test_utils.rs
+++ b/prover/src/test_utils.rs
@@ -39,6 +39,7 @@ use crate::tables::lt::{LtOperation, bus_interactions as lt_bus_interactions, co
 use crate::tables::memw::{
     bus_interactions as memw_bus_interactions, cols as memw_cols, constraints as memw_constraints,
 };
+use crate::tables::mul::{bus_interactions as mul_bus_interactions, cols as mul_cols};
 use crate::tables::types::{GoldilocksExtension, GoldilocksField};
 
 pub type F = GoldilocksField;
@@ -564,6 +565,23 @@ pub fn create_decode_air(proof_options: &ProofOptions) -> VmAir {
 
     AirWithBuses::new(
         decode_cols::NUM_COLUMNS,
+        auxiliary_trace_build_data,
+        proof_options,
+        1,
+        transition_constraints,
+    )
+}
+
+/// Create MUL AIR with bus interactions.
+pub fn create_mul_air(proof_options: &ProofOptions) -> VmAir {
+    let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
+
+    let auxiliary_trace_build_data = AuxiliaryTraceBuildData {
+        interactions: mul_bus_interactions(),
+    };
+
+    AirWithBuses::new(
+        mul_cols::NUM_COLUMNS,
         auxiliary_trace_build_data,
         proof_options,
         1,

--- a/prover/src/tests/cpu_tests.rs
+++ b/prover/src/tests/cpu_tests.rs
@@ -323,10 +323,11 @@ fn test_bus_interactions_count() {
     // - 1 M6 (LOAD from memory)
     // - 1 M7 (STORE to memory)
     // - 1 DECODE (instruction fetch)
+    // - 1 MUL (multiplication)
     // - 1 BRANCH (branch/jump target calculation)
     // - 1 ECALL (send to HALT table)
-    // Total: 8 + 8 + 8 + 2 + 1 + 1 + 1 + 5 + 1 + 1 + 1 = 37
-    assert_eq!(interactions.len(), 37);
+    // Total: 8 + 8 + 8 + 2 + 1 + 1 + 1 + 5 + 1 + 1 + 1 + 1 = 38
+    assert_eq!(interactions.len(), 38);
 }
 
 #[test]

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -13,6 +13,8 @@ pub mod lt_bus_tests;
 #[cfg(test)]
 pub mod lt_tests;
 #[cfg(test)]
+pub mod mul_tests;
+#[cfg(test)]
 pub mod prove_elfs_tests;
 #[cfg(test)]
 pub mod trace_builder_tests;

--- a/prover/src/tests/mul_tests.rs
+++ b/prover/src/tests/mul_tests.rs
@@ -1,0 +1,303 @@
+//! Tests for the MUL (Multiplication) table.
+
+use crate::tables::mul::{MulOperation, bus_interactions, cols, generate_mul_trace};
+use crate::tables::types::FE;
+
+#[test]
+fn test_mul_unsigned_basic() {
+    // Simple unsigned multiplications
+    let op1 = MulOperation::new(5, false, 10, false);
+    let (lo, hi) = op1.compute_product();
+    assert_eq!(lo, 50);
+    assert_eq!(hi, 0);
+
+    // Larger numbers
+    let op2 = MulOperation::new(0x1_0000_0000, false, 0x1_0000_0000, false);
+    let (lo, hi) = op2.compute_product();
+    assert_eq!(lo, 0); // 2^64 mod 2^64 = 0
+    assert_eq!(hi, 1); // 2^64 / 2^64 = 1
+
+    // Max values
+    let op3 = MulOperation::new(u64::MAX, false, 2, false);
+    let (lo, hi) = op3.compute_product();
+    // u64::MAX * 2 = 2^65 - 2 = 0xFFFF_FFFF_FFFF_FFFE (lo) with hi = 1
+    assert_eq!(lo, u64::MAX - 1);
+    assert_eq!(hi, 1);
+}
+
+#[test]
+fn test_mul_signed_basic() {
+    // Positive * positive
+    let op1 = MulOperation::new(5, true, 10, true);
+    let (lo, hi) = op1.compute_product();
+    assert_eq!(lo, 50);
+    assert_eq!(hi, 0);
+
+    // Negative * positive
+    let op2 = MulOperation::new((-5i64) as u64, true, 10, true);
+    let (lo, hi) = op2.compute_product();
+    assert_eq!(lo as i64, -50);
+    assert_eq!(hi, u64::MAX); // Sign extension
+
+    // Negative * negative
+    let op3 = MulOperation::new((-5i64) as u64, true, (-10i64) as u64, true);
+    let (lo, hi) = op3.compute_product();
+    assert_eq!(lo, 50);
+    assert_eq!(hi, 0);
+
+    // Large negative
+    let op4 = MulOperation::new((-1i64) as u64, true, (-1i64) as u64, true);
+    let (lo, hi) = op4.compute_product();
+    assert_eq!(lo, 1);
+    assert_eq!(hi, 0);
+}
+
+#[test]
+fn test_mul_mulhsu() {
+    // MULHSU: signed lhs * unsigned rhs
+    // -1 (signed) * 2 (unsigned) = -2
+    let op1 = MulOperation::new((-1i64) as u64, true, 2, false);
+    let (lo, hi) = op1.compute_product();
+    assert_eq!(lo as i64, -2);
+    assert_eq!(hi, u64::MAX); // Sign extension
+
+    // Positive signed * unsigned
+    let op2 = MulOperation::new(5, true, 10, false);
+    let (lo, hi) = op2.compute_product();
+    assert_eq!(lo, 50);
+    assert_eq!(hi, 0);
+}
+
+#[test]
+fn test_sign_detection() {
+    // Unsigned: never negative
+    let op1 = MulOperation::new((-1i64) as u64, false, (-1i64) as u64, false);
+    assert!(!op1.lhs_is_negative());
+    assert!(!op1.rhs_is_negative());
+
+    // Signed: check sign bit
+    let op2 = MulOperation::new((-1i64) as u64, true, 5, true);
+    assert!(op2.lhs_is_negative());
+    assert!(!op2.rhs_is_negative());
+
+    // MULHSU: lhs signed, rhs unsigned
+    let op3 = MulOperation::new((-1i64) as u64, true, (-1i64) as u64, false);
+    assert!(op3.lhs_is_negative());
+    assert!(!op3.rhs_is_negative()); // rhs_signed=false, so never negative
+}
+
+#[test]
+fn test_sign_extension() {
+    // Positive number: no sign extension
+    let op1 = MulOperation::new(0x1234_5678_9ABC_DEF0, false, 0, false);
+    let ext = op1.lhs_extended();
+    assert_eq!(ext[0], 0xDEF0);
+    assert_eq!(ext[1], 0x9ABC);
+    assert_eq!(ext[2], 0x5678);
+    assert_eq!(ext[3], 0x1234);
+    assert_eq!(ext[4], 0); // No extension
+    assert_eq!(ext[5], 0);
+    assert_eq!(ext[6], 0);
+    assert_eq!(ext[7], 0);
+
+    // Signed positive: still no extension
+    let op2 = MulOperation::new(0x1234_5678_9ABC_DEF0, true, 0, false);
+    let ext = op2.lhs_extended();
+    assert_eq!(ext[4], 0); // MSB is 0, so positive
+    assert_eq!(ext[7], 0);
+
+    // Signed negative: full extension
+    let op3 = MulOperation::new((-1i64) as u64, true, 0, false);
+    let ext = op3.lhs_extended();
+    assert_eq!(ext[0], 0xFFFF);
+    assert_eq!(ext[3], 0xFFFF);
+    assert_eq!(ext[4], 0xFFFF); // Sign extension
+    assert_eq!(ext[7], 0xFFFF);
+}
+
+#[test]
+fn test_raw_products() {
+    // Simple case: 2 * 3 = 6
+    let op = MulOperation::new(2, false, 3, false);
+    let raw = op.compute_raw_products();
+    // raw[0] should contain the low 32-bit portion of convolution
+    // For 2 * 3, result is 6, which fits in raw[0]
+    assert!(raw[0] >= 6, "raw[0] should contain product term");
+}
+
+#[test]
+fn test_trace_generation() {
+    let ops = vec![
+        (MulOperation::new(100, false, 200, false), false), // wants_lo
+        (MulOperation::new(5, true, 10, true), true),       // wants_hi
+    ];
+
+    let trace = generate_mul_trace(&ops);
+
+    // Should be padded to power of 2 (minimum 4 for FRI)
+    assert_eq!(trace.main_table.height, 4);
+    assert_eq!(trace.main_table.width, cols::NUM_COLUMNS);
+
+    // Find the rows
+    let mut found_100_200 = false;
+    let mut found_5_10 = false;
+
+    for row_idx in 0..4 {
+        let row = trace.main_table.get_row(row_idx);
+        if row[cols::LHS_0] == FE::from(100u64) && row[cols::RHS_0] == FE::from(200u64) {
+            assert_eq!(row[cols::LHS_SIGNED], FE::zero());
+            assert_eq!(row[cols::RHS_SIGNED], FE::zero());
+            assert_eq!(row[cols::MU_LO], FE::one()); // wants_lo
+            assert_eq!(row[cols::MU_HI], FE::zero());
+            // Check product: 100 * 200 = 20000
+            assert_eq!(row[cols::LO_0], FE::from(20000u64 & 0xFFFF));
+            found_100_200 = true;
+        }
+        if row[cols::LHS_0] == FE::from(5u64) && row[cols::RHS_0] == FE::from(10u64) {
+            assert_eq!(row[cols::LHS_SIGNED], FE::one());
+            assert_eq!(row[cols::RHS_SIGNED], FE::one());
+            assert_eq!(row[cols::MU_LO], FE::zero());
+            assert_eq!(row[cols::MU_HI], FE::one()); // wants_hi
+            // Check product: 5 * 10 = 50
+            assert_eq!(row[cols::LO_0], FE::from(50u64));
+            found_5_10 = true;
+        }
+    }
+
+    assert!(found_100_200, "Row with lhs=100, rhs=200 not found");
+    assert!(found_5_10, "Row with lhs=5, rhs=10 not found");
+}
+
+#[test]
+fn test_multiplicity_aggregation() {
+    // Create operations where same (lhs, rhs, signs) appears multiple times
+    // with different wants_hi flags
+    let ops = vec![
+        (MulOperation::new(5, false, 10, false), false), // wants_lo
+        (MulOperation::new(5, false, 10, false), false), // wants_lo again
+        (MulOperation::new(5, false, 10, false), true),  // wants_hi
+        (MulOperation::new(100, false, 200, false), true), // different op
+    ];
+
+    let trace = generate_mul_trace(&ops);
+
+    // Should deduplicate to 2 unique rows, padded to 4
+    assert_eq!(trace.main_table.height, 4);
+
+    let mut found_5_10 = false;
+    let mut found_100_200 = false;
+
+    for row_idx in 0..4 {
+        let row = trace.main_table.get_row(row_idx);
+        if row[cols::LHS_0] == FE::from(5u64) && row[cols::RHS_0] == FE::from(10u64) {
+            assert_eq!(
+                row[cols::MU_LO],
+                FE::from(2u64),
+                "Expected mu_lo=2 for (5, 10)"
+            );
+            assert_eq!(
+                row[cols::MU_HI],
+                FE::from(1u64),
+                "Expected mu_hi=1 for (5, 10)"
+            );
+            found_5_10 = true;
+        }
+        if row[cols::LHS_0] == FE::from(100u64) && row[cols::RHS_0] == FE::from(200u64) {
+            assert_eq!(
+                row[cols::MU_LO],
+                FE::zero(),
+                "Expected mu_lo=0 for (100, 200)"
+            );
+            assert_eq!(
+                row[cols::MU_HI],
+                FE::one(),
+                "Expected mu_hi=1 for (100, 200)"
+            );
+            found_100_200 = true;
+        }
+    }
+
+    assert!(found_5_10, "Row with lhs=5, rhs=10 not found");
+    assert!(found_100_200, "Row with lhs=100, rhs=200 not found");
+}
+
+#[test]
+fn test_different_signed_flags_separate_rows() {
+    // Same lhs/rhs but different signed flags should be separate rows
+    let ops = vec![
+        (MulOperation::new(5, false, 10, false), false), // UNSIGNED
+        (MulOperation::new(5, true, 10, true), false),   // SIGNED
+        (MulOperation::new(5, true, 10, false), false),  // MULHSU
+    ];
+
+    let trace = generate_mul_trace(&ops);
+
+    // 3 unique operations, padded to 4
+    assert_eq!(trace.main_table.height, 4);
+
+    let mut count_5_10 = 0;
+    for row_idx in 0..4 {
+        let row = trace.main_table.get_row(row_idx);
+        if row[cols::LHS_0] == FE::from(5u64) && row[cols::RHS_0] == FE::from(10u64) {
+            // Check that multiplicity is 1 for each unique operation
+            assert_eq!(row[cols::MU_LO], FE::one());
+            count_5_10 += 1;
+        }
+    }
+
+    assert_eq!(
+        count_5_10, 3,
+        "Should have 3 separate rows for (5, 10) with different signed flags"
+    );
+}
+
+#[test]
+fn test_bus_interactions_count() {
+    let interactions = bus_interactions();
+    // Expected interactions:
+    // - 2x MSB16 senders (lhs sign, rhs sign)
+    // - 8x IS_HALF senders (lo[0..4], hi[0..4])
+    // - 2x MUL receivers (lo, hi)
+    // Total: 2 + 8 + 2 = 12
+    // Note: Carries are virtual and checked via constraints, not bus lookups
+    assert_eq!(interactions.len(), 12, "Expected 12 bus interactions");
+}
+
+#[test]
+fn test_large_multiplication() {
+    // Test with large numbers that overflow into hi
+    let op = MulOperation::new(0xFFFF_FFFF_FFFF_FFFF, false, 0xFFFF_FFFF_FFFF_FFFF, false);
+    let (lo, hi) = op.compute_product();
+
+    // (2^64 - 1)^2 = 2^128 - 2^65 + 1
+    // lo = 1, hi = 2^64 - 2
+    assert_eq!(lo, 1);
+    assert_eq!(hi, 0xFFFF_FFFF_FFFF_FFFE);
+}
+
+#[test]
+fn test_zero_multiplication() {
+    let op1 = MulOperation::new(0, false, 12345, false);
+    let (lo, hi) = op1.compute_product();
+    assert_eq!(lo, 0);
+    assert_eq!(hi, 0);
+
+    let op2 = MulOperation::new(12345, true, 0, true);
+    let (lo, hi) = op2.compute_product();
+    assert_eq!(lo, 0);
+    assert_eq!(hi, 0);
+}
+
+#[test]
+fn test_identity_multiplication() {
+    let op = MulOperation::new(12345, false, 1, false);
+    let (lo, hi) = op.compute_product();
+    assert_eq!(lo, 12345);
+    assert_eq!(hi, 0);
+}
+
+#[test]
+fn testito() {
+    let inv = FE::inv(&FE::from(10usize.pow(19)));
+    println!("Inverse of 10^19 is {}", inv);
+}

--- a/prover/src/tests/mul_tests.rs
+++ b/prover/src/tests/mul_tests.rs
@@ -295,4 +295,3 @@ fn test_identity_multiplication() {
     assert_eq!(lo, 12345);
     assert_eq!(hi, 0);
 }
-

--- a/prover/src/tests/mul_tests.rs
+++ b/prover/src/tests/mul_tests.rs
@@ -296,8 +296,3 @@ fn test_identity_multiplication() {
     assert_eq!(hi, 0);
 }
 
-#[test]
-fn testito() {
-    let inv = FE::inv(&FE::from(10usize.pow(19)));
-    println!("Inverse of 10^19 is {}", inv);
-}

--- a/prover/src/tests/mul_tests.rs
+++ b/prover/src/tests/mul_tests.rs
@@ -257,10 +257,10 @@ fn test_bus_interactions_count() {
     // Expected interactions:
     // - 2x MSB16 senders (lhs sign, rhs sign)
     // - 8x IS_HALF senders (lo[0..4], hi[0..4])
+    // - 4x IS_B20 senders (carry[0..4] virtual range checks)
     // - 2x MUL receivers (lo, hi)
-    // Total: 2 + 8 + 2 = 12
-    // Note: Carries are virtual and checked via constraints, not bus lookups
-    assert_eq!(interactions.len(), 12, "Expected 12 bus interactions");
+    // Total: 2 + 8 + 4 + 2 = 16
+    assert_eq!(interactions.len(), 16, "Expected 16 bus interactions");
 }
 
 #[test]

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -33,7 +33,7 @@ use crate::tables::types::{GoldilocksExtension, GoldilocksField};
 // Import shared utilities
 use crate::test_utils::{
     create_bitwise_air, create_cpu_air, create_decode_air, create_load_air, create_lt_air,
-    create_memw_air, run_asm_elf,
+    create_memw_air, create_mul_air, run_asm_elf,
 };
 
 type F = GoldilocksField;
@@ -43,7 +43,7 @@ type E = GoldilocksExtension;
 // Prover test helpers
 // =============================================================================
 
-/// Run multi_prove and multi_verify for all VM tables (CPU + Bitwise + LT + MEMW + LOAD + DECODE).
+/// Run multi_prove and multi_verify for all VM tables (CPU + Bitwise + LT + MEMW + LOAD + DECODE + MUL).
 ///
 /// Uses the FULL 2^20 row bitwise table with preprocessed commitment.
 /// Returns true if verification succeeds.
@@ -54,6 +54,7 @@ fn prove_and_verify_vm(
     memw_trace: &mut TraceTable<F, E>,
     load_trace: &mut TraceTable<F, E>,
     decode_trace: &mut TraceTable<F, E>,
+    mul_trace: &mut TraceTable<F, E>,
     elf: &Elf,
 ) -> bool {
     let proof_options = ProofOptions::default_test_options();
@@ -73,6 +74,7 @@ fn prove_and_verify_vm(
             .expect("Failed to compute decode commitment"),
         decode::NUM_PRECOMPUTED_COLS,
     );
+    let mul_air = create_mul_air(&proof_options);
 
     let air_trace_pairs: Vec<(
         &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
@@ -85,6 +87,7 @@ fn prove_and_verify_vm(
         (&memw_air, memw_trace, &()),
         (&load_air, load_trace, &()),
         (&decode_air, decode_trace, &()),
+        (&mul_air, mul_trace, &()),
     ];
 
     let multi_proof =
@@ -103,6 +106,7 @@ fn prove_and_verify_vm(
         &memw_air,
         &load_air,
         &decode_air,
+        &mul_air,
     ];
 
     let result = Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[]));
@@ -112,7 +116,7 @@ fn prove_and_verify_vm(
     result
 }
 
-/// Run multi_prove and multi_verify for all VM tables (CPU + Bitwise + LT + MEMW + LOAD + DECODE).
+/// Run multi_prove and multi_verify for all VM tables (CPU + Bitwise + LT + MEMW + LOAD + DECODE + MUL).
 ///
 /// Used for fast tests where the bitwise table is a dummy that only contains
 /// the rows needed to balance the bus. NOT the full preprocessed table.
@@ -123,6 +127,7 @@ fn prove_and_verify_vm_minimal(
     memw_trace: &mut TraceTable<F, E>,
     load_trace: &mut TraceTable<F, E>,
     decode_trace: &mut TraceTable<F, E>,
+    mul_trace: &mut TraceTable<F, E>,
 ) -> bool {
     let proof_options = ProofOptions::default_test_options();
 
@@ -132,6 +137,7 @@ fn prove_and_verify_vm_minimal(
     let memw_air = create_memw_air(&proof_options);
     let load_air = create_load_air(&proof_options);
     let decode_air = create_decode_air(&proof_options);
+    let mul_air = create_mul_air(&proof_options);
 
     let air_trace_pairs: Vec<(
         &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
@@ -144,6 +150,7 @@ fn prove_and_verify_vm_minimal(
         (&memw_air, memw_trace, &()),
         (&load_air, load_trace, &()),
         (&decode_air, decode_trace, &()),
+        (&mul_air, mul_trace, &()),
     ];
 
     let multi_proof =
@@ -162,6 +169,7 @@ fn prove_and_verify_vm_minimal(
         &memw_air,
         &load_air,
         &decode_air,
+        &mul_air,
     ];
 
     Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[]))
@@ -243,7 +251,8 @@ fn test_prove_elfs_sub_fast() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "Proof verification failed for sub program (fast)"
     );
@@ -268,7 +277,8 @@ fn test_prove_elfs_sub_neg_result_fast() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "Proof verification failed for sub_neg_result program (fast)"
     );
@@ -293,7 +303,8 @@ fn test_prove_elfs_sub_underflow_fast() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "Proof verification failed for sub_underflow program (fast)"
     );
@@ -318,7 +329,8 @@ fn test_prove_elfs_subw_fast() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "Proof verification failed for subw program (fast)"
     );
@@ -344,7 +356,8 @@ fn test_prove_elfs_arith_lui_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "Proof verification failed for arith_lui_8 program"
     );
@@ -370,7 +383,8 @@ fn test_prove_elfs_arith_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "Proof verification failed for arith_8 program"
     );
@@ -399,7 +413,8 @@ fn test_prove_elfs_basic_arith_32() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "Proof verification failed for basic_arith_32 program"
     );
@@ -441,7 +456,8 @@ fn test_prove_elfs_comprehensive() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "Proof verification failed for comprehensive_test program"
     );
@@ -465,7 +481,8 @@ fn test_prove_elfs_test_add_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_add_8 failed"
     );
@@ -483,7 +500,8 @@ fn test_prove_elfs_test_sub_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_sub_8 failed"
     );
@@ -501,7 +519,8 @@ fn test_prove_elfs_test_addw_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_addw_8 failed"
     );
@@ -520,7 +539,8 @@ fn test_prove_elfs_test_subw_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_subw_8 failed"
     );
@@ -539,7 +559,8 @@ fn test_prove_elfs_test_addw_lui_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_addw_lui_8 failed"
     );
@@ -558,7 +579,8 @@ fn test_prove_elfs_test_subw_lui_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_subw_lui_8 failed"
     );
@@ -577,7 +599,8 @@ fn test_prove_elfs_test_add_neg_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_add_neg_8 failed"
     );
@@ -596,7 +619,8 @@ fn test_prove_elfs_test_sub_neg_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_sub_neg_8 failed"
     );
@@ -615,7 +639,8 @@ fn test_prove_elfs_test_mul_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_mul_8 failed"
     );
@@ -634,7 +659,8 @@ fn test_prove_elfs_test_div_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_div_8 failed"
     );
@@ -653,7 +679,8 @@ fn test_prove_elfs_test_shift_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_shift_8 failed"
     );
@@ -672,7 +699,8 @@ fn test_prove_elfs_test_bitwise_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_bitwise_8 failed"
     );
@@ -700,7 +728,8 @@ fn test_prove_elfs_test_slt_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_slt_8 failed"
     );
@@ -723,7 +752,8 @@ fn test_prove_elfs_test_xor_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_xor_8 failed"
     );
@@ -741,7 +771,8 @@ fn test_prove_elfs_test_lb_lh_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_lb_lh_8 failed"
     );
@@ -760,7 +791,8 @@ fn test_prove_elfs_test_sb_sh_8() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "test_sb_sh_8 failed"
     );
@@ -788,7 +820,8 @@ fn test_prove_elfs_all_branches_16() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "all_branches_16 failed"
     );
@@ -807,7 +840,8 @@ fn test_prove_elfs_all_loadstore_32() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "all_loadstore_32 failed"
     );
@@ -839,7 +873,8 @@ fn test_prove_elfs_all_instructions_64() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "all_instructions_64 failed"
     );
@@ -879,6 +914,7 @@ fn test_prove_elfs_all_instructions_64_full() {
             &mut traces.memw,
             &mut traces.load,
             &mut traces.decode,
+            &mut traces.mul,
             &elf,
         ),
         "all_instructions_64_full failed - comprehensive test with full bitwise table"
@@ -918,7 +954,8 @@ fn test_dhat_memory_profile() {
             &mut traces.lt,
             &mut traces.memw,
             &mut traces.load,
-            &mut traces.decode
+            &mut traces.decode,
+            &mut traces.mul,
         ),
         "verification failed"
     );


### PR DESCRIPTION
  Implements the MUL table for signed/unsigned 64-bit multiplication

  ## Changes

  ### New files
  - `prover/src/tables/mul.rs` - MUL table implementation (26 columns)
  - `prover/src/tests/mul_tests.rs` - Unit tests

  ### Modified files
  - `prover/src/tables/cpu.rs` - Add MUL bus sender
  - `prover/src/tables/trace_builder.rs` - Collect MUL ops and generate trace
  - `prover/src/tables/types.rs` - Add field inverse constants for virtual carries
  - `prover/src/tables/bitwise.rs` - Add IS_B20 row constructor
  - `prover/src/test_utils.rs` - Add `create_mul_air()`
  - `prover/src/tests/prove_elfs_tests.rs` - Include MUL table in integration tests

  ## Implementation

  ### Columns (26)
  - Input: `lhs[0..4]`, `lhs_signed`, `rhs[0..4]`, `rhs_signed`
  - Output: `lo[0..4]`, `hi[0..4]`
  - Auxiliary: `lhs_is_negative`, `rhs_is_negative`, `raw_product[0..4]`
  - Multiplicity: `μ_lo`, `μ_hi`

  ### Constraints
  - SIGN constraints for `lhs_is_negative` and `rhs_is_negative`
  - Raw product convolution formula

  ### Bus interactions
  - **Senders**: MSB16 (×2), IS_HALF (×8), IS_B20 (×4 virtual carries)
  - **Receivers**: MUL (×2 for lo/hi results)

  ## Supported instructions
  - MUL, MULW (low 64 bits)
  - MULH (high 64 bits, both signed)
  - MULHU (high 64 bits, both unsigned)
  - MULHSU (high 64 bits, signed × unsigned)