### PR TITLE
spec: drop `IsZero` template

### DIFF
--- a/spec/cpu.typ
+++ b/spec/cpu.typ
@@ -76,9 +76,8 @@ including the appropriate sign/zero extension, depending on `word_instr`.
 #render_constraint_table(chip, config, groups: "ext")
 
 === Other constraints
-
-#rj[proper ref to IsZero/IsEqual]
-For @cpu:c:is_equal, refer to the logic of IsZero or IsEqual, in combination with the subtraction of @cpu:c:sub.
+For @cpu:c:is_equal, note that @cpu:c:sub sets `res` to be the difference between `arg1` and `arg2` whenever `BEQ` is $1$.
+Given that this difference is $0$ when both are equal, @cpu:c:is_equal ensures `is_equal` is set to $1$ if and only if $#`arg1` = #`arg2`$ and `BEQ` is set.
 
 #render_constraint_table(chip, config, groups: "misc")
 

--- a/spec/src/shift.toml
+++ b/spec/src/shift.toml
@@ -198,8 +198,8 @@ ref = "shift:c:bit_shift_if_right"
 multiplicity = "right"
 
 [[constraints.bit_shift]]
-kind = "template"
-tag = "IsZero"
+kind = "interaction"
+tag = "ZERO"
 input = ["bit_shift"]
 output = "zbs"
 ref = "shift:c:zbs"


### PR DESCRIPTION
This PR proposes to 
1. drop the `IsZero` template from the specification, and
2. remove the `IsEqual` template from the road map.

This is proposed for the following reasons:
1. Both are infrequently used. Currently, the `IsZero` template is used in `SHIFT` and the upcoming `DVRM`; `IsEqual` is only used in the `DVRM` chip.
2. Both are not much more than a conditional wrapper around the `ZERO` lookup, serving little additional purpose.
3. The requirements for using the `IsEqual` template are quite complex. Introducing it as a template will likely lead to specification and/or implementation errors in the future.
4. Both templates will likely be used with a varying numbers of inputs, something the specification "language" currently does not support us to template for.