### PR TITLE
Add trace segmentation support for large executions

### DIFF
--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -49,8 +49,6 @@ pub enum Error {
     MissingInstruction(u64),
     /// Program does not contain an ECALL (halt) instruction
     MissingHaltEcall,
-    /// ECALL found in intermediate segment (should only be in final segment)
-    UnexpectedEcallInSegment,
     /// Executor failed (setup or runtime error)
     Execution(String),
     /// STARK proving failed
@@ -64,12 +62,6 @@ impl fmt::Display for Error {
             Error::MissingInstruction(pc) => write!(f, "instruction not found for PC {pc:#x}"),
             Error::MissingHaltEcall => {
                 write!(f, "program does not contain an ECALL (halt) instruction")
-            }
-            Error::UnexpectedEcallInSegment => {
-                write!(
-                    f,
-                    "ECALL found in intermediate segment (must be in final segment only)"
-                )
             }
             Error::Execution(msg) => write!(f, "execution error: {msg}"),
             Error::Prover(msg) => write!(f, "proving error: {msg}"),

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -49,6 +49,8 @@ pub enum Error {
     MissingInstruction(u64),
     /// Program does not contain an ECALL (halt) instruction
     MissingHaltEcall,
+    /// ECALL found in intermediate segment (should only be in final segment)
+    UnexpectedEcallInSegment,
     /// Executor failed (setup or runtime error)
     Execution(String),
     /// STARK proving failed
@@ -62,6 +64,12 @@ impl fmt::Display for Error {
             Error::MissingInstruction(pc) => write!(f, "instruction not found for PC {pc:#x}"),
             Error::MissingHaltEcall => {
                 write!(f, "program does not contain an ECALL (halt) instruction")
+            }
+            Error::UnexpectedEcallInSegment => {
+                write!(
+                    f,
+                    "ECALL found in intermediate segment (must be in final segment only)"
+                )
             }
             Error::Execution(msg) => write!(f, "execution error: {msg}"),
             Error::Prover(msg) => write!(f, "proving error: {msg}"),

--- a/prover/src/tables/halt.rs
+++ b/prover/src/tables/halt.rs
@@ -64,6 +64,20 @@ pub fn generate_halt_trace(timestamp: u64) -> TraceTable<GoldilocksField, Goldil
     TraceTable::new_main(data, cols::NUM_COLUMNS, 1)
 }
 
+/// Generates a dummy HALT trace for non-final segments.
+///
+/// Non-final segments don't contain an ECALL instruction, so the CPU doesn't
+/// send anything to the ECALL bus. This dummy trace has zero multiplicity
+/// (the BusInteraction::receiver with Multiplicity::One will contribute 0
+/// to the LogUp accumulator when the timestamp values don't match any sender).
+///
+/// The timestamp is set to 0 which won't match any real CPU timestamp
+/// (real timestamps start at 4).
+pub fn generate_dummy_halt_trace() -> TraceTable<GoldilocksField, GoldilocksExtension> {
+    let data = vec![FE::zero(), FE::zero()];
+    TraceTable::new_main(data, cols::NUM_COLUMNS, 1)
+}
+
 // =========================================================================
 // Bus interactions
 // =========================================================================

--- a/prover/src/tables/mod.rs
+++ b/prover/src/tables/mod.rs
@@ -25,6 +25,8 @@ pub mod load;
 pub mod lt;
 pub mod memw;
 pub mod mul;
+pub mod segment;
 pub mod trace_builder;
 
+pub use segment::{SegmentBoundary, SegmentConfig, SegmentResult};
 pub use types::BusId;

--- a/prover/src/tables/mod.rs
+++ b/prover/src/tables/mod.rs
@@ -28,5 +28,5 @@ pub mod mul;
 pub mod segment;
 pub mod trace_builder;
 
-pub use segment::{SegmentBoundary, SegmentConfig, SegmentResult};
+pub use segment::{OpBoundaries, SegmentResult};
 pub use types::BusId;

--- a/prover/src/tables/segment.rs
+++ b/prover/src/tables/segment.rs
@@ -1,8 +1,7 @@
 //! Trace segmentation support for large executions.
 //!
 //! When trace length exceeds the FFT domain limit, execution must be divided
-//! into segments. This module provides the data structures for segment boundaries
-//! and configuration.
+//! into segments. This module provides the data structures for segmentation.
 //!
 //! ## FFT Constraint
 //!
@@ -50,91 +49,28 @@ pub fn get_max_trace_size() -> usize {
         .unwrap_or(MAX_TRACE_SIZE)
 }
 
-/// State captured at segment boundaries for continuity.
+/// Cumulative derived op counts after processing each CPU operation.
 ///
-/// This struct captures all state needed to resume trace generation
-/// from a previous segment, ensuring continuity of timestamps, memory,
-/// and register values across segment boundaries.
-#[derive(Debug, Clone, Default)]
-pub struct SegmentBoundary {
-    /// Segment index (0-based)
-    pub segment_index: u32,
-
-    /// Starting timestamp for this segment.
-    /// Each instruction consumes 4 timestamps, so this should be
-    /// the end timestamp of the previous segment.
-    pub start_timestamp: u64,
-
-    /// Memory state: (address, value, timestamp) tuples.
-    /// Contains all memory cells that were written during previous segments.
-    pub memory_state: Vec<(u64, u8, u64)>,
-
-    /// Register state: [(value, timestamp); 31] for registers x1-x31.
-    /// x0 is excluded as it's always zero.
-    pub register_state: [(u64, u64); 31],
-
-    /// PC at segment start (for validation/debugging).
-    pub start_pc: u64,
-}
-
-impl SegmentBoundary {
-    /// Create the initial boundary for the first segment.
-    pub fn initial() -> Self {
-        Self {
-            segment_index: 0,
-            start_timestamp: 4, // Timestamps start at 4 (not 0)
-            memory_state: Vec::new(),
-            register_state: [(0, 0); 31],
-            start_pc: 0,
-        }
-    }
-
-    /// Create a boundary for the next segment.
-    pub fn next(
-        &self,
-        end_timestamp: u64,
-        memory_state: Vec<(u64, u8, u64)>,
-        register_state: [(u64, u64); 31],
-        next_pc: u64,
-    ) -> Self {
-        Self {
-            segment_index: self.segment_index + 1,
-            start_timestamp: end_timestamp,
-            memory_state,
-            register_state,
-            start_pc: next_pc,
-        }
-    }
-}
-
-/// Configuration for segment-based trace generation.
-#[derive(Debug, Clone)]
-pub struct SegmentConfig {
-    /// Whether this is the final segment (has ECALL).
-    /// Non-final segments use a dummy HALT trace with zero multiplicity.
-    pub is_final: bool,
-}
-
-impl SegmentConfig {
-    /// Create config for a non-final segment.
-    pub fn intermediate() -> Self {
-        Self { is_final: false }
-    }
-
-    /// Create config for the final segment.
-    pub fn final_segment() -> Self {
-        Self { is_final: true }
-    }
+/// During phase 2, we track how many derived ops have been generated after
+/// each CPU operation. This allows slicing derived ops per segment without
+/// re-processing: `segment_ops = all_ops[boundaries[start]..boundaries[end]]`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OpBoundaries {
+    pub memw: usize,
+    pub load: usize,
+    pub lt: usize,
+    pub mul: usize,
+    pub branch: usize,
+    /// Bitwise ops from phase 2 (CPU ops + load ops). Phase 4 adds more per-segment.
+    pub bitwise: usize,
 }
 
 /// Result of generating traces for a single segment.
 pub struct SegmentResult {
     /// Generated traces for this segment.
     pub traces: Traces,
-
-    /// Boundary state for the next segment (None if this is the final segment).
-    pub next_boundary: Option<SegmentBoundary>,
-
     /// Whether this was the final segment.
     pub is_final: bool,
+    /// Segment index (0-based).
+    pub segment_index: usize,
 }

--- a/prover/src/tables/segment.rs
+++ b/prover/src/tables/segment.rs
@@ -1,0 +1,140 @@
+//! Trace segmentation support for large executions.
+//!
+//! When trace length exceeds the FFT domain limit, execution must be divided
+//! into segments. This module provides the data structures for segment boundaries
+//! and configuration.
+//!
+//! ## FFT Constraint
+//!
+//! The Goldilocks field has TWO_ADICITY = 32, meaning the maximum FFT domain
+//! size is 2^32 elements. With a blowup factor of 4, the LDE domain is 4× the
+//! trace length, so:
+//!
+//! - **Max trace length = 2^30 rows** (LDE = 2^32 = field limit)
+//! - Exceeding this triggers `FFTError::DomainSizeError`
+//!
+//! For safety margin, we use MAX_TRACE_SIZE = 2^23 (~8M rows) by default.
+//!
+//! ## Note on Table Growth Rates
+//!
+//! **This implementation segments based on CPU table size** (1 row per instruction)
+//! as a starting point. Different tables have different growth rates:
+//!
+//! | Table | Rows per instruction | Notes |
+//! |-------|---------------------|-------|
+//! | CPU | 1 | One row per instruction |
+//! | MEMW | 1-4+ | Up to 3 register ops + memory op per instruction |
+//! | LT | Variable | Grows with comparisons + timestamp ordering checks |
+//! | LOAD | 0-1 | Only for load instructions |
+//! | MUL | 0-1 | Only for multiply instructions |
+//! | BRANCH | 0-1 | Only for taken branches |
+//!
+//! Future improvement: Check which table reaches MAX_TRACE_SIZE first.
+
+use super::trace_builder::Traces;
+
+/// Maximum trace size before segmentation is required.
+///
+/// Can be overridden via `LAMBDA_VM_MAX_TRACE_SIZE` env var.
+/// Must be <= 2^30 due to FFT domain limit (TWO_ADICITY=32, blowup=4).
+///
+/// NOTE: Currently we segment based on CPU table size (1 row per instruction).
+/// A proper implementation should check which table reaches this limit first.
+pub const MAX_TRACE_SIZE: usize = 1 << 23; // 8M rows
+
+/// Get max trace size from env var or constant.
+pub fn get_max_trace_size() -> usize {
+    std::env::var("LAMBDA_VM_MAX_TRACE_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(MAX_TRACE_SIZE)
+}
+
+/// State captured at segment boundaries for continuity.
+///
+/// This struct captures all state needed to resume trace generation
+/// from a previous segment, ensuring continuity of timestamps, memory,
+/// and register values across segment boundaries.
+#[derive(Debug, Clone, Default)]
+pub struct SegmentBoundary {
+    /// Segment index (0-based)
+    pub segment_index: u32,
+
+    /// Starting timestamp for this segment.
+    /// Each instruction consumes 4 timestamps, so this should be
+    /// the end timestamp of the previous segment.
+    pub start_timestamp: u64,
+
+    /// Memory state: (address, value, timestamp) tuples.
+    /// Contains all memory cells that were written during previous segments.
+    pub memory_state: Vec<(u64, u8, u64)>,
+
+    /// Register state: [(value, timestamp); 31] for registers x1-x31.
+    /// x0 is excluded as it's always zero.
+    pub register_state: [(u64, u64); 31],
+
+    /// PC at segment start (for validation/debugging).
+    pub start_pc: u64,
+}
+
+impl SegmentBoundary {
+    /// Create the initial boundary for the first segment.
+    pub fn initial() -> Self {
+        Self {
+            segment_index: 0,
+            start_timestamp: 4, // Timestamps start at 4 (not 0)
+            memory_state: Vec::new(),
+            register_state: [(0, 0); 31],
+            start_pc: 0,
+        }
+    }
+
+    /// Create a boundary for the next segment.
+    pub fn next(
+        &self,
+        end_timestamp: u64,
+        memory_state: Vec<(u64, u8, u64)>,
+        register_state: [(u64, u64); 31],
+        next_pc: u64,
+    ) -> Self {
+        Self {
+            segment_index: self.segment_index + 1,
+            start_timestamp: end_timestamp,
+            memory_state,
+            register_state,
+            start_pc: next_pc,
+        }
+    }
+}
+
+/// Configuration for segment-based trace generation.
+#[derive(Debug, Clone)]
+pub struct SegmentConfig {
+    /// Whether this is the final segment (has ECALL).
+    /// Non-final segments use a dummy HALT trace with zero multiplicity.
+    pub is_final: bool,
+}
+
+impl SegmentConfig {
+    /// Create config for a non-final segment.
+    pub fn intermediate() -> Self {
+        Self { is_final: false }
+    }
+
+    /// Create config for the final segment.
+    pub fn final_segment() -> Self {
+        Self { is_final: true }
+    }
+}
+
+/// Result of generating traces for a single segment.
+pub struct SegmentResult {
+    /// Generated traces for this segment.
+    pub traces: Traces,
+
+    /// Boundary state for the next segment (None if this is the final segment).
+    pub next_boundary: Option<SegmentBoundary>,
+
+    /// Whether this was the final segment.
+    pub is_final: bool,
+}

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -40,7 +40,7 @@ use super::load::{self, LoadOperation};
 use super::lt::{self, LtOperation};
 use super::memw::{self, MemwOperation};
 use super::mul::{self, MulOperation};
-use super::segment::{SegmentBoundary, SegmentConfig, SegmentResult};
+use super::segment::{OpBoundaries, SegmentResult, get_max_trace_size};
 use super::types::{GoldilocksExtension, GoldilocksField};
 use crate::Error;
 
@@ -65,24 +65,6 @@ impl MemoryState {
         Self {
             cells: HashMap::new(),
         }
-    }
-
-    /// Create memory state from a segment boundary.
-    pub fn from_boundary(boundary: &SegmentBoundary) -> Self {
-        let mut cells = HashMap::new();
-        for &(addr, val, ts) in &boundary.memory_state {
-            cells.insert(addr, (val, ts));
-        }
-        Self { cells }
-    }
-
-    /// Export memory state for segment boundary.
-    /// Returns (address, value, timestamp) tuples for all cells.
-    pub fn to_boundary(&self) -> Vec<(u64, u8, u64)> {
-        self.cells
-            .iter()
-            .map(|(&addr, &(val, ts))| (addr, val, ts))
-            .collect()
     }
 
     /// Read a byte from memory. Returns (value, timestamp) or (0, 0) if never written.
@@ -128,27 +110,6 @@ impl RegisterState {
             // All registers start at (0, 0) - value 0 at timestamp 0
             regs: [(0, 0); 32],
         }
-    }
-
-    /// Create register state from a segment boundary.
-    pub fn from_boundary(boundary: &SegmentBoundary) -> Self {
-        let mut regs = [(0u64, 0u64); 32];
-        // x0 is always (0, 0)
-        // x1-x31 come from boundary
-        for (i, &(val, ts)) in boundary.register_state.iter().enumerate() {
-            regs[i + 1] = (val, ts);
-        }
-        Self { regs }
-    }
-
-    /// Export register state for segment boundary.
-    /// Returns [(value, timestamp); 31] for x1-x31 (x0 excluded).
-    pub fn to_boundary(&self) -> [(u64, u64); 31] {
-        let mut result = [(0u64, 0u64); 31];
-        for (i, cell) in result.iter_mut().enumerate() {
-            *cell = self.regs[i + 1];
-        }
-        result
     }
 
     /// Read a register. Returns (value, last_write_timestamp).
@@ -225,6 +186,20 @@ fn collect_cpu_ops(
 // Phase 2: CPU ops → MEMW, LOAD, LT, Bitwise
 // =============================================================================
 
+/// Collected operations from phase 2.
+struct Phase2Result {
+    memw_ops: Vec<MemwOperation>,
+    load_ops: Vec<LoadOperation>,
+    lt_ops: Vec<LtOperation>,
+    bitwise_ops: Vec<BitwiseOperation>,
+    mul_ops: Vec<(MulOperation, bool)>,
+    branch_ops: Vec<BranchOperation>,
+    /// boundaries[i] = cumulative counts after processing cpu_ops[0..i].
+    /// boundaries[0] is always Default (all zeros).
+    /// Length = cpu_ops.len() + 1.
+    boundaries: Vec<OpBoundaries>,
+}
+
 /// Collects all derived operations from CPU operations in a single pass.
 ///
 /// This includes:
@@ -232,24 +207,27 @@ fn collect_cpu_ops(
 /// - LOAD ops (memory loads with sign/zero extension)
 /// - LT ops (from SLT/BLT instructions)
 /// - Bitwise lookups (from CPU operations)
+/// - MUL ops (from multiply instructions)
+/// - BRANCH ops (from taken branches)
+///
+/// Also tracks OpBoundaries for segmentation: cumulative derived op counts
+/// after each CPU op, allowing per-segment slicing without re-processing.
 ///
 /// MEMW and LOAD collection requires sequential processing with state tracking.
-///
-/// Returns: (memw_ops, load_ops, lt_ops, bitwise_ops)
 fn collect_ops_from_cpu(
     cpu_ops: &[CpuOperation],
     memory_state: &mut MemoryState,
     register_state: &mut RegisterState,
-) -> (
-    Vec<MemwOperation>,
-    Vec<LoadOperation>,
-    Vec<LtOperation>,
-    Vec<BitwiseOperation>,
-) {
+) -> Phase2Result {
     let mut memw_ops = Vec::with_capacity(cpu_ops.len() * 3);
     let mut load_ops = Vec::with_capacity(cpu_ops.len() / 8 + 1);
     let mut lt_ops = Vec::with_capacity(cpu_ops.len() / 10 + 1);
     let mut bitwise_ops = Vec::with_capacity(cpu_ops.len() * 4);
+    let mut mul_ops = Vec::with_capacity(cpu_ops.len() / 10 + 1);
+    let mut branch_ops = Vec::with_capacity(cpu_ops.len() / 10 + 1);
+
+    let mut boundaries = Vec::with_capacity(cpu_ops.len() + 1);
+    boundaries.push(OpBoundaries::default());
 
     for op in cpu_ops {
         // --- MEMW and LOAD (require state tracking, order matters) ---
@@ -280,9 +258,49 @@ fn collect_ops_from_cpu(
 
         // Collect bitwise lookups
         bitwise_ops.extend(op.collect_bitwise_ops());
+
+        // Collect MUL operations
+        if op.decode.op_mul {
+            let lhs = op.compute_arg1();
+            let lhs_signed = op.decode.signed;
+            let rhs_signed = op.decode.mp_selector;
+            let rhs = op.compute_arg2();
+            let wants_hi = op.decode.muldiv_selector;
+            mul_ops.push((
+                MulOperation::new(lhs, lhs_signed, rhs, rhs_signed),
+                wants_hi,
+            ));
+        }
+
+        // Collect BRANCH operations
+        if op.branch_cond {
+            branch_ops.push(BranchOperation::new(
+                op.decode.pc,
+                op.decode.imm,
+                op.compute_arg1(),
+                op.decode.op_jalr,
+            ));
+        }
+
+        boundaries.push(OpBoundaries {
+            memw: memw_ops.len(),
+            load: load_ops.len(),
+            lt: lt_ops.len(),
+            mul: mul_ops.len(),
+            branch: branch_ops.len(),
+            bitwise: bitwise_ops.len(),
+        });
     }
 
-    (memw_ops, load_ops, lt_ops, bitwise_ops)
+    Phase2Result {
+        memw_ops,
+        load_ops,
+        lt_ops,
+        bitwise_ops,
+        mul_ops,
+        branch_ops,
+        boundaries,
+    }
 }
 
 /// Collects a LOAD operation and corresponding MEMW read from CpuOperation.
@@ -788,46 +806,20 @@ impl Traces {
         let cpu_ops = collect_cpu_ops(logs, &instructions, 4)?;
 
         // =====================================================================
-        // PHASE 2: CPU ops → MEMW, LOAD, LT, Bitwise, Branch
+        // PHASE 2: CPU ops → MEMW, LOAD, LT, Bitwise, MUL, Branch
         // =====================================================================
         // Processes cpu_ops in order. MEMW/LOAD need state tracking, LT/Bitwise don't.
         let mut memory_state = MemoryState::new();
         let mut register_state = RegisterState::new();
-        let (memw_ops, load_ops, mut lt_ops, mut bitwise_ops) =
-            collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
-
-        // Collect MUL operations from CPU ops where op_mul = true
-        let mul_ops: Vec<(MulOperation, bool)> = cpu_ops
-            .iter()
-            .filter(|op| op.decode.op_mul)
-            .map(|op| {
-                let lhs = op.compute_arg1();
-                let lhs_signed = op.decode.signed;
-                // rhs_signed = mp_selector per spec CPU-CA44:
-                // MUL/MULH have mp_selector=1 (both signed), MULHU/MULHSU have mp_selector=0 (rhs unsigned)
-                let rhs_signed = op.decode.mp_selector;
-                let rhs = op.compute_arg2();
-                let wants_hi = op.decode.muldiv_selector;
-                (
-                    MulOperation::new(lhs, lhs_signed, rhs, rhs_signed),
-                    wants_hi,
-                )
-            })
-            .collect();
-
-        // Collect BRANCH operations from CPU ops where branch_cond = true
-        let branch_ops: Vec<BranchOperation> = cpu_ops
-            .iter()
-            .filter(|op| op.branch_cond)
-            .map(|op| {
-                BranchOperation::new(
-                    op.decode.pc,
-                    op.decode.imm, // offset as full 64-bit DWordWL (already sign-extended)
-                    op.compute_arg1(), // register value must match CPU's arg1 for bus signature
-                    op.decode.op_jalr,
-                )
-            })
-            .collect();
+        let Phase2Result {
+            memw_ops,
+            load_ops,
+            mut lt_ops,
+            mut bitwise_ops,
+            mul_ops,
+            branch_ops,
+            ..
+        } = collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
 
         // =====================================================================
         // PHASE 3: MEMW → LT (timestamp ordering and overflow checks)
@@ -886,157 +878,141 @@ impl Traces {
         })
     }
 
-    /// Generates all traces from execution logs for a segment.
+    /// Generates traces for all segments from execution logs.
     ///
     /// This is the segmented version of `from_logs` that:
-    /// - Accepts a `SegmentBoundary` to restore state from a previous segment
-    /// - Accepts a `SegmentConfig` to control segment-specific behavior
-    /// - Returns a `SegmentResult` with traces and optional next boundary
+    /// 1. Runs phases 1-2 on ALL logs (collecting ops + tracking OpBoundaries)
+    /// 2. Generates the full CPU trace, then chunks it by max_trace_size
+    /// 3. Slices derived ops per segment using OpBoundaries
+    /// 4. Runs phases 3-4 per segment (pure functions, no shared state)
+    /// 5. Generates per-segment traces
     ///
-    /// For the first segment, use `SegmentBoundary::initial()`.
-    /// For non-final segments, use `SegmentConfig::intermediate()`.
-    /// For the final segment (containing ECALL), use `SegmentConfig::final_segment()`.
+    /// Segmentation is determined internally based on CPU trace size.
+    /// ECALL always lands in the final segment (executor guarantees it's the last instruction).
     pub fn from_logs_segmented(
         logs: &[Log],
         instructions: U64HashMap<Instruction>,
-        boundary: &SegmentBoundary,
-        config: &SegmentConfig,
-    ) -> Result<SegmentResult, Error> {
-        // =====================================================================
-        // PHASE 1: Logs → CPU operations (with timestamp offset)
-        // =====================================================================
-        let cpu_ops = collect_cpu_ops(logs, &instructions, boundary.start_timestamp)?;
+    ) -> Result<Vec<SegmentResult>, Error> {
+        Self::from_logs_segmented_with_max_size(logs, instructions, get_max_trace_size())
+    }
 
+    /// Generates traces for all segments with a custom max trace size.
+    ///
+    /// Same as [`from_logs_segmented`] but allows specifying the segment size
+    /// directly, useful for testing.
+    pub fn from_logs_segmented_with_max_size(
+        logs: &[Log],
+        instructions: U64HashMap<Instruction>,
+        max_size: usize,
+    ) -> Result<Vec<SegmentResult>, Error> {
         // =====================================================================
-        // PHASE 2: CPU ops → MEMW, LOAD, LT, Bitwise, Branch
+        // PHASE 1: Logs → CPU operations
         // =====================================================================
-        // Initialize state from boundary (preserves state from previous segment)
-        let mut memory_state = MemoryState::from_boundary(boundary);
-        let mut register_state = RegisterState::from_boundary(boundary);
-
-        let (memw_ops, load_ops, mut lt_ops, mut bitwise_ops) =
-            collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
-
-        // Collect MUL operations from CPU ops where op_mul = true
-        let mul_ops: Vec<(MulOperation, bool)> = cpu_ops
-            .iter()
-            .filter(|op| op.decode.op_mul)
-            .map(|op| {
-                let lhs = op.compute_arg1();
-                let lhs_signed = op.decode.signed;
-                let rhs_signed = op.decode.mp_selector;
-                let rhs = op.compute_arg2();
-                let wants_hi = op.decode.muldiv_selector;
-                (
-                    MulOperation::new(lhs, lhs_signed, rhs, rhs_signed),
-                    wants_hi,
-                )
-            })
-            .collect();
-
-        // Collect BRANCH operations from CPU ops where branch_cond = true
-        let branch_ops: Vec<BranchOperation> = cpu_ops
-            .iter()
-            .filter(|op| op.branch_cond)
-            .map(|op| {
-                BranchOperation::new(
-                    op.decode.pc,
-                    op.decode.imm,
-                    op.compute_arg1(),
-                    op.decode.op_jalr,
-                )
-            })
-            .collect();
+        let cpu_ops = collect_cpu_ops(logs, &instructions, 4)?;
 
         // =====================================================================
-        // PHASE 3: MEMW → LT (timestamp ordering and overflow checks)
+        // PHASE 2: CPU ops → all derived ops (with OpBoundaries tracking)
         // =====================================================================
-        lt_ops.extend(collect_lt_from_memw(&memw_ops));
-
-        // =====================================================================
-        // PHASE 4: All → Bitwise lookups
-        // =====================================================================
-        bitwise_ops.extend(collect_bitwise_from_lt(&lt_ops));
-        bitwise_ops.extend(collect_bitwise_from_memw(&memw_ops));
-        bitwise_ops.extend(collect_bitwise_from_mul(&mul_ops));
-        bitwise_ops.extend(collect_bitwise_from_branch(&branch_ops));
+        let mut memory_state = MemoryState::new();
+        let mut register_state = RegisterState::new();
+        let phase2 = collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
 
         // =====================================================================
-        // PHASE 5: Generate final traces
+        // Segment based on CPU op count
         // =====================================================================
+        let num_cpu_ops = cpu_ops.len();
+        let num_segments = num_cpu_ops.div_ceil(max_size);
+        let num_segments = num_segments.max(1); // At least one segment
 
-        // Generate HALT trace based on segment type
-        let halt_trace = if config.is_final {
-            // Final segment: find ECALL and generate proper halt trace
-            let halt_op = cpu_ops
-                .iter()
-                .rev()
-                .find(|op| op.decode.op_ecall)
-                .ok_or(Error::MissingHaltEcall)?;
-            halt::generate_halt_trace(halt_op.timestamp)
-        } else {
-            // Non-final segment: verify no ECALL present (would cause bus imbalance)
-            if cpu_ops.iter().any(|op| op.decode.op_ecall) {
-                return Err(Error::UnexpectedEcallInSegment);
-            }
-            // Generate dummy halt trace
-            halt::generate_dummy_halt_trace()
-        };
+        let mut results = Vec::with_capacity(num_segments);
 
-        let cpu = cpu::generate_cpu_trace(&cpu_ops);
-        let lt = lt::generate_lt_trace(&lt_ops);
-        let memw = memw::generate_memw_trace(&memw_ops);
-        let load = load::generate_load_trace(&load_ops);
-        let mul = mul::generate_mul_trace(&mul_ops);
-        let branch = branch::generate_branch_trace(&branch_ops);
+        for seg_idx in 0..num_segments {
+            let cpu_start = seg_idx * max_size;
+            let cpu_end = ((seg_idx + 1) * max_size).min(num_cpu_ops);
+            let is_final = seg_idx == num_segments - 1;
 
-        let mut bitwise = bitwise::generate_bitwise_trace();
-        bitwise::update_multiplicities(&mut bitwise, &bitwise_ops);
+            let seg_cpu_ops = &cpu_ops[cpu_start..cpu_end];
 
-        // Generate DECODE trace and update multiplicities
-        let (mut decode, pc_to_row) = decode::generate_decode_trace(&instructions);
-        let num_padding_rows = cpu_ops.len().next_power_of_two() - cpu_ops.len();
-        let mut decode_lookups: Vec<u64> = cpu_ops.iter().map(|op| op.decode.pc).collect();
-        decode_lookups.extend(std::iter::repeat_n(cpu::CPU_PADDING_PC, num_padding_rows));
-        decode::update_multiplicities(&mut decode, &pc_to_row, &decode_lookups);
+            // Slice derived ops using OpBoundaries
+            let b_start = &phase2.boundaries[cpu_start];
+            let b_end = &phase2.boundaries[cpu_end];
 
-        let traces = Traces {
-            cpu,
-            bitwise,
-            lt,
-            memw,
-            load,
-            decode,
-            mul,
-            branch,
-            halt: halt_trace,
-        };
+            let seg_memw_ops = &phase2.memw_ops[b_start.memw..b_end.memw];
+            let seg_load_ops = &phase2.load_ops[b_start.load..b_end.load];
+            let seg_mul_ops = &phase2.mul_ops[b_start.mul..b_end.mul];
+            let seg_branch_ops = &phase2.branch_ops[b_start.branch..b_end.branch];
 
-        // =====================================================================
-        // PHASE 6: Capture boundary for next segment
-        // =====================================================================
-        let next_boundary = if config.is_final {
-            None
-        } else {
-            // Calculate end timestamp: start + (num_logs * 4)
-            let end_timestamp = boundary.start_timestamp + (logs.len() as u64) * 4;
+            // Phase 2 LT ops (from SLT/BLT instructions only)
+            let mut seg_lt_ops: Vec<LtOperation> = phase2.lt_ops[b_start.lt..b_end.lt].to_vec();
 
-            // Get next PC from last log
-            let next_pc = logs.last().map(|l| l.next_pc).unwrap_or(0);
+            // =================================================================
+            // PHASE 3 (per-segment): MEMW → LT
+            // =================================================================
+            seg_lt_ops.extend(collect_lt_from_memw(seg_memw_ops));
 
-            Some(boundary.next(
-                end_timestamp,
-                memory_state.to_boundary(),
-                register_state.to_boundary(),
-                next_pc,
-            ))
-        };
+            // =================================================================
+            // PHASE 4 (per-segment): All → Bitwise lookups
+            // =================================================================
+            // Start with phase-2 bitwise ops (from CPU ops + load ops), sliced
+            let mut seg_bitwise_ops: Vec<BitwiseOperation> =
+                phase2.bitwise_ops[b_start.bitwise..b_end.bitwise].to_vec();
+            // Add phase-4 bitwise ops (from LT, MEMW, MUL, BRANCH)
+            seg_bitwise_ops.extend(collect_bitwise_from_lt(&seg_lt_ops));
+            seg_bitwise_ops.extend(collect_bitwise_from_memw(seg_memw_ops));
+            seg_bitwise_ops.extend(collect_bitwise_from_mul(seg_mul_ops));
+            seg_bitwise_ops.extend(collect_bitwise_from_branch(seg_branch_ops));
 
-        Ok(SegmentResult {
-            traces,
-            next_boundary,
-            is_final: config.is_final,
-        })
+            // =================================================================
+            // PHASE 5 (per-segment): Generate traces
+            // =================================================================
+
+            // HALT trace
+            let halt_trace = if is_final {
+                let halt_op = cpu_ops
+                    .iter()
+                    .rev()
+                    .find(|op| op.decode.op_ecall)
+                    .ok_or(Error::MissingHaltEcall)?;
+                halt::generate_halt_trace(halt_op.timestamp)
+            } else {
+                halt::generate_dummy_halt_trace()
+            };
+
+            let cpu = cpu::generate_cpu_trace(seg_cpu_ops);
+            let lt = lt::generate_lt_trace(&seg_lt_ops);
+            let memw = memw::generate_memw_trace(seg_memw_ops);
+            let load = load::generate_load_trace(seg_load_ops);
+            let mul = mul::generate_mul_trace(seg_mul_ops);
+            let branch = branch::generate_branch_trace(seg_branch_ops);
+
+            let mut bitwise_table = bitwise::generate_bitwise_trace();
+            bitwise::update_multiplicities(&mut bitwise_table, &seg_bitwise_ops);
+
+            let (mut decode, pc_to_row) = decode::generate_decode_trace(&instructions);
+            let seg_num_ops = seg_cpu_ops.len();
+            let num_padding_rows = seg_num_ops.next_power_of_two() - seg_num_ops;
+            let mut decode_lookups: Vec<u64> = seg_cpu_ops.iter().map(|op| op.decode.pc).collect();
+            decode_lookups.extend(std::iter::repeat_n(cpu::CPU_PADDING_PC, num_padding_rows));
+            decode::update_multiplicities(&mut decode, &pc_to_row, &decode_lookups);
+
+            results.push(SegmentResult {
+                traces: Traces {
+                    cpu,
+                    bitwise: bitwise_table,
+                    lt,
+                    memw,
+                    load,
+                    decode,
+                    mul,
+                    branch,
+                    halt: halt_trace,
+                },
+                is_final,
+                segment_index: seg_idx,
+            });
+        }
+
+        Ok(results)
     }
 
     /// Generates all traces with a trimmed bitwise table (TEST ONLY).

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -975,7 +975,11 @@ impl Traces {
                 .ok_or(Error::MissingHaltEcall)?;
             halt::generate_halt_trace(halt_op.timestamp)
         } else {
-            // Non-final segment: generate dummy halt trace
+            // Non-final segment: verify no ECALL present (would cause bus imbalance)
+            if cpu_ops.iter().any(|op| op.decode.op_ecall) {
+                return Err(Error::UnexpectedEcallInSegment);
+            }
+            // Generate dummy halt trace
             halt::generate_dummy_halt_trace()
         };
 

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -40,6 +40,7 @@ use super::load::{self, LoadOperation};
 use super::lt::{self, LtOperation};
 use super::memw::{self, MemwOperation};
 use super::mul::{self, MulOperation};
+use super::segment::{SegmentBoundary, SegmentConfig, SegmentResult};
 use super::types::{GoldilocksExtension, GoldilocksField};
 use crate::Error;
 
@@ -54,7 +55,7 @@ type MemoryCell = (u8, u64);
 type RegisterCell = (u64, u64);
 
 /// Memory state tracker for generating MEMW/LOAD traces.
-struct MemoryState {
+pub(crate) struct MemoryState {
     /// Map from byte address to (value, timestamp)
     cells: HashMap<u64, MemoryCell>,
 }
@@ -64,6 +65,24 @@ impl MemoryState {
         Self {
             cells: HashMap::new(),
         }
+    }
+
+    /// Create memory state from a segment boundary.
+    pub fn from_boundary(boundary: &SegmentBoundary) -> Self {
+        let mut cells = HashMap::new();
+        for &(addr, val, ts) in &boundary.memory_state {
+            cells.insert(addr, (val, ts));
+        }
+        Self { cells }
+    }
+
+    /// Export memory state for segment boundary.
+    /// Returns (address, value, timestamp) tuples for all cells.
+    pub fn to_boundary(&self) -> Vec<(u64, u8, u64)> {
+        self.cells
+            .iter()
+            .map(|(&addr, &(val, ts))| (addr, val, ts))
+            .collect()
     }
 
     /// Read a byte from memory. Returns (value, timestamp) or (0, 0) if never written.
@@ -98,7 +117,7 @@ impl MemoryState {
 }
 
 /// Register state tracker for generating MEMW register traces.
-struct RegisterState {
+pub(crate) struct RegisterState {
     /// Register file: (value, last_write_timestamp)
     regs: [RegisterCell; 32],
 }
@@ -109,6 +128,27 @@ impl RegisterState {
             // All registers start at (0, 0) - value 0 at timestamp 0
             regs: [(0, 0); 32],
         }
+    }
+
+    /// Create register state from a segment boundary.
+    pub fn from_boundary(boundary: &SegmentBoundary) -> Self {
+        let mut regs = [(0u64, 0u64); 32];
+        // x0 is always (0, 0)
+        // x1-x31 come from boundary
+        for (i, &(val, ts)) in boundary.register_state.iter().enumerate() {
+            regs[i + 1] = (val, ts);
+        }
+        Self { regs }
+    }
+
+    /// Export register state for segment boundary.
+    /// Returns [(value, timestamp); 31] for x1-x31 (x0 excluded).
+    pub fn to_boundary(&self) -> [(u64, u64); 31] {
+        let mut result = [(0u64, 0u64); 31];
+        for (i, cell) in result.iter_mut().enumerate() {
+            *cell = self.regs[i + 1];
+        }
+        result
     }
 
     /// Read a register. Returns (value, last_write_timestamp).
@@ -156,17 +196,20 @@ fn pack_register_value(value: u64) -> [u64; 8] {
 
 /// Collects CPU operations from execution logs.
 ///
+/// The `start_timestamp` parameter allows continuing timestamp sequence from
+/// a previous segment. For the first segment, use 4 (timestamps start at 4,
+/// not 0, to ensure old_timestamp < timestamp holds for the first access).
+///
 /// Returns a vector of CpuOperation, one per log entry.
 fn collect_cpu_ops(
     logs: &[Log],
     instructions: &U64HashMap<Instruction>,
+    start_timestamp: u64,
 ) -> Result<Vec<CpuOperation>, Error> {
     let mut cpu_ops = Vec::with_capacity(logs.len());
 
-    // Timestamps start at 4 (not 0) to ensure old_timestamp < timestamp holds
-    // for the first access to any register/memory location (where old_timestamp=0).
     for (i, log) in logs.iter().enumerate() {
-        let timestamp = (i as u64) * 4 + 4;
+        let timestamp = start_timestamp + (i as u64) * 4;
         let instruction = instructions
             .get(&log.current_pc)
             .copied()
@@ -740,7 +783,9 @@ impl Traces {
         // =====================================================================
         // PHASE 1: Logs → CPU operations
         // =====================================================================
-        let cpu_ops = collect_cpu_ops(logs, &instructions)?;
+        // Timestamps start at 4 (not 0) to ensure old_timestamp < timestamp holds
+        // for the first access to any register/memory location (where old_timestamp=0).
+        let cpu_ops = collect_cpu_ops(logs, &instructions, 4)?;
 
         // =====================================================================
         // PHASE 2: CPU ops → MEMW, LOAD, LT, Bitwise, Branch
@@ -838,6 +883,155 @@ impl Traces {
             mul,
             branch,
             halt: halt_trace,
+        })
+    }
+
+    /// Generates all traces from execution logs for a segment.
+    ///
+    /// This is the segmented version of `from_logs` that:
+    /// - Accepts a `SegmentBoundary` to restore state from a previous segment
+    /// - Accepts a `SegmentConfig` to control segment-specific behavior
+    /// - Returns a `SegmentResult` with traces and optional next boundary
+    ///
+    /// For the first segment, use `SegmentBoundary::initial()`.
+    /// For non-final segments, use `SegmentConfig::intermediate()`.
+    /// For the final segment (containing ECALL), use `SegmentConfig::final_segment()`.
+    pub fn from_logs_segmented(
+        logs: &[Log],
+        instructions: U64HashMap<Instruction>,
+        boundary: &SegmentBoundary,
+        config: &SegmentConfig,
+    ) -> Result<SegmentResult, Error> {
+        // =====================================================================
+        // PHASE 1: Logs → CPU operations (with timestamp offset)
+        // =====================================================================
+        let cpu_ops = collect_cpu_ops(logs, &instructions, boundary.start_timestamp)?;
+
+        // =====================================================================
+        // PHASE 2: CPU ops → MEMW, LOAD, LT, Bitwise, Branch
+        // =====================================================================
+        // Initialize state from boundary (preserves state from previous segment)
+        let mut memory_state = MemoryState::from_boundary(boundary);
+        let mut register_state = RegisterState::from_boundary(boundary);
+
+        let (memw_ops, load_ops, mut lt_ops, mut bitwise_ops) =
+            collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
+
+        // Collect MUL operations from CPU ops where op_mul = true
+        let mul_ops: Vec<(MulOperation, bool)> = cpu_ops
+            .iter()
+            .filter(|op| op.decode.op_mul)
+            .map(|op| {
+                let lhs = op.compute_arg1();
+                let lhs_signed = op.decode.signed;
+                let rhs_signed = op.decode.mp_selector;
+                let rhs = op.compute_arg2();
+                let wants_hi = op.decode.muldiv_selector;
+                (
+                    MulOperation::new(lhs, lhs_signed, rhs, rhs_signed),
+                    wants_hi,
+                )
+            })
+            .collect();
+
+        // Collect BRANCH operations from CPU ops where branch_cond = true
+        let branch_ops: Vec<BranchOperation> = cpu_ops
+            .iter()
+            .filter(|op| op.branch_cond)
+            .map(|op| {
+                BranchOperation::new(
+                    op.decode.pc,
+                    op.decode.imm,
+                    op.compute_arg1(),
+                    op.decode.op_jalr,
+                )
+            })
+            .collect();
+
+        // =====================================================================
+        // PHASE 3: MEMW → LT (timestamp ordering and overflow checks)
+        // =====================================================================
+        lt_ops.extend(collect_lt_from_memw(&memw_ops));
+
+        // =====================================================================
+        // PHASE 4: All → Bitwise lookups
+        // =====================================================================
+        bitwise_ops.extend(collect_bitwise_from_lt(&lt_ops));
+        bitwise_ops.extend(collect_bitwise_from_memw(&memw_ops));
+        bitwise_ops.extend(collect_bitwise_from_mul(&mul_ops));
+        bitwise_ops.extend(collect_bitwise_from_branch(&branch_ops));
+
+        // =====================================================================
+        // PHASE 5: Generate final traces
+        // =====================================================================
+
+        // Generate HALT trace based on segment type
+        let halt_trace = if config.is_final {
+            // Final segment: find ECALL and generate proper halt trace
+            let halt_op = cpu_ops
+                .iter()
+                .rev()
+                .find(|op| op.decode.op_ecall)
+                .ok_or(Error::MissingHaltEcall)?;
+            halt::generate_halt_trace(halt_op.timestamp)
+        } else {
+            // Non-final segment: generate dummy halt trace
+            halt::generate_dummy_halt_trace()
+        };
+
+        let cpu = cpu::generate_cpu_trace(&cpu_ops);
+        let lt = lt::generate_lt_trace(&lt_ops);
+        let memw = memw::generate_memw_trace(&memw_ops);
+        let load = load::generate_load_trace(&load_ops);
+        let mul = mul::generate_mul_trace(&mul_ops);
+        let branch = branch::generate_branch_trace(&branch_ops);
+
+        let mut bitwise = bitwise::generate_bitwise_trace();
+        bitwise::update_multiplicities(&mut bitwise, &bitwise_ops);
+
+        // Generate DECODE trace and update multiplicities
+        let (mut decode, pc_to_row) = decode::generate_decode_trace(&instructions);
+        let num_padding_rows = cpu_ops.len().next_power_of_two() - cpu_ops.len();
+        let mut decode_lookups: Vec<u64> = cpu_ops.iter().map(|op| op.decode.pc).collect();
+        decode_lookups.extend(std::iter::repeat_n(cpu::CPU_PADDING_PC, num_padding_rows));
+        decode::update_multiplicities(&mut decode, &pc_to_row, &decode_lookups);
+
+        let traces = Traces {
+            cpu,
+            bitwise,
+            lt,
+            memw,
+            load,
+            decode,
+            mul,
+            branch,
+            halt: halt_trace,
+        };
+
+        // =====================================================================
+        // PHASE 6: Capture boundary for next segment
+        // =====================================================================
+        let next_boundary = if config.is_final {
+            None
+        } else {
+            // Calculate end timestamp: start + (num_logs * 4)
+            let end_timestamp = boundary.start_timestamp + (logs.len() as u64) * 4;
+
+            // Get next PC from last log
+            let next_pc = logs.last().map(|l| l.next_pc).unwrap_or(0);
+
+            Some(boundary.next(
+                end_timestamp,
+                memory_state.to_boundary(),
+                register_state.to_boundary(),
+                next_pc,
+            ))
+        };
+
+        Ok(SegmentResult {
+            traces,
+            next_boundary,
+            is_final: config.is_final,
         })
     }
 

--- a/prover/src/tests/mod.rs
+++ b/prover/src/tests/mod.rs
@@ -21,4 +21,6 @@ pub mod mul_tests;
 #[cfg(test)]
 pub mod prove_elfs_tests;
 #[cfg(test)]
+pub mod segment_tests;
+#[cfg(test)]
 pub mod trace_builder_tests;

--- a/prover/src/tests/segment_tests.rs
+++ b/prover/src/tests/segment_tests.rs
@@ -1,0 +1,227 @@
+//! Tests for trace segmentation.
+//!
+//! These tests verify:
+//! - Boundary state serialization/deserialization
+//! - Memory and register state continuity across segments
+//! - Timestamp continuity across segments
+
+use crate::tables::segment::{SegmentBoundary, SegmentConfig};
+use crate::tables::trace_builder::Traces;
+use crate::test_utils::run_asm_elf;
+use executor::vm::instruction::decoding::Instruction;
+use executor::vm::logs::Log;
+use executor::vm::memory::U64HashMap;
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/// Find the index of the ECALL instruction in the logs.
+/// Returns None if no ECALL is found.
+fn find_ecall_index(logs: &[Log], instructions: &U64HashMap<Instruction>) -> Option<usize> {
+    logs.iter().position(|log| {
+        instructions
+            .get(&log.current_pc)
+            .map(|inst| matches!(inst, Instruction::EcallEbreak))
+            .unwrap_or(false)
+    })
+}
+
+// =============================================================================
+// Boundary State Tests
+// =============================================================================
+
+#[test]
+fn test_boundary_initial() {
+    let boundary = SegmentBoundary::initial();
+
+    assert_eq!(boundary.segment_index, 0);
+    assert_eq!(boundary.start_timestamp, 4);
+    assert!(boundary.memory_state.is_empty());
+    assert_eq!(boundary.register_state, [(0, 0); 31]);
+    assert_eq!(boundary.start_pc, 0);
+}
+
+#[test]
+fn test_boundary_next() {
+    let initial = SegmentBoundary::initial();
+
+    let memory_state = vec![(0x1000, 0x42, 100), (0x1001, 0x43, 104)];
+    let mut register_state = [(0u64, 0u64); 31];
+    register_state[0] = (0xDEAD, 108); // x1
+    register_state[9] = (0xBEEF, 112); // x10
+
+    let next = initial.next(200, memory_state.clone(), register_state, 0x80000010);
+
+    assert_eq!(next.segment_index, 1);
+    assert_eq!(next.start_timestamp, 200);
+    assert_eq!(next.memory_state, memory_state);
+    assert_eq!(next.register_state, register_state);
+    assert_eq!(next.start_pc, 0x80000010);
+}
+
+// =============================================================================
+// Segmented Trace Generation Tests
+// =============================================================================
+
+#[test]
+fn test_from_logs_segmented_intermediate_segment() {
+    // Test that from_logs_segmented works for an intermediate (non-final) segment
+    // Intermediate segments don't need an ECALL
+    let (_elf, logs, instructions) = run_asm_elf("sub");
+
+    let boundary = SegmentBoundary::initial();
+    let config = SegmentConfig::intermediate();
+
+    let result = Traces::from_logs_segmented(&logs, instructions, &boundary, &config)
+        .expect("Failed to generate segmented traces");
+
+    assert!(!result.is_final);
+    assert!(result.next_boundary.is_some());
+
+    // Verify traces are generated
+    assert!(result.traces.cpu.main_table.height > 0);
+    assert!(result.traces.memw.main_table.height > 0);
+}
+
+#[test]
+fn test_from_logs_segmented_with_state_continuity() {
+    // Test that state is properly captured and restored across segments
+    let (_elf, logs, instructions) = run_asm_elf("comprehensive_test");
+
+    // Find ECALL position
+    let ecall_idx = match find_ecall_index(&logs, &instructions) {
+        Some(idx) => idx,
+        None => {
+            // No ECALL found, skip test
+            return;
+        }
+    };
+
+    // Need at least 2 logs to split
+    if ecall_idx == 0 {
+        return;
+    }
+
+    // Split so ECALL is in the second segment
+    let first_half = &logs[..ecall_idx];
+    let second_half = &logs[ecall_idx..];
+
+    // Generate first segment (intermediate - no ECALL)
+    let boundary = SegmentBoundary::initial();
+    let config = SegmentConfig::intermediate();
+
+    let result1 = Traces::from_logs_segmented(first_half, instructions.clone(), &boundary, &config)
+        .expect("Failed to generate first segment");
+
+    assert!(!result1.is_final);
+    let next_boundary = result1.next_boundary.expect("Should have next boundary");
+
+    // Verify boundary state
+    assert_eq!(next_boundary.segment_index, 1);
+    assert_eq!(
+        next_boundary.start_timestamp,
+        4 + (first_half.len() as u64) * 4
+    );
+
+    // Generate second segment (final - contains ECALL)
+    let config = SegmentConfig::final_segment();
+
+    let result2 = Traces::from_logs_segmented(second_half, instructions, &next_boundary, &config)
+        .expect("Failed to generate second segment");
+
+    assert!(result2.is_final);
+    assert!(result2.next_boundary.is_none());
+}
+
+#[test]
+fn test_timestamp_continuity() {
+    // Verify timestamps are continuous across segments
+    let (_elf, logs, instructions) = run_asm_elf("arith_8");
+
+    if logs.len() < 4 {
+        return;
+    }
+
+    let split_point = logs.len() / 2;
+    let first_half = &logs[..split_point];
+
+    // Generate first segment (intermediate)
+    let boundary = SegmentBoundary::initial();
+    let config = SegmentConfig::intermediate();
+
+    let result = Traces::from_logs_segmented(first_half, instructions, &boundary, &config)
+        .expect("Failed to generate segment");
+
+    let next_boundary = result.next_boundary.expect("Should have next boundary");
+
+    // Expected end timestamp: start (4) + num_logs * 4
+    let expected_end_ts = 4 + (first_half.len() as u64) * 4;
+    assert_eq!(next_boundary.start_timestamp, expected_end_ts);
+}
+
+#[test]
+fn test_multi_segment_trace_generation() {
+    // Test generating traces across 3 segments
+    let (_elf, logs, instructions) = run_asm_elf("all_instructions_64");
+
+    // Find ECALL position
+    let ecall_idx = match find_ecall_index(&logs, &instructions) {
+        Some(idx) => idx,
+        None => return,
+    };
+
+    // Need at least 3 instructions before ECALL to split into 3 segments
+    if ecall_idx < 3 {
+        return;
+    }
+
+    // Split into 3 segments: [0..n/3], [n/3..ecall_idx], [ecall_idx..]
+    let first_end = ecall_idx / 3;
+    let second_end = ecall_idx;
+
+    let seg1_logs = &logs[..first_end];
+    let seg2_logs = &logs[first_end..second_end];
+    let seg3_logs = &logs[second_end..];
+
+    // Segment 1: intermediate
+    let boundary1 = SegmentBoundary::initial();
+    let result1 = Traces::from_logs_segmented(
+        seg1_logs,
+        instructions.clone(),
+        &boundary1,
+        &SegmentConfig::intermediate(),
+    )
+    .expect("Segment 1 failed");
+    assert!(!result1.is_final);
+    let boundary2 = result1.next_boundary.expect("Should have boundary");
+
+    // Segment 2: intermediate
+    let result2 = Traces::from_logs_segmented(
+        seg2_logs,
+        instructions.clone(),
+        &boundary2,
+        &SegmentConfig::intermediate(),
+    )
+    .expect("Segment 2 failed");
+    assert!(!result2.is_final);
+    let boundary3 = result2.next_boundary.expect("Should have boundary");
+
+    // Segment 3: final (contains ECALL)
+    let result3 = Traces::from_logs_segmented(
+        seg3_logs,
+        instructions,
+        &boundary3,
+        &SegmentConfig::final_segment(),
+    )
+    .expect("Segment 3 failed");
+    assert!(result3.is_final);
+    assert!(result3.next_boundary.is_none());
+
+    // Verify timestamp continuity
+    assert_eq!(boundary2.start_timestamp, 4 + (seg1_logs.len() as u64) * 4);
+    assert_eq!(
+        boundary3.start_timestamp,
+        boundary2.start_timestamp + (seg2_logs.len() as u64) * 4
+    );
+}

--- a/prover/src/tests/segment_tests.rs
+++ b/prover/src/tests/segment_tests.rs
@@ -1,14 +1,13 @@
 //! Tests for trace segmentation.
 //!
 //! These tests verify:
-//! - Boundary state serialization/deserialization
-//! - Memory and register state continuity across segments
-//! - Timestamp continuity across segments
+//! - Single-segment behavior when trace fits in one segment
+//! - Multi-segment splitting with correct op slicing
+//! - ECALL lands in final segment naturally
+//! - Segment traces are valid (non-empty, correct structure)
 
-use crate::tables::segment::{SegmentBoundary, SegmentConfig};
 use crate::tables::trace_builder::Traces;
-use crate::test_utils::run_asm_elf;
-use executor::vm::instruction::decoding::Instruction;
+use executor::vm::instruction::decoding::{ArithOp, Instruction};
 use executor::vm::logs::Log;
 use executor::vm::memory::U64HashMap;
 
@@ -16,244 +15,172 @@ use executor::vm::memory::U64HashMap;
 // Helper Functions
 // =============================================================================
 
-/// Find the index of the ECALL instruction in the logs.
-/// Returns None if no ECALL is found.
-fn find_ecall_index(logs: &[Log], instructions: &U64HashMap<Instruction>) -> Option<usize> {
-    logs.iter().position(|log| {
-        instructions
-            .get(&log.current_pc)
-            .map(|inst| matches!(inst, Instruction::EcallEbreak))
-            .unwrap_or(false)
-    })
-}
-
-// =============================================================================
-// Boundary State Tests
-// =============================================================================
-
-#[test]
-fn test_boundary_initial() {
-    let boundary = SegmentBoundary::initial();
-
-    assert_eq!(boundary.segment_index, 0);
-    assert_eq!(boundary.start_timestamp, 4);
-    assert!(boundary.memory_state.is_empty());
-    assert_eq!(boundary.register_state, [(0, 0); 31]);
-    assert_eq!(boundary.start_pc, 0);
-}
-
-#[test]
-fn test_boundary_next() {
-    let initial = SegmentBoundary::initial();
-
-    let memory_state = vec![(0x1000, 0x42, 100), (0x1001, 0x43, 104)];
-    let mut register_state = [(0u64, 0u64); 31];
-    register_state[0] = (0xDEAD, 108); // x1
-    register_state[9] = (0xBEEF, 112); // x10
-
-    let next = initial.next(200, memory_state.clone(), register_state, 0x80000010);
-
-    assert_eq!(next.segment_index, 1);
-    assert_eq!(next.start_timestamp, 200);
-    assert_eq!(next.memory_state, memory_state);
-    assert_eq!(next.register_state, register_state);
-    assert_eq!(next.start_pc, 0x80000010);
-}
-
-// =============================================================================
-// Segmented Trace Generation Tests
-// =============================================================================
-
-#[test]
-fn test_from_logs_segmented_intermediate_segment() {
-    // Test that from_logs_segmented works for an intermediate (non-final) segment
-    // Intermediate segments must NOT contain an ECALL
-    let (_elf, logs, instructions) = run_asm_elf("sub");
-
-    // Find ECALL and exclude it from intermediate segment
-    let ecall_idx = find_ecall_index(&logs, &instructions).unwrap_or(logs.len());
-    if ecall_idx == 0 {
-        return; // Can't test with only ECALL
+fn make_add_log(pc: u64, rs1_val: u64, rs2_val: u64, dst_val: u64) -> Log {
+    Log {
+        current_pc: pc,
+        next_pc: pc + 4,
+        src1_val: rs1_val,
+        src2_val: rs2_val,
+        dst_val,
     }
-    let logs_without_ecall = &logs[..ecall_idx];
+}
 
-    let boundary = SegmentBoundary::initial();
-    let config = SegmentConfig::intermediate();
+fn make_instructions(logs: &[Log], instrs: &[Instruction]) -> U64HashMap<Instruction> {
+    let mut map = U64HashMap::default();
+    for (log, instr) in logs.iter().zip(instrs.iter()) {
+        map.insert(log.current_pc, *instr);
+    }
+    map
+}
 
-    let result = Traces::from_logs_segmented(logs_without_ecall, instructions, &boundary, &config)
-        .expect("Failed to generate segmented traces");
+fn append_ecall(logs: &mut Vec<Log>, instrs: &mut Vec<Instruction>) {
+    let last_pc = logs.last().map(|l| l.current_pc + 4).unwrap_or(0x1000);
+    logs.push(Log {
+        current_pc: last_pc,
+        next_pc: 0,
+        src1_val: 0,
+        src2_val: 0,
+        dst_val: 0,
+    });
+    instrs.push(Instruction::EcallEbreak);
+}
 
-    assert!(!result.is_final);
-    assert!(result.next_boundary.is_some());
+/// Build N ADD instructions followed by ECALL.
+fn make_test_program(n: usize) -> (Vec<Log>, U64HashMap<Instruction>) {
+    let mut logs: Vec<Log> = (0..n)
+        .map(|i| make_add_log(0x1000 + (i as u64) * 4, i as u64, i as u64, (i * 2) as u64))
+        .collect();
+    let mut instrs: Vec<Instruction> = (0..n)
+        .map(|_| Instruction::Arith {
+            dst: 1,
+            src1: 2,
+            src2: 3,
+            op: ArithOp::Add,
+        })
+        .collect();
+    append_ecall(&mut logs, &mut instrs);
+    let instructions = make_instructions(&logs, &instrs);
+    (logs, instructions)
+}
 
-    // Verify traces are generated
-    assert!(result.traces.cpu.main_table.height > 0);
-    assert!(result.traces.memw.main_table.height > 0);
+// =============================================================================
+// Single-segment tests
+// =============================================================================
+
+#[test]
+fn test_single_segment_when_trace_fits() {
+    let (logs, instructions) = make_test_program(5);
+
+    let results =
+        Traces::from_logs_segmented(&logs, instructions).expect("Failed to generate segments");
+
+    assert_eq!(results.len(), 1);
+    assert!(results[0].is_final);
+    assert_eq!(results[0].segment_index, 0);
+    assert!(results[0].traces.cpu.main_table.height > 0);
 }
 
 #[test]
-fn test_from_logs_segmented_with_state_continuity() {
-    // Test that state is properly captured and restored across segments
-    let (_elf, logs, instructions) = run_asm_elf("comprehensive_test");
+fn test_segmented_matches_unsegmented() {
+    let (logs, instructions) = make_test_program(10);
 
-    // Find ECALL position
-    let ecall_idx = match find_ecall_index(&logs, &instructions) {
-        Some(idx) => idx,
-        None => {
-            // No ECALL found, skip test
-            return;
-        }
-    };
+    let unsegmented = Traces::from_logs(&logs, instructions.clone()).expect("from_logs failed");
+    let segmented =
+        Traces::from_logs_segmented(&logs, instructions).expect("from_logs_segmented failed");
 
-    // Need at least 2 logs to split
-    if ecall_idx == 0 {
-        return;
-    }
-
-    // Split so ECALL is in the second segment
-    let first_half = &logs[..ecall_idx];
-    let second_half = &logs[ecall_idx..];
-
-    // Generate first segment (intermediate - no ECALL)
-    let boundary = SegmentBoundary::initial();
-    let config = SegmentConfig::intermediate();
-
-    let result1 = Traces::from_logs_segmented(first_half, instructions.clone(), &boundary, &config)
-        .expect("Failed to generate first segment");
-
-    assert!(!result1.is_final);
-    let next_boundary = result1.next_boundary.expect("Should have next boundary");
-
-    // Verify boundary state
-    assert_eq!(next_boundary.segment_index, 1);
+    assert_eq!(segmented.len(), 1);
     assert_eq!(
-        next_boundary.start_timestamp,
-        4 + (first_half.len() as u64) * 4
+        segmented[0].traces.cpu.main_table.height,
+        unsegmented.cpu.main_table.height
     );
-
-    // Generate second segment (final - contains ECALL)
-    let config = SegmentConfig::final_segment();
-
-    let result2 = Traces::from_logs_segmented(second_half, instructions, &next_boundary, &config)
-        .expect("Failed to generate second segment");
-
-    assert!(result2.is_final);
-    assert!(result2.next_boundary.is_none());
-}
-
-#[test]
-fn test_timestamp_continuity() {
-    // Verify timestamps are continuous across segments
-    let (_elf, logs, instructions) = run_asm_elf("arith_8");
-
-    if logs.len() < 4 {
-        return;
-    }
-
-    let split_point = logs.len() / 2;
-    let first_half = &logs[..split_point];
-
-    // Generate first segment (intermediate)
-    let boundary = SegmentBoundary::initial();
-    let config = SegmentConfig::intermediate();
-
-    let result = Traces::from_logs_segmented(first_half, instructions, &boundary, &config)
-        .expect("Failed to generate segment");
-
-    let next_boundary = result.next_boundary.expect("Should have next boundary");
-
-    // Expected end timestamp: start (4) + num_logs * 4
-    let expected_end_ts = 4 + (first_half.len() as u64) * 4;
-    assert_eq!(next_boundary.start_timestamp, expected_end_ts);
-}
-
-#[test]
-fn test_multi_segment_trace_generation() {
-    // Test generating traces across 3 segments
-    let (_elf, logs, instructions) = run_asm_elf("all_instructions_64");
-
-    // Find ECALL position
-    let ecall_idx = match find_ecall_index(&logs, &instructions) {
-        Some(idx) => idx,
-        None => return,
-    };
-
-    // Need at least 3 instructions before ECALL to split into 3 segments
-    if ecall_idx < 3 {
-        return;
-    }
-
-    // Split into 3 segments: [0..n/3], [n/3..ecall_idx], [ecall_idx..]
-    let first_end = ecall_idx / 3;
-    let second_end = ecall_idx;
-
-    let seg1_logs = &logs[..first_end];
-    let seg2_logs = &logs[first_end..second_end];
-    let seg3_logs = &logs[second_end..];
-
-    // Segment 1: intermediate
-    let boundary1 = SegmentBoundary::initial();
-    let result1 = Traces::from_logs_segmented(
-        seg1_logs,
-        instructions.clone(),
-        &boundary1,
-        &SegmentConfig::intermediate(),
-    )
-    .expect("Segment 1 failed");
-    assert!(!result1.is_final);
-    let boundary2 = result1.next_boundary.expect("Should have boundary");
-
-    // Segment 2: intermediate
-    let result2 = Traces::from_logs_segmented(
-        seg2_logs,
-        instructions.clone(),
-        &boundary2,
-        &SegmentConfig::intermediate(),
-    )
-    .expect("Segment 2 failed");
-    assert!(!result2.is_final);
-    let boundary3 = result2.next_boundary.expect("Should have boundary");
-
-    // Segment 3: final (contains ECALL)
-    let result3 = Traces::from_logs_segmented(
-        seg3_logs,
-        instructions,
-        &boundary3,
-        &SegmentConfig::final_segment(),
-    )
-    .expect("Segment 3 failed");
-    assert!(result3.is_final);
-    assert!(result3.next_boundary.is_none());
-
-    // Verify timestamp continuity
-    assert_eq!(boundary2.start_timestamp, 4 + (seg1_logs.len() as u64) * 4);
     assert_eq!(
-        boundary3.start_timestamp,
-        boundary2.start_timestamp + (seg2_logs.len() as u64) * 4
+        segmented[0].traces.memw.main_table.height,
+        unsegmented.memw.main_table.height
+    );
+    assert_eq!(
+        segmented[0].traces.lt.main_table.height,
+        unsegmented.lt.main_table.height
     );
 }
 
+// =============================================================================
+// Multi-segment tests
+// =============================================================================
+
 #[test]
-fn test_ecall_in_intermediate_segment_rejected() {
-    // Verify that an ECALL in an intermediate segment is rejected
-    let (_elf, logs, instructions) = run_asm_elf("sub");
+fn test_multi_segment_with_small_max_size() {
+    // 20 ADDs + 1 ECALL = 21 ops, max_size=4 → 6 segments
+    let (logs, instructions) = make_test_program(20);
 
-    // Find ECALL position
-    let ecall_idx = match find_ecall_index(&logs, &instructions) {
-        Some(idx) => idx,
-        None => return, // No ECALL, skip test
-    };
-
-    // Include the ECALL in the segment but mark it as intermediate
-    let logs_with_ecall = &logs[..=ecall_idx];
-
-    let boundary = SegmentBoundary::initial();
-    let config = SegmentConfig::intermediate(); // Wrong! ECALL should be in final segment
-
-    let result = Traces::from_logs_segmented(logs_with_ecall, instructions, &boundary, &config);
+    let results = Traces::from_logs_segmented_with_max_size(&logs, instructions, 4)
+        .expect("Failed to generate segments");
 
     assert!(
-        result.is_err(),
-        "Should reject ECALL in intermediate segment"
+        results.len() > 1,
+        "Expected multiple segments, got {}",
+        results.len()
     );
+
+    // Only the last segment should be final
+    for (i, result) in results.iter().enumerate() {
+        assert_eq!(result.segment_index, i);
+        if i < results.len() - 1 {
+            assert!(!result.is_final, "Segment {i} should not be final");
+        } else {
+            assert!(result.is_final, "Last segment should be final");
+        }
+    }
+
+    // All segments should have non-empty CPU traces
+    for (i, result) in results.iter().enumerate() {
+        assert!(
+            result.traces.cpu.main_table.height > 0,
+            "Segment {i} has empty CPU trace"
+        );
+    }
+}
+
+#[test]
+fn test_segment_cpu_row_counts() {
+    let max_size = 8;
+    // 30 ADDs + 1 ECALL = 31 ops
+    let (logs, instructions) = make_test_program(30);
+    let num_ops = logs.len(); // 31
+
+    let results = Traces::from_logs_segmented_with_max_size(&logs, instructions, max_size)
+        .expect("Failed to generate segments");
+
+    let expected_segments = num_ops.div_ceil(max_size);
+    assert_eq!(results.len(), expected_segments);
+}
+
+#[test]
+fn test_intermediate_segments_have_dummy_halt() {
+    // 16 ADDs + 1 ECALL = 17 ops, max_size=4 → 5 segments
+    let (logs, instructions) = make_test_program(16);
+
+    let results = Traces::from_logs_segmented_with_max_size(&logs, instructions, 4)
+        .expect("Failed to generate segments");
+
+    assert!(results.len() > 1);
+
+    // All segments should have halt trace height 1 (it's always a single-row table)
+    for result in &results {
+        assert_eq!(result.traces.halt.main_table.height, 1);
+    }
+}
+
+#[test]
+fn test_ecall_in_final_segment() {
+    // Verify ECALL naturally lands in the final segment
+    // 7 ADDs + 1 ECALL = 8 ops, max_size=3 → 3 segments: [0..3], [3..6], [6..8]
+    let (logs, instructions) = make_test_program(7);
+
+    let results = Traces::from_logs_segmented_with_max_size(&logs, instructions, 3)
+        .expect("Failed to generate segments");
+
+    assert_eq!(results.len(), 3);
+    assert!(results[2].is_final);
+    assert!(!results[0].is_final);
+    assert!(!results[1].is_final);
 }

--- a/prover/src/tests/segment_tests.rs
+++ b/prover/src/tests/segment_tests.rs
@@ -67,13 +67,20 @@ fn test_boundary_next() {
 #[test]
 fn test_from_logs_segmented_intermediate_segment() {
     // Test that from_logs_segmented works for an intermediate (non-final) segment
-    // Intermediate segments don't need an ECALL
+    // Intermediate segments must NOT contain an ECALL
     let (_elf, logs, instructions) = run_asm_elf("sub");
+
+    // Find ECALL and exclude it from intermediate segment
+    let ecall_idx = find_ecall_index(&logs, &instructions).unwrap_or(logs.len());
+    if ecall_idx == 0 {
+        return; // Can't test with only ECALL
+    }
+    let logs_without_ecall = &logs[..ecall_idx];
 
     let boundary = SegmentBoundary::initial();
     let config = SegmentConfig::intermediate();
 
-    let result = Traces::from_logs_segmented(&logs, instructions, &boundary, &config)
+    let result = Traces::from_logs_segmented(logs_without_ecall, instructions, &boundary, &config)
         .expect("Failed to generate segmented traces");
 
     assert!(!result.is_final);
@@ -223,5 +230,30 @@ fn test_multi_segment_trace_generation() {
     assert_eq!(
         boundary3.start_timestamp,
         boundary2.start_timestamp + (seg2_logs.len() as u64) * 4
+    );
+}
+
+#[test]
+fn test_ecall_in_intermediate_segment_rejected() {
+    // Verify that an ECALL in an intermediate segment is rejected
+    let (_elf, logs, instructions) = run_asm_elf("sub");
+
+    // Find ECALL position
+    let ecall_idx = match find_ecall_index(&logs, &instructions) {
+        Some(idx) => idx,
+        None => return, // No ECALL, skip test
+    };
+
+    // Include the ECALL in the segment but mark it as intermediate
+    let logs_with_ecall = &logs[..=ecall_idx];
+
+    let boundary = SegmentBoundary::initial();
+    let config = SegmentConfig::intermediate(); // Wrong! ECALL should be in final segment
+
+    let result = Traces::from_logs_segmented(logs_with_ecall, instructions, &boundary, &config);
+
+    assert!(
+        result.is_err(),
+        "Should reject ECALL in intermediate segment"
     );
 }


### PR DESCRIPTION
Adds infrastructure for splitting execution traces into segments when trace length exceeds limits.

## Changes

- `SegmentBoundary` struct for state continuity across segments (timestamps, memory, registers)
- `SegmentConfig` for segment-specific behavior (is_final flag)
- `Traces::from_logs_segmented()` for segmented trace generation
- `generate_dummy_halt_trace()` for non-final segments
- Validation to reject ECALL in intermediate segments (fails early instead of bus imbalance later)

## Memory model

- Traces (~200MB) can be freed after each segment is proved
- Only `SegmentBoundary` (KB) carried forward between segments
- Rust ownership handles this automatically

## Deferred

- Proving logic (each segment would re-prove static tables like BITWISE)
- Proof aggregation / cross-segment LogUp balance