### PR TITLE
spec: Fix `LOAD` signature

### DIFF
--- a/spec/src/load.toml
+++ b/spec/src/load.toml
@@ -155,6 +155,6 @@ name = "output"
 [[constraints.output]]
 kind = "interaction"
 tag = "LOAD"
-input = ["base_address", "timestamp", "read2", "read4", "read8"]
+input = ["base_address", "timestamp", "read2", "read4", "read8", "signed"]
 output = ["cast", "res", "DWordWL"]
 multiplicity = ["-", "μ"]


### PR DESCRIPTION
This PR fixes a minor mistake in the signature of the LOAD chip: it was missing the `signed` flag.