### PR TITLE
feat(math): Implement IsPrimeField for GoldilocksField and rename representative → canonical

### DIFF
--- a/crypto/crypto/src/hash/poseidon/starknet/parameters.rs
+++ b/crypto/crypto/src/hash/poseidon/starknet/parameters.rs
@@ -478,13 +478,13 @@ impl PoseidonCairoStark252 {
             res = format!(
                 "{}, \n FE::from_hex_unchecked(\"{}\")",
                 res,
-                c_current[2].representative().to_hex()
+                c_current[2]\.canonical().to_hex()
             );
             if i == 86 {
                 c_next[0] += Self::UNOPTIMIZED_ROUND_CONSTANTS[3 * 87];
                 c_next[1] += Self::UNOPTIMIZED_ROUND_CONSTANTS[3 * 87 + 1];
                 c_next[2] += Self::UNOPTIMIZED_ROUND_CONSTANTS[3 * 87 + 2];
-                res = format!("{}, Last constant: \n FE::from_hex_unchecked(\"{}\"), \n FE::from_hex_unchecked(\"{}\"), \n FE::from_hex_unchecked(\"{}\")", res, c_next[0].representative().to_hex(), c_next[1].representative().to_hex(),c_next[2].representative().to_hex());
+                res = format!("{}, Last constant: \n FE::from_hex_unchecked(\"{}\"), \n FE::from_hex_unchecked(\"{}\"), \n FE::from_hex_unchecked(\"{}\")", res, c_next[0]\.canonical().to_hex(), c_next[1]\.canonical().to_hex(),c_next[2]\.canonical().to_hex());
             }
             i += 1;
         }

--- a/crypto/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
+++ b/crypto/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/compression.rs
@@ -55,7 +55,7 @@ impl Compress for BLS12381Curve {
             x_bytes[0] |= 1 << 7;
 
             let y_neg = core::ops::Neg::neg(y);
-            if y_neg.representative() < y.representative() {
+            if y_neg.canonical() < y.canonical() {
                 x_bytes[0] |= 1 << 5;
             }
             x_bytes
@@ -96,10 +96,7 @@ impl Compress for BLS12381Curve {
         // we call "negative" to the greate root,
         // if the third bit is 1, we take this grater value.
         // Otherwise, we take the second one.
-        let y = match (
-            y_sqrt_1.representative().cmp(&y_sqrt_2.representative()),
-            third_bit,
-        ) {
+        let y = match (y_sqrt_1.canonical().cmp(&y_sqrt_2.canonical()), third_bit) {
             (Ordering::Greater, 0) => y_sqrt_2,
             (Ordering::Greater, _) => y_sqrt_1,
             (Ordering::Less, 0) => y_sqrt_1,
@@ -143,12 +140,8 @@ impl Compress for BLS12381Curve {
             let y_neg = -y;
 
             match (
-                y.value()[0]
-                    .representative()
-                    .cmp(&y_neg.value()[0].representative()),
-                y.value()[1]
-                    .representative()
-                    .cmp(&y_neg.value()[1].representative()),
+                y.value()[0].canonical().cmp(&y_neg.value()[0].canonical()),
+                y.value()[1].canonical().cmp(&y_neg.value()[1].canonical()),
             ) {
                 (Ordering::Greater, _) | (Ordering::Equal, Ordering::Greater) => {
                     x_bytes[0] |= 1 << 5;

--- a/crypto/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/sqrt.rs
+++ b/crypto/math/src/elliptic_curve/short_weierstrass/curves/bls12_381/sqrt.rs
@@ -9,10 +9,7 @@ pub fn select_sqrt_value_from_third_bit(
     sqrt_2: BLS12381FieldElement,
     third_bit: u8,
 ) -> BLS12381FieldElement {
-    match (
-        sqrt_1.representative().cmp(&sqrt_2.representative()),
-        third_bit,
-    ) {
+    match (sqrt_1.canonical().cmp(&sqrt_2.canonical()), third_bit) {
         (Ordering::Greater, 0) => sqrt_2,
         (Ordering::Greater, _) | (Ordering::Less, 0) | (Ordering::Equal, _) => sqrt_1,
         (Ordering::Less, _) => sqrt_2,

--- a/crypto/math/src/elliptic_curve/short_weierstrass/curves/bn_254/compression.rs
+++ b/crypto/math/src/elliptic_curve/short_weierstrass/curves/bn_254/compression.rs
@@ -57,7 +57,7 @@ impl Compress for BN254Curve {
             x_bytes[0] |= 1 << 7; // x_bytes = 10000000
 
             let y_neg = core::ops::Neg::neg(y);
-            if y_neg.representative() < y.representative() {
+            if y_neg.canonical() < y.canonical() {
                 x_bytes[0] |= 1 << 6; // x_bytes = 11000000
             }
             x_bytes
@@ -97,10 +97,7 @@ impl Compress for BN254Curve {
 
         // If the frist two bits are 10, we take the smaller root.
         // If the first two bits are 11, we take the grater one.
-        let y = match (
-            y_sqrt_1.representative().cmp(&y_sqrt_2.representative()),
-            prefix_bits,
-        ) {
+        let y = match (y_sqrt_1.canonical().cmp(&y_sqrt_2.canonical()), prefix_bits) {
             (Ordering::Greater, 2_u8) => y_sqrt_2,
             (Ordering::Greater, _) => y_sqrt_1,
             (Ordering::Less, 2_u8) => y_sqrt_1,
@@ -141,12 +138,8 @@ impl Compress for BN254Curve {
             // a0 = b0 and a1 < b1.
             let y_neg = -y;
             match (
-                y.value()[0]
-                    .representative()
-                    .cmp(&y_neg.value()[0].representative()),
-                y.value()[1]
-                    .representative()
-                    .cmp(&y_neg.value()[1].representative()),
+                y.value()[0].canonical().cmp(&y_neg.value()[0].canonical()),
+                y.value()[1].canonical().cmp(&y_neg.value()[1].canonical()),
             ) {
                 (Ordering::Greater, _) | (Ordering::Equal, Ordering::Greater) => {
                     x_bytes[0] |= 1 << 6; // Prefix: 11

--- a/crypto/math/src/elliptic_curve/short_weierstrass/curves/bn_254/sqrt.rs
+++ b/crypto/math/src/elliptic_curve/short_weierstrass/curves/bn_254/sqrt.rs
@@ -12,10 +12,7 @@ pub fn select_sqrt_value_from_third_bit(
     sqrt_2: BN254FieldElement,
     third_bit: u8,
 ) -> BN254FieldElement {
-    match (
-        sqrt_1.representative().cmp(&sqrt_2.representative()),
-        third_bit,
-    ) {
+    match (sqrt_1.canonical().cmp(&sqrt_2.canonical()), third_bit) {
         (Ordering::Greater, 0) => sqrt_2,
         (Ordering::Greater, _) | (Ordering::Less, 0) | (Ordering::Equal, _) => sqrt_1,
         (Ordering::Less, _) => sqrt_2,

--- a/crypto/math/src/errors.rs
+++ b/crypto/math/src/errors.rs
@@ -13,7 +13,7 @@ pub enum CreationError {
     InvalidHexString,
     InvalidDecString,
     HexStringIsTooBig,
-    RepresentativeOutOfRange,
+    CanonicalOutOfRange,
     EmptyString,
 }
 

--- a/crypto/math/src/field/element.rs
+++ b/crypto/math/src/field/element.rs
@@ -598,9 +598,9 @@ where
 }
 
 impl<F: IsPrimeField> FieldElement<F> {
-    /// Returns the representative of the value stored
-    pub fn representative(&self) -> F::RepresentativeType {
-        F::representative(self.value())
+    /// Returns the canonical of the value stored
+    pub fn canonical(&self) -> F::CanonicalType {
+        F::canonical(self.value())
     }
 
     /// Returns the two square roots of a field element, provided it exists
@@ -620,7 +620,7 @@ impl<F: IsPrimeField> FieldElement<F> {
     /// Returns a `CreationError::EmptyString` if the input string is empty.
     /// Returns a `CreationError::HexStringIsTooBig` if the the input hex string is bigger than the
     /// maximum amount of characters for this element.
-    /// Returns a `CreationError::RepresentativeOutOfRange` if the representative of the value is
+    /// Returns a `CreationError::RepresentativeOutOfRange` if the canonical of the value is
     /// out of the range [0, p-1] where p is the modulus.
     pub fn from_hex(hex_string: &str) -> Result<Self, CreationError> {
         if hex_string.is_empty() {
@@ -665,7 +665,7 @@ impl<F: IsPrimeField> Serialize for FieldElement<F> {
     {
         use crate::alloc::string::ToString;
         let mut state = serializer.serialize_struct("FieldElement", 1)?;
-        state.serialize_field("value", &F::representative(self.value()).to_string())?;
+        state.serialize_field("value", &F::canonical(self.value()).to_string())?;
         state.end()
     }
 }
@@ -807,7 +807,7 @@ where
     M: IsModulus<UnsignedInteger<NUM_LIMBS>> + Clone + Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let value: UnsignedInteger<NUM_LIMBS> = self.representative();
+        let value: UnsignedInteger<NUM_LIMBS> = self.canonical();
         write!(f, "{value}")
     }
 }

--- a/crypto/math/src/field/element.rs
+++ b/crypto/math/src/field/element.rs
@@ -598,7 +598,7 @@ where
 }
 
 impl<F: IsPrimeField> FieldElement<F> {
-    /// Returns the canonical of the value stored
+    /// Returns the canonical form of the value stored
     pub fn canonical(&self) -> F::CanonicalType {
         F::canonical(self.value())
     }
@@ -620,7 +620,7 @@ impl<F: IsPrimeField> FieldElement<F> {
     /// Returns a `CreationError::EmptyString` if the input string is empty.
     /// Returns a `CreationError::HexStringIsTooBig` if the the input hex string is bigger than the
     /// maximum amount of characters for this element.
-    /// Returns a `CreationError::RepresentativeOutOfRange` if the canonical of the value is
+    /// Returns a `CreationError::CanonicalOutOfRange` if the canonical form of the value is
     /// out of the range [0, p-1] where p is the modulus.
     pub fn from_hex(hex_string: &str) -> Result<Self, CreationError> {
         if hex_string.is_empty() {

--- a/crypto/math/src/field/fields/fft_friendly/babybear.rs
+++ b/crypto/math/src/field/fields/fft_friendly/babybear.rs
@@ -37,12 +37,12 @@ impl IsFFTField for Babybear31PrimeField {
 
 impl FieldElement<Babybear31PrimeField> {
     pub fn to_bytes_le(&self) -> [u8; 8] {
-        let limbs = self.representative().limbs;
+        let limbs = self.canonical().limbs;
         limbs[0].to_le_bytes()
     }
 
     pub fn to_bytes_be(&self) -> [u8; 8] {
-        let limbs = self.representative().limbs;
+        let limbs = self.canonical().limbs;
         limbs[0].to_be_bytes()
     }
 }

--- a/crypto/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
+++ b/crypto/math/src/field/fields/fft_friendly/stark_252_prime_field.rs
@@ -33,7 +33,7 @@ impl FieldElement<Stark252PrimeField> {
     /// This follows the convention used by
     /// Starkware and Lambdaclass Cairo VM It's the same as ByteConversion to_bytes_le.
     pub fn to_bytes_le(&self) -> [u8; 32] {
-        let limbs = self.representative().limbs;
+        let limbs = self.canonical().limbs;
         let mut bytes: [u8; 32] = [0; 32];
 
         for i in (0..4).rev() {
@@ -48,7 +48,7 @@ impl FieldElement<Stark252PrimeField> {
 
     /// This follows the convention used by starknet-rs
     pub fn to_bits_le(&self) -> [bool; 256] {
-        let limbs = self.representative().limbs;
+        let limbs = self.canonical().limbs;
         let mut bits = [false; 256];
 
         for i in (0..4).rev() {
@@ -70,7 +70,7 @@ impl FieldElement<Stark252PrimeField> {
     /// This follows the convention used by
     /// Starkware and Lambdaclass Cairo VM It's the same as ByteConversion to_bytes_be.
     pub fn to_bytes_be(&self) -> [u8; 32] {
-        let limbs = self.representative().limbs;
+        let limbs = self.canonical().limbs;
         let mut bytes: [u8; 32] = [0; 32];
 
         for i in 0..4 {
@@ -86,12 +86,12 @@ impl FieldElement<Stark252PrimeField> {
 #[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for FieldElement<Stark252PrimeField> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.representative().partial_cmp(&other.representative())
+        self.canonical().partial_cmp(&other.canonical())
     }
 }
 
 impl Ord for FieldElement<Stark252PrimeField> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.representative().cmp(&other.representative())
+        self.canonical().cmp(&other.canonical())
     }
 }

--- a/crypto/math/src/field/fields/fft_friendly/u64_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/u64_goldilocks.rs
@@ -174,7 +174,6 @@ fn reduce128(x: u128) -> u64 {
     }
 }
 
-
 /// Inversion using optimized addition chain for a^(p-2).
 /// Based on Plonky2's approach.
 ///
@@ -334,8 +333,8 @@ impl AsBytes for FieldElement<GoldilocksField> {
 }
 
 // Implement IsPrimeField for the native Goldilocks
-use crate::field::traits::IsPrimeField;
 use crate::errors::CreationError;
+use crate::field::traits::IsPrimeField;
 
 impl IsPrimeField for GoldilocksField {
     type RepresentativeType = u64;
@@ -352,7 +351,7 @@ impl IsPrimeField for GoldilocksField {
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError> {
         let hex = hex_string.strip_prefix("0x").unwrap_or(hex_string);
         u64::from_str_radix(hex, 16)
-            .map(|v| Self::from_u64(v))
+            .map(Self::from_u64)
             .map_err(|_| CreationError::InvalidHexString)
     }
 
@@ -413,7 +412,10 @@ mod tests {
         let a = 3u64;
         let b = 10u64;
         let result = GoldilocksField::sub(&a, &b);
-        assert_eq!(GoldilocksField::representative(&result), GOLDILOCKS_PRIME - 7);
+        assert_eq!(
+            GoldilocksField::representative(&result),
+            GOLDILOCKS_PRIME - 7
+        );
     }
 
     #[test]
@@ -484,7 +486,12 @@ mod tests {
         for a in [5u64, 123456789, GOLDILOCKS_PRIME - 1, 0xDEADBEEF, 1, 2] {
             let a_inv = inv_addition_chain(a);
             let product = GoldilocksField::mul(&a, &a_inv);
-            assert_eq!(GoldilocksField::representative(&product), 1, "Failed for a = {}", a);
+            assert_eq!(
+                GoldilocksField::representative(&product),
+                1,
+                "Failed for a = {}",
+                a
+            );
         }
     }
 

--- a/crypto/math/src/field/fields/fft_friendly/u64_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/u64_goldilocks.rs
@@ -81,7 +81,7 @@ impl IsField for GoldilocksField {
     /// Negation: -a = p - a (or 0 if a = 0)
     #[inline(always)]
     fn neg(a: &u64) -> u64 {
-        let canonical = Self::representative(a);
+        let canonical = Self::canonical(a);
         if canonical == 0 {
             0
         } else {
@@ -91,7 +91,7 @@ impl IsField for GoldilocksField {
 
     /// Multiplicative inverse using Fermat's little theorem: a^(-1) = a^(p-2)
     fn inv(a: &u64) -> Result<u64, FieldError> {
-        let canonical = Self::representative(a);
+        let canonical = Self::canonical(a);
         if canonical == 0 {
             return Err(FieldError::InvZeroError);
         }
@@ -105,7 +105,7 @@ impl IsField for GoldilocksField {
 
     #[inline(always)]
     fn eq(a: &u64, b: &u64) -> bool {
-        Self::representative(a) == Self::representative(b)
+        Self::canonical(a) == Self::canonical(b)
     }
 
     #[inline(always)]
@@ -258,18 +258,18 @@ impl GoldilocksElement {
     }
 
     /// Get the canonical u64 representation in [0, p).
-    pub fn representative_u64(&self) -> u64 {
-        GoldilocksField::representative(self.value())
+    pub fn canonical_u64(&self) -> u64 {
+        GoldilocksField::canonical(self.value())
     }
 
     /// Convert to little-endian bytes.
     pub fn to_bytes_le(&self) -> [u8; 8] {
-        self.representative_u64().to_le_bytes()
+        self.canonical_u64().to_le_bytes()
     }
 
     /// Convert to big-endian bytes.
     pub fn to_bytes_be(&self) -> [u8; 8] {
-        self.representative_u64().to_be_bytes()
+        self.canonical_u64().to_be_bytes()
     }
 
     /// Create a field element from an i64.
@@ -286,12 +286,12 @@ impl GoldilocksElement {
 impl ByteConversion for FieldElement<GoldilocksField> {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
-        self.representative_u64().to_be_bytes().to_vec()
+        self.canonical_u64().to_be_bytes().to_vec()
     }
 
     #[cfg(feature = "alloc")]
     fn to_bytes_le(&self) -> alloc::vec::Vec<u8> {
-        self.representative_u64().to_le_bytes().to_vec()
+        self.canonical_u64().to_le_bytes().to_vec()
     }
 
     fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
@@ -337,10 +337,10 @@ use crate::errors::CreationError;
 use crate::field::traits::IsPrimeField;
 
 impl IsPrimeField for GoldilocksField {
-    type RepresentativeType = u64;
+    type CanonicalType = u64;
 
     #[inline(always)]
-    fn representative(a: &Self::BaseType) -> Self::RepresentativeType {
+    fn canonical(a: &Self::BaseType) -> Self::CanonicalType {
         if *a >= GOLDILOCKS_PRIME {
             *a - GOLDILOCKS_PRIME
         } else {
@@ -357,7 +357,7 @@ impl IsPrimeField for GoldilocksField {
 
     #[cfg(feature = "std")]
     fn to_hex(a: &Self::BaseType) -> String {
-        format!("{:x}", Self::representative(a))
+        format!("{:x}", Self::canonical(a))
     }
 
     fn field_bit_size() -> usize {
@@ -397,7 +397,7 @@ mod tests {
         let a = GOLDILOCKS_PRIME - 1;
         let b = 2u64;
         let result = GoldilocksField::add(&a, &b);
-        assert_eq!(GoldilocksField::representative(&result), 1);
+        assert_eq!(GoldilocksField::canonical(&result), 1);
     }
 
     #[test]
@@ -412,10 +412,7 @@ mod tests {
         let a = 3u64;
         let b = 10u64;
         let result = GoldilocksField::sub(&a, &b);
-        assert_eq!(
-            GoldilocksField::representative(&result),
-            GOLDILOCKS_PRIME - 7
-        );
+        assert_eq!(GoldilocksField::canonical(&result), GOLDILOCKS_PRIME - 7);
     }
 
     #[test]
@@ -434,7 +431,7 @@ mod tests {
         // (2^40)^2 = 2^80 mod p
         // 2^80 = 2^64 * 2^16 ≡ EPSILON * 2^16 (mod p)
         let expected = ((a as u128 * b as u128) % GOLDILOCKS_PRIME as u128) as u64;
-        assert_eq!(GoldilocksField::representative(&result), expected);
+        assert_eq!(GoldilocksField::canonical(&result), expected);
     }
 
     #[test]
@@ -442,7 +439,7 @@ mod tests {
         let a = 5u64;
         let a_inv = GoldilocksField::inv(&a).unwrap();
         let product = GoldilocksField::mul(&a, &a_inv);
-        assert_eq!(GoldilocksField::representative(&product), 1);
+        assert_eq!(GoldilocksField::canonical(&product), 1);
     }
 
     #[test]
@@ -450,7 +447,7 @@ mod tests {
         let a = 123456789u64;
         let a_inv = GoldilocksField::inv(&a).unwrap();
         let product = GoldilocksField::mul(&a, &a_inv);
-        assert_eq!(GoldilocksField::representative(&product), 1);
+        assert_eq!(GoldilocksField::canonical(&product), 1);
     }
 
     #[test]
@@ -463,7 +460,7 @@ mod tests {
         let a = 5u64;
         let neg_a = GoldilocksField::neg(&a);
         let sum = GoldilocksField::add(&a, &neg_a);
-        assert_eq!(GoldilocksField::representative(&sum), 0);
+        assert_eq!(GoldilocksField::canonical(&sum), 0);
     }
 
     #[test]
@@ -477,7 +474,7 @@ mod tests {
         for _ in 0..32 {
             result = GoldilocksField::square(&result);
         }
-        assert_eq!(GoldilocksField::representative(&result), 1);
+        assert_eq!(GoldilocksField::canonical(&result), 1);
     }
 
     #[test]
@@ -487,7 +484,7 @@ mod tests {
             let a_inv = inv_addition_chain(a);
             let product = GoldilocksField::mul(&a, &a_inv);
             assert_eq!(
-                GoldilocksField::representative(&product),
+                GoldilocksField::canonical(&product),
                 1,
                 "Failed for a = {}",
                 a
@@ -502,8 +499,8 @@ mod tests {
             let sq = GoldilocksField::square(&a);
             let mul = GoldilocksField::mul(&a, &a);
             assert_eq!(
-                GoldilocksField::representative(&sq),
-                GoldilocksField::representative(&mul),
+                GoldilocksField::canonical(&sq),
+                GoldilocksField::canonical(&mul),
                 "Square mismatch for a = {}",
                 a
             );

--- a/crypto/math/src/field/fields/fft_friendly/u64_goldilocks.rs
+++ b/crypto/math/src/field/fields/fft_friendly/u64_goldilocks.rs
@@ -81,7 +81,7 @@ impl IsField for GoldilocksField {
     /// Negation: -a = p - a (or 0 if a = 0)
     #[inline(always)]
     fn neg(a: &u64) -> u64 {
-        let canonical = canonicalize(*a);
+        let canonical = Self::representative(a);
         if canonical == 0 {
             0
         } else {
@@ -91,7 +91,7 @@ impl IsField for GoldilocksField {
 
     /// Multiplicative inverse using Fermat's little theorem: a^(-1) = a^(p-2)
     fn inv(a: &u64) -> Result<u64, FieldError> {
-        let canonical = canonicalize(*a);
+        let canonical = Self::representative(a);
         if canonical == 0 {
             return Err(FieldError::InvZeroError);
         }
@@ -105,7 +105,7 @@ impl IsField for GoldilocksField {
 
     #[inline(always)]
     fn eq(a: &u64, b: &u64) -> bool {
-        canonicalize(*a) == canonicalize(*b)
+        Self::representative(a) == Self::representative(b)
     }
 
     #[inline(always)]
@@ -174,18 +174,6 @@ fn reduce128(x: u128) -> u64 {
     }
 }
 
-/// Canonicalize a field element to [0, p).
-/// This is needed for comparisons and serialization.
-#[inline(always)]
-fn canonicalize(x: u64) -> u64 {
-    // Since values can be up to 2^64 - 1, we may need multiple subtractions
-    // But in practice, after proper reduction, at most one subtraction is needed
-    if x >= GOLDILOCKS_PRIME {
-        x - GOLDILOCKS_PRIME
-    } else {
-        x
-    }
-}
 
 /// Inversion using optimized addition chain for a^(p-2).
 /// Based on Plonky2's approach.
@@ -271,18 +259,18 @@ impl GoldilocksElement {
     }
 
     /// Get the canonical u64 representation in [0, p).
-    pub fn to_canonical_u64(&self) -> u64 {
-        canonicalize(*self.value())
+    pub fn representative_u64(&self) -> u64 {
+        GoldilocksField::representative(self.value())
     }
 
     /// Convert to little-endian bytes.
     pub fn to_bytes_le(&self) -> [u8; 8] {
-        self.to_canonical_u64().to_le_bytes()
+        self.representative_u64().to_le_bytes()
     }
 
     /// Convert to big-endian bytes.
     pub fn to_bytes_be(&self) -> [u8; 8] {
-        self.to_canonical_u64().to_be_bytes()
+        self.representative_u64().to_be_bytes()
     }
 
     /// Create a field element from an i64.
@@ -299,12 +287,12 @@ impl GoldilocksElement {
 impl ByteConversion for FieldElement<GoldilocksField> {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
-        self.to_canonical_u64().to_be_bytes().to_vec()
+        self.representative_u64().to_be_bytes().to_vec()
     }
 
     #[cfg(feature = "alloc")]
     fn to_bytes_le(&self) -> alloc::vec::Vec<u8> {
-        self.to_canonical_u64().to_le_bytes().to_vec()
+        self.representative_u64().to_le_bytes().to_vec()
     }
 
     fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
@@ -345,6 +333,39 @@ impl AsBytes for FieldElement<GoldilocksField> {
     }
 }
 
+// Implement IsPrimeField for the native Goldilocks
+use crate::field::traits::IsPrimeField;
+use crate::errors::CreationError;
+
+impl IsPrimeField for GoldilocksField {
+    type RepresentativeType = u64;
+
+    #[inline(always)]
+    fn representative(a: &Self::BaseType) -> Self::RepresentativeType {
+        if *a >= GOLDILOCKS_PRIME {
+            *a - GOLDILOCKS_PRIME
+        } else {
+            *a
+        }
+    }
+
+    fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError> {
+        let hex = hex_string.strip_prefix("0x").unwrap_or(hex_string);
+        u64::from_str_radix(hex, 16)
+            .map(|v| Self::from_u64(v))
+            .map_err(|_| CreationError::InvalidHexString)
+    }
+
+    #[cfg(feature = "std")]
+    fn to_hex(a: &Self::BaseType) -> String {
+        format!("{:x}", Self::representative(a))
+    }
+
+    fn field_bit_size() -> usize {
+        64 // Goldilocks uses 64-bit representation
+    }
+}
+
 // Implement IsFFTField for the native Goldilocks
 use crate::field::traits::IsFFTField;
 
@@ -377,7 +398,7 @@ mod tests {
         let a = GOLDILOCKS_PRIME - 1;
         let b = 2u64;
         let result = GoldilocksField::add(&a, &b);
-        assert_eq!(canonicalize(result), 1);
+        assert_eq!(GoldilocksField::representative(&result), 1);
     }
 
     #[test]
@@ -392,7 +413,7 @@ mod tests {
         let a = 3u64;
         let b = 10u64;
         let result = GoldilocksField::sub(&a, &b);
-        assert_eq!(canonicalize(result), GOLDILOCKS_PRIME - 7);
+        assert_eq!(GoldilocksField::representative(&result), GOLDILOCKS_PRIME - 7);
     }
 
     #[test]
@@ -411,7 +432,7 @@ mod tests {
         // (2^40)^2 = 2^80 mod p
         // 2^80 = 2^64 * 2^16 ≡ EPSILON * 2^16 (mod p)
         let expected = ((a as u128 * b as u128) % GOLDILOCKS_PRIME as u128) as u64;
-        assert_eq!(canonicalize(result), expected);
+        assert_eq!(GoldilocksField::representative(&result), expected);
     }
 
     #[test]
@@ -419,7 +440,7 @@ mod tests {
         let a = 5u64;
         let a_inv = GoldilocksField::inv(&a).unwrap();
         let product = GoldilocksField::mul(&a, &a_inv);
-        assert_eq!(canonicalize(product), 1);
+        assert_eq!(GoldilocksField::representative(&product), 1);
     }
 
     #[test]
@@ -427,7 +448,7 @@ mod tests {
         let a = 123456789u64;
         let a_inv = GoldilocksField::inv(&a).unwrap();
         let product = GoldilocksField::mul(&a, &a_inv);
-        assert_eq!(canonicalize(product), 1);
+        assert_eq!(GoldilocksField::representative(&product), 1);
     }
 
     #[test]
@@ -440,7 +461,7 @@ mod tests {
         let a = 5u64;
         let neg_a = GoldilocksField::neg(&a);
         let sum = GoldilocksField::add(&a, &neg_a);
-        assert_eq!(canonicalize(sum), 0);
+        assert_eq!(GoldilocksField::representative(&sum), 0);
     }
 
     #[test]
@@ -454,7 +475,7 @@ mod tests {
         for _ in 0..32 {
             result = GoldilocksField::square(&result);
         }
-        assert_eq!(canonicalize(result), 1);
+        assert_eq!(GoldilocksField::representative(&result), 1);
     }
 
     #[test]
@@ -463,7 +484,7 @@ mod tests {
         for a in [5u64, 123456789, GOLDILOCKS_PRIME - 1, 0xDEADBEEF, 1, 2] {
             let a_inv = inv_addition_chain(a);
             let product = GoldilocksField::mul(&a, &a_inv);
-            assert_eq!(canonicalize(product), 1, "Failed for a = {}", a);
+            assert_eq!(GoldilocksField::representative(&product), 1, "Failed for a = {}", a);
         }
     }
 
@@ -474,8 +495,8 @@ mod tests {
             let sq = GoldilocksField::square(&a);
             let mul = GoldilocksField::mul(&a, &a);
             assert_eq!(
-                canonicalize(sq),
-                canonicalize(mul),
+                GoldilocksField::representative(&sq),
+                GoldilocksField::representative(&mul),
                 "Square mismatch for a = {}",
                 a
             );

--- a/crypto/math/src/field/fields/fft_friendly/u64_mersenne_montgomery_field.rs
+++ b/crypto/math/src/field/fields/fft_friendly/u64_mersenne_montgomery_field.rs
@@ -20,12 +20,12 @@ pub type Mersenne31MontgomeryPrimeField =
 
 impl FieldElement<Mersenne31MontgomeryPrimeField> {
     pub fn to_bytes_le(&self) -> [u8; 8] {
-        let limbs = self.representative().limbs;
+        let limbs = self.canonical().limbs;
         limbs[0].to_le_bytes()
     }
 
     pub fn to_bytes_be(&self) -> [u8; 8] {
-        let limbs = self.representative().limbs;
+        let limbs = self.canonical().limbs;
         limbs[0].to_be_bytes()
     }
 }
@@ -33,12 +33,12 @@ impl FieldElement<Mersenne31MontgomeryPrimeField> {
 #[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for FieldElement<Mersenne31MontgomeryPrimeField> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        self.representative().partial_cmp(&other.representative())
+        self.canonical().partial_cmp(&other.canonical())
     }
 }
 
 impl Ord for FieldElement<Mersenne31MontgomeryPrimeField> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.representative().cmp(&other.representative())
+        self.canonical().cmp(&other.canonical())
     }
 }

--- a/crypto/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/crypto/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -297,7 +297,7 @@ where
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError> {
         let integer = Self::BaseType::from_hex(hex_string)?;
         if integer > M::MODULUS {
-            return Err(CreationError::RepresentativeOutOfRange);
+            return Err(CreationError::CanonicalOutOfRange);
         }
 
         Ok(MontgomeryAlgorithms::cios(

--- a/crypto/math/src/field/fields/montgomery_backed_prime_fields.rs
+++ b/crypto/math/src/field/fields/montgomery_backed_prime_fields.rs
@@ -276,9 +276,9 @@ impl<M, const NUM_LIMBS: usize> IsPrimeField for MontgomeryBackendPrimeField<M, 
 where
     M: IsModulus<UnsignedInteger<NUM_LIMBS>> + Clone + Debug,
 {
-    type RepresentativeType = Self::BaseType;
+    type CanonicalType = Self::BaseType;
 
-    fn representative(x: &Self::BaseType) -> Self::RepresentativeType {
+    fn canonical(x: &Self::BaseType) -> Self::CanonicalType {
         MontgomeryAlgorithms::cios(x, &UnsignedInteger::from_u64(1), &M::MODULUS, &Self::MU)
     }
 

--- a/crypto/math/src/field/fields/u32_montgomery_backend_prime_field.rs
+++ b/crypto/math/src/field/fields/u32_montgomery_backend_prime_field.rs
@@ -191,9 +191,9 @@ impl<const MODULUS: u32> IsField for U32MontgomeryBackendPrimeField<MODULUS> {
 }
 
 impl<const MODULUS: u32> IsPrimeField for U32MontgomeryBackendPrimeField<MODULUS> {
-    type RepresentativeType = Self::BaseType;
+    type CanonicalType = Self::BaseType;
 
-    fn representative(x: &Self::BaseType) -> Self::RepresentativeType {
+    fn canonical(x: &Self::BaseType) -> Self::CanonicalType {
         MontgomeryAlgorithms::mul(x, &1u32, &MODULUS, &Self::MU)
     }
 

--- a/crypto/math/src/field/fields/u64_prime_field.rs
+++ b/crypto/math/src/field/fields/u64_prime_field.rs
@@ -75,9 +75,9 @@ impl<const MODULUS: u64> IsField for U64PrimeField<MODULUS> {
 impl<const MODULUS: u64> Copy for U64FieldElement<MODULUS> {}
 
 impl<const MODULUS: u64> IsPrimeField for U64PrimeField<MODULUS> {
-    type RepresentativeType = u64;
+    type CanonicalType = u64;
 
-    fn representative(x: &u64) -> u64 {
+    fn canonical(x: &u64) -> u64 {
         *x
     }
 

--- a/crypto/math/src/field/test_fields/u32_test_field.rs
+++ b/crypto/math/src/field/test_fields/u32_test_field.rs
@@ -89,9 +89,9 @@ impl<const MODULUS: u32> IsField for U32Field<MODULUS> {
 }
 
 impl<const MODULUS: u32> IsPrimeField for U32Field<MODULUS> {
-    type RepresentativeType = u32;
+    type CanonicalType = u32;
 
-    fn representative(a: &Self::BaseType) -> u32 {
+    fn canonical(a: &Self::BaseType) -> u32 {
         *a
     }
 

--- a/crypto/math/src/field/test_fields/u64_test_field.rs
+++ b/crypto/math/src/field/test_fields/u64_test_field.rs
@@ -64,9 +64,9 @@ impl<const MODULUS: u64> IsField for U64Field<MODULUS> {
 }
 
 impl<const MODULUS: u64> IsPrimeField for U64Field<MODULUS> {
-    type RepresentativeType = u64;
+    type CanonicalType = u64;
 
-    fn representative(x: &u64) -> u64 {
+    fn canonical(x: &u64) -> u64 {
         *x
     }
 

--- a/crypto/math/src/field/traits.rs
+++ b/crypto/math/src/field/traits.rs
@@ -203,15 +203,15 @@ pub enum LegendreSymbol {
 }
 
 pub trait IsPrimeField: IsField {
-    type RepresentativeType: IsUnsignedInteger;
+    type CanonicalType: IsUnsignedInteger;
 
-    /// Returns the integer representative in
+    /// Returns the integer canonical in
     /// the range [0, p-1], where p the modulus
-    fn representative(a: &Self::BaseType) -> Self::RepresentativeType;
+    fn canonical(a: &Self::BaseType) -> Self::CanonicalType;
 
     /// Returns p - 1, which is -1 mod p
-    fn modulus_minus_one() -> Self::RepresentativeType {
-        Self::representative(&Self::neg(&Self::one()))
+    fn modulus_minus_one() -> Self::CanonicalType {
+        Self::canonical(&Self::neg(&Self::one()))
     }
 
     /// Creates a BaseType from a Hex String
@@ -248,7 +248,7 @@ pub trait IsPrimeField: IsField {
             LegendreSymbol::One => (),
         };
 
-        let integer_one = Self::RepresentativeType::from(1_u16);
+        let integer_one = Self::CanonicalType::from(1_u16);
         let mut s: usize = 0;
         let mut q = Self::modulus_minus_one();
 

--- a/crypto/math/src/tests/montgomery_backed_prime_fields_tests.rs
+++ b/crypto/math/src/tests/montgomery_backed_prime_fields_tests.rs
@@ -872,7 +872,7 @@ mod tests_u256_prime_fields {
         assert!(a.is_err());
         assert_eq!(
             a.unwrap_err(),
-            crate::errors::CreationError::RepresentativeOutOfRange
+            crate::errors::CreationError::CanonicalOutOfRange
         )
     }
 

--- a/crypto/math/src/tests/montgomery_backed_prime_fields_tests.rs
+++ b/crypto/math/src/tests/montgomery_backed_prime_fields_tests.rs
@@ -90,11 +90,11 @@ mod tests_u384_prime_fields {
     }
 
     #[test]
-    fn montgomery_backend_primefield_representative() {
+    fn montgomery_backend_primefield_canonical() {
         let a: U384 = UnsignedInteger {
             limbs: [0, 0, 0, 0, 0, 11],
         };
-        assert_eq!(U384F23::representative(&U384F23::from_u64(770_u64)), a);
+        assert_eq!(U384F23::canonical(&U384F23::from_u64(770_u64)), a);
     }
 
     #[test]
@@ -500,12 +500,12 @@ mod tests_u256_prime_fields {
     }
 
     #[test]
-    fn montgomery_backend_primefield_representative() {
+    fn montgomery_backend_primefield_canonical() {
         // 770%29
         let a: U256 = UnsignedInteger {
             limbs: [0, 0, 0, 16],
         };
-        assert_eq!(U256F29::representative(&U256F29::from_u64(770_u64)), a);
+        assert_eq!(U256F29::canonical(&U256F29::from_u64(770_u64)), a);
     }
 
     #[test]
@@ -831,18 +831,18 @@ mod tests_u256_prime_fields {
 
     #[test]
     #[cfg(feature = "alloc")]
-    fn creating_a_field_element_from_its_representative_returns_the_same_element_1() {
+    fn creating_a_field_element_from_its_canonical_returns_the_same_element_1() {
         let change = U256::from_u64(1);
         let f1 = U256FP1Element::new(U256ModulusP1::MODULUS + change);
-        let f2 = U256FP1Element::new(f1.representative());
+        let f2 = U256FP1Element::new(f1.canonical());
         assert_eq!(f1, f2);
     }
 
     #[test]
-    fn creating_a_field_element_from_its_representative_returns_the_same_element_2() {
+    fn creating_a_field_element_from_its_canonical_returns_the_same_element_2() {
         let change = U256::from_u64(27);
         let f1 = U256F29Element::new(U256Modulus29::MODULUS + change);
-        let f2 = U256F29Element::new(f1.representative());
+        let f2 = U256F29Element::new(f1.canonical());
         assert_eq!(f1, f2);
     }
 

--- a/crypto/math/src/tests/polynomial_tests.rs
+++ b/crypto/math/src/tests/polynomial_tests.rs
@@ -122,7 +122,7 @@ mod tests {
                 continue;
             }
 
-            let coeff_str = coeff.representative().to_string();
+            let coeff_str = coeff.canonical().to_string();
 
             if i == poly.coefficients().len() - 1 {
                 string.push_str(&coeff_str);

--- a/crypto/math/src/tests/u64_prime_field_tests.rs
+++ b/crypto/math/src/tests/u64_prime_field_tests.rs
@@ -218,18 +218,18 @@ mod tests {
     }
 
     #[test]
-    fn creating_a_field_element_from_its_representative_returns_the_same_element_1() {
+    fn creating_a_field_element_from_its_canonical_returns_the_same_element_1() {
         let change = 1;
         let f1 = FE::new(MODULUS + change);
-        let f2 = FE::new(f1.representative());
+        let f2 = FE::new(f1.canonical());
         assert_eq!(f1, f2);
     }
 
     #[test]
-    fn creating_a_field_element_from_its_representative_returns_the_same_element_2() {
+    fn creating_a_field_element_from_its_canonical_returns_the_same_element_2() {
         let change = 8;
         let f1 = FE::new(MODULUS + change);
-        let f2 = FE::new(f1.representative());
+        let f2 = FE::new(f1.canonical());
         assert_eq!(f1, f2);
     }
 }

--- a/crypto/stark/src/examples/read_only_memory.rs
+++ b/crypto/stark/src/examples/read_only_memory.rs
@@ -379,7 +379,7 @@ pub fn sort_rap_trace<F: IsFFTField + IsPrimeField>(
 ) -> TraceTable<F, F> {
     let mut address_value_pairs: Vec<_> = address.iter().zip(value.iter()).collect();
 
-    address_value_pairs.sort_by_key(|(addr, _)| addr.representative());
+    address_value_pairs.sort_by_key(|(addr, _)| addr.canonical());
 
     let (sorted_address, sorted_value): (Vec<FieldElement<F>>, Vec<FieldElement<F>>) =
         address_value_pairs

--- a/crypto/stark/src/examples/read_only_memory_logup.rs
+++ b/crypto/stark/src/examples/read_only_memory_logup.rs
@@ -527,7 +527,7 @@ pub fn read_only_logup_trace<
     values: Vec<FieldElement<F>>,
 ) -> TraceTable<F, E> {
     let mut address_value_pairs: Vec<_> = addresses.iter().zip(values.iter()).collect();
-    address_value_pairs.sort_by_key(|(addr, _)| addr.representative());
+    address_value_pairs.sort_by_key(|(addr, _)| addr.canonical());
 
     let mut multiplicities = Vec::new();
     let mut sorted_addresses = Vec::new();

--- a/prover/src/tests/bitwise_tests.rs
+++ b/prover/src/tests/bitwise_tests.rs
@@ -253,57 +253,57 @@ fn test_generate_bitwise_row_matches_trace() {
 
         assert_eq!(
             const_row[0],
-            trace_row[cols::X].to_canonical_u64(),
+            trace_row[cols::X].representative_u64(),
             "X mismatch at index {idx}"
         );
         assert_eq!(
             const_row[1],
-            trace_row[cols::Y].to_canonical_u64(),
+            trace_row[cols::Y].representative_u64(),
             "Y mismatch at index {idx}"
         );
         assert_eq!(
             const_row[2],
-            trace_row[cols::Z].to_canonical_u64(),
+            trace_row[cols::Z].representative_u64(),
             "Z mismatch at index {idx}"
         );
         assert_eq!(
             const_row[3],
-            trace_row[cols::AND].to_canonical_u64(),
+            trace_row[cols::AND].representative_u64(),
             "AND mismatch at index {idx}"
         );
         assert_eq!(
             const_row[4],
-            trace_row[cols::OR].to_canonical_u64(),
+            trace_row[cols::OR].representative_u64(),
             "OR mismatch at index {idx}"
         );
         assert_eq!(
             const_row[5],
-            trace_row[cols::XOR].to_canonical_u64(),
+            trace_row[cols::XOR].representative_u64(),
             "XOR mismatch at index {idx}"
         );
         assert_eq!(
             const_row[6],
-            trace_row[cols::MSB8].to_canonical_u64(),
+            trace_row[cols::MSB8].representative_u64(),
             "MSB8 mismatch at index {idx}"
         );
         assert_eq!(
             const_row[7],
-            trace_row[cols::MSB16].to_canonical_u64(),
+            trace_row[cols::MSB16].representative_u64(),
             "MSB16 mismatch at index {idx}"
         );
         assert_eq!(
             const_row[8],
-            trace_row[cols::ZERO].to_canonical_u64(),
+            trace_row[cols::ZERO].representative_u64(),
             "ZERO mismatch at index {idx}"
         );
         assert_eq!(
             const_row[9],
-            trace_row[cols::SLL].to_canonical_u64(),
+            trace_row[cols::SLL].representative_u64(),
             "SLL mismatch at index {idx}"
         );
         assert_eq!(
             const_row[10],
-            trace_row[cols::SLLC].to_canonical_u64(),
+            trace_row[cols::SLLC].representative_u64(),
             "SLLC mismatch at index {idx}"
         );
     }
@@ -321,7 +321,7 @@ fn test_generate_bitwise_row_exhaustive_sample() {
 
         for col in 0..NUM_PRECOMPUTED_COLS {
             let const_val = const_row[col];
-            let trace_val = trace_row[col].to_canonical_u64();
+            let trace_val = trace_row[col].representative_u64();
             assert_eq!(
                 const_val, trace_val,
                 "Mismatch at index {idx}, column {col}: const={const_val}, trace={trace_val}"

--- a/prover/src/tests/bitwise_tests.rs
+++ b/prover/src/tests/bitwise_tests.rs
@@ -253,57 +253,57 @@ fn test_generate_bitwise_row_matches_trace() {
 
         assert_eq!(
             const_row[0],
-            trace_row[cols::X].representative_u64(),
+            trace_row[cols::X].canonical_u64(),
             "X mismatch at index {idx}"
         );
         assert_eq!(
             const_row[1],
-            trace_row[cols::Y].representative_u64(),
+            trace_row[cols::Y].canonical_u64(),
             "Y mismatch at index {idx}"
         );
         assert_eq!(
             const_row[2],
-            trace_row[cols::Z].representative_u64(),
+            trace_row[cols::Z].canonical_u64(),
             "Z mismatch at index {idx}"
         );
         assert_eq!(
             const_row[3],
-            trace_row[cols::AND].representative_u64(),
+            trace_row[cols::AND].canonical_u64(),
             "AND mismatch at index {idx}"
         );
         assert_eq!(
             const_row[4],
-            trace_row[cols::OR].representative_u64(),
+            trace_row[cols::OR].canonical_u64(),
             "OR mismatch at index {idx}"
         );
         assert_eq!(
             const_row[5],
-            trace_row[cols::XOR].representative_u64(),
+            trace_row[cols::XOR].canonical_u64(),
             "XOR mismatch at index {idx}"
         );
         assert_eq!(
             const_row[6],
-            trace_row[cols::MSB8].representative_u64(),
+            trace_row[cols::MSB8].canonical_u64(),
             "MSB8 mismatch at index {idx}"
         );
         assert_eq!(
             const_row[7],
-            trace_row[cols::MSB16].representative_u64(),
+            trace_row[cols::MSB16].canonical_u64(),
             "MSB16 mismatch at index {idx}"
         );
         assert_eq!(
             const_row[8],
-            trace_row[cols::ZERO].representative_u64(),
+            trace_row[cols::ZERO].canonical_u64(),
             "ZERO mismatch at index {idx}"
         );
         assert_eq!(
             const_row[9],
-            trace_row[cols::SLL].representative_u64(),
+            trace_row[cols::SLL].canonical_u64(),
             "SLL mismatch at index {idx}"
         );
         assert_eq!(
             const_row[10],
-            trace_row[cols::SLLC].representative_u64(),
+            trace_row[cols::SLLC].canonical_u64(),
             "SLLC mismatch at index {idx}"
         );
     }
@@ -321,7 +321,7 @@ fn test_generate_bitwise_row_exhaustive_sample() {
 
         for col in 0..NUM_PRECOMPUTED_COLS {
             let const_val = const_row[col];
-            let trace_val = trace_row[col].representative_u64();
+            let trace_val = trace_row[col].canonical_u64();
             assert_eq!(
                 const_val, trace_val,
                 "Mismatch at index {idx}, column {col}: const={const_val}, trace={trace_val}"


### PR DESCRIPTION
Summary:

  - Implements IsPrimeField trait for GoldilocksField, enabling serde serialization support and consistent API across prime field types
  - Renames representative → canonical throughout the codebase for clearer semantics
  - Removes the standalone canonicalize function in favor of the trait method

  Changes

  - New: IsPrimeField implementation for GoldilocksField with:
    - canonical() - returns value in [0, p)
    - from_hex() / to_hex() - hex string conversion
    - field_bit_size() - returns 64
  - Renamed across all field implementations:
    - RepresentativeType → CanonicalType
    - representative() → canonical()
    - to_canonical_u64() → canonical_u64()