### PR TITLE
fix(prover): Add signed to LOAD bus interaction signature

### DIFF
--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -1408,9 +1408,9 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
     ));
 
     // -------------------------------------------------------------------------
-    // M6: LOAD[rvd; base_address, timestamp, read2, read4, read8] | LOAD
+    // M6: LOAD[rvd; base_address, timestamp, read2, read4, read8, signed] | LOAD
     // -------------------------------------------------------------------------
-    // LOAD receiver expects: [res::DWordBL(2), base_address::DWordWL(2), timestamp::DWordWL(2), flags(3)] = 9 elements
+    // LOAD receiver expects: [res::DWordBL(2), base_address::DWordWL(2), timestamp::DWordWL(2), flags(3), signed(1)] = 10 elements
     //
     // For CPU LOAD:
     // - rvd (the loaded result) corresponds to res
@@ -1448,6 +1448,11 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
             },
             BusValue::Packed {
                 start_column: cols::MEMORY_8BYTES,
+                packing: Packing::Direct,
+            },
+            // signed flag
+            BusValue::Packed {
+                start_column: cols::SIGNED,
                 packing: Packing::Direct,
             },
         ],

--- a/prover/src/tables/load.rs
+++ b/prover/src/tables/load.rs
@@ -425,7 +425,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
     // -------------------------------------------------------------------------
     // LOAD receiver (from CPU)
     // -------------------------------------------------------------------------
-    // Spec: LOAD[res::DWordWL; base_address, timestamp, read2, read4, read8] | -μ
+    // Spec: LOAD[res::DWordWL; base_address, timestamp, read2, read4, read8, signed] | -μ
     //
     // res is DWordBL (8 bytes) but packed as DWordWL (2 words) for the bus.
     // DWordBL packing: 8 bytes → 2 bus elements [lo32, hi32]
@@ -459,6 +459,11 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
             },
             BusValue::Packed {
                 start_column: cols::READ8,
+                packing: Packing::Direct,
+            },
+            // signed flag
+            BusValue::Packed {
+                start_column: cols::SIGNED,
                 packing: Packing::Direct,
             },
         ],


### PR DESCRIPTION
  Aligns the LOAD bus interaction (LOAD-C9) with the spec update from #284, which added signed to the
  interaction input signature.

  Both sides of the BusId::Load interaction were missing the signed field:
  - load.rs: Added signed to the LOAD-C9 receiver
  - cpu.rs: Added signed to the CPU-CM51 sender