### PR TITLE
refactor(math): idiomatic Rust cleanup, bug fixes, and performance im…

### DIFF
--- a/crypto/math/src/elliptic_curve/short_weierstrass/point.rs
+++ b/crypto/math/src/elliptic_curve/short_weierstrass/point.rs
@@ -92,7 +92,7 @@ impl<E: IsShortWeierstrass> ShortWeierstrassProjectivePoint<E> {
         let [px, py, pz] = self.coordinates();
 
         let px_square = px * px;
-        let three_px_square = &px_square + &px_square + &px_square;
+        let three_px_square = px_square.double() + &px_square;
         let w = E::a() * pz * pz + three_px_square;
         let w_square = &w * &w;
 
@@ -293,45 +293,34 @@ where
     /// Serialize the points in the given format
     #[cfg(feature = "alloc")]
     pub fn serialize(&self, point_format: PointFormat, endianness: Endianness) -> Vec<u8> {
-        // TODO: Add more compact serialization formats
-        // Uncompressed affine / Compressed
-
-        let mut bytes: Vec<u8> = Vec::new();
-        let x_bytes: Vec<u8>;
-        let y_bytes: Vec<u8>;
-        let z_bytes: Vec<u8>;
-
         match point_format {
             PointFormat::Projective => {
                 let [x, y, z] = self.coordinates();
-                if endianness == Endianness::BigEndian {
-                    x_bytes = x.to_bytes_be();
-                    y_bytes = y.to_bytes_be();
-                    z_bytes = z.to_bytes_be();
+                let (x_bytes, y_bytes, z_bytes) = if endianness == Endianness::BigEndian {
+                    (x.to_bytes_be(), y.to_bytes_be(), z.to_bytes_be())
                 } else {
-                    x_bytes = x.to_bytes_le();
-                    y_bytes = y.to_bytes_le();
-                    z_bytes = z.to_bytes_le();
-                }
+                    (x.to_bytes_le(), y.to_bytes_le(), z.to_bytes_le())
+                };
+                let mut bytes = Vec::with_capacity(x_bytes.len() * 3);
                 bytes.extend(&x_bytes);
                 bytes.extend(&y_bytes);
                 bytes.extend(&z_bytes);
+                bytes
             }
             PointFormat::Uncompressed => {
                 let affine_representation = self.to_affine();
                 let [x, y, _z] = affine_representation.coordinates();
-                if endianness == Endianness::BigEndian {
-                    x_bytes = x.to_bytes_be();
-                    y_bytes = y.to_bytes_be();
+                let (x_bytes, y_bytes) = if endianness == Endianness::BigEndian {
+                    (x.to_bytes_be(), y.to_bytes_be())
                 } else {
-                    x_bytes = x.to_bytes_le();
-                    y_bytes = y.to_bytes_le();
-                }
+                    (x.to_bytes_le(), y.to_bytes_le())
+                };
+                let mut bytes = Vec::with_capacity(x_bytes.len() * 2);
                 bytes.extend(&x_bytes);
                 bytes.extend(&y_bytes);
+                bytes
             }
         }
-        bytes
     }
 
     pub fn deserialize(

--- a/crypto/math/src/elliptic_curve/short_weierstrass/traits.rs
+++ b/crypto/math/src/elliptic_curve/short_weierstrass/traits.rs
@@ -40,9 +40,10 @@ pub trait IsShortWeierstrass: IsEllipticCurve + Clone + Debug {
         y: &FieldElement<Self::BaseField>,
         z: &FieldElement<Self::BaseField>,
     ) -> FieldElement<Self::BaseField> {
-        y.square()
-            - ((x.square() + Self::a() * z.square().square()) * x
-                + Self::b() * z.square().square() * z.square())
+        let z2 = z.square();
+        let z4 = z2.square();
+        let z6 = &z4 * &z2;
+        y.square() - ((x.square() + Self::a() * &z4) * x + Self::b() * z6)
     }
 }
 

--- a/crypto/math/src/errors.rs
+++ b/crypto/math/src/errors.rs
@@ -34,8 +34,8 @@ pub enum PairingError {
 impl From<ByteConversionError> for DeserializationError {
     fn from(error: ByteConversionError) -> Self {
         match error {
-            ByteConversionError::FromBEBytesError => DeserializationError::FieldFromBytesError,
-            ByteConversionError::FromLEBytesError => DeserializationError::FieldFromBytesError,
+            ByteConversionError::FromBEBytesError
+            | ByteConversionError::FromLEBytesError => DeserializationError::FieldFromBytesError,
             _ => DeserializationError::InvalidValue,
         }
     }

--- a/crypto/math/src/fft/cpu/roots_of_unity.rs
+++ b/crypto/math/src/fft/cpu/roots_of_unity.rs
@@ -55,9 +55,13 @@ pub fn get_powers_of_primitive_root_coset<F: IsFFTField>(
     offset: &FieldElement<F>,
 ) -> Result<Vec<FieldElement<F>>, FFTError> {
     let root = F::get_primitive_root_of_unity(n)?;
-    let results = (0..count).map(|i| offset * root.pow(i));
-
-    Ok(results.collect())
+    let mut results = Vec::with_capacity(count);
+    results.extend((0..count).scan(offset.clone(), |state, _| {
+        let res = state.clone();
+        *state = &(*state) * &root;
+        Some(res)
+    }));
+    Ok(results)
 }
 
 /// Returns 2^`order` / 2 twiddle factors for FFT in some configuration `config`.

--- a/crypto/math/src/field/fields/fft_friendly/quartic_babybear_u32.rs
+++ b/crypto/math/src/field/fields/fft_friendly/quartic_babybear_u32.rs
@@ -252,7 +252,8 @@ impl ByteConversion for [FieldElement<Babybear31PrimeField>; 4] {
     where
         Self: Sized,
     {
-        const BYTES_PER_FIELD: usize = 32;
+        // Babybear31PrimeField uses U32MontgomeryBackendPrimeField = 4 bytes per element
+        const BYTES_PER_FIELD: usize = 4;
 
         let x0 = FieldElement::from_bytes_be(&bytes[0..BYTES_PER_FIELD])?;
         let x1 = FieldElement::from_bytes_be(&bytes[BYTES_PER_FIELD..BYTES_PER_FIELD * 2])?;
@@ -266,7 +267,8 @@ impl ByteConversion for [FieldElement<Babybear31PrimeField>; 4] {
     where
         Self: Sized,
     {
-        const BYTES_PER_FIELD: usize = 32;
+        // Babybear31PrimeField uses U32MontgomeryBackendPrimeField = 4 bytes per element
+        const BYTES_PER_FIELD: usize = 4;
 
         let x0 = FieldElement::from_bytes_le(&bytes[0..BYTES_PER_FIELD])?;
         let x1 = FieldElement::from_bytes_le(&bytes[BYTES_PER_FIELD..BYTES_PER_FIELD * 2])?;

--- a/crypto/math/src/field/fields/u32_montgomery_backend_prime_field.rs
+++ b/crypto/math/src/field/fields/u32_montgomery_backend_prime_field.rs
@@ -215,8 +215,6 @@ impl<const MODULUS: u32> IsPrimeField for U32MontgomeryBackendPrimeField<MODULUS
     }
 }
 
-impl<const MODULUS: u32> FieldElement<U32MontgomeryBackendPrimeField<MODULUS>> {}
-
 impl<const MODULUS: u32> ByteConversion for FieldElement<U32MontgomeryBackendPrimeField<MODULUS>> {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {

--- a/crypto/math/src/field/fields/u64_prime_field.rs
+++ b/crypto/math/src/field/fields/u64_prime_field.rs
@@ -32,7 +32,11 @@ impl<const MODULUS: u64> IsField for U64PrimeField<MODULUS> {
     }
 
     fn neg(a: &u64) -> u64 {
-        MODULUS - a
+        if *a == 0 {
+            0
+        } else {
+            MODULUS - (a % MODULUS)
+        }
     }
 
     fn mul(a: &u64, b: &u64) -> u64 {
@@ -88,16 +92,7 @@ impl<const MODULUS: u64> IsPrimeField for U64PrimeField<MODULUS> {
     }
 
     fn from_hex(hex_string: &str) -> Result<Self::BaseType, CreationError> {
-        let mut hex_string = hex_string;
-        // Remove 0x if it's on the string
-        let mut char_iterator = hex_string.chars();
-        if hex_string.len() > 2
-            && char_iterator.next().unwrap() == '0'
-            && char_iterator.next().unwrap() == 'x'
-        {
-            hex_string = &hex_string[2..];
-        }
-
+        let hex_string = hex_string.strip_prefix("0x").unwrap_or(hex_string);
         u64::from_str_radix(hex_string, 16).map_err(|_| CreationError::InvalidHexString)
     }
 

--- a/crypto/math/src/helpers.rs
+++ b/crypto/math/src/helpers.rs
@@ -1,15 +1,6 @@
 #[cfg(feature = "alloc")]
 use crate::field::{element::FieldElement, traits::IsFFTField};
 
-/// Computes the power of two that is equal or greater than n
-pub fn next_power_of_two(n: u64) -> u64 {
-    if n <= 1 {
-        1
-    } else {
-        (u64::MAX >> (n - 1).leading_zeros()) + 1
-    }
-}
-
 /// Pads the trace table with zeros until the length of the columns of the trace
 /// is equal to a power of 2
 /// This is required to ensure that we can use the radix-2 Cooley-Tukey FFT algorithm
@@ -18,10 +9,7 @@ pub fn resize_to_next_power_of_two<F: IsFFTField>(
     trace_colums: &mut [alloc::vec::Vec<FieldElement<F>>],
 ) {
     trace_colums.iter_mut().for_each(|col| {
-        // TODO: Remove this unwrap. This may panic if the usize cant be
-        // casted into a u64.
-        let col_len = col.len().try_into().unwrap();
-        let next_power_of_two_len = next_power_of_two(col_len);
-        col.resize(next_power_of_two_len as usize, FieldElement::<F>::zero())
+        let next_power_of_two_len = col.len().next_power_of_two();
+        col.resize(next_power_of_two_len, FieldElement::<F>::zero())
     })
 }

--- a/crypto/math/src/polynomial/dense_multilinear_poly.rs
+++ b/crypto/math/src/polynomial/dense_multilinear_poly.rs
@@ -42,7 +42,7 @@ where
     }
 
     /// Returns a reference to the evaluations vector.
-    pub fn evals(&self) -> &Vec<FieldElement<F>> {
+    pub fn evals(&self) -> &[FieldElement<F>] {
         &self.evals
     }
 
@@ -172,12 +172,13 @@ where
     /// Merges a series of DenseMultilinearPolynomials into one polynomial.
     /// Zero-pads the final merged polynomial to the next power-of-two length if necessary.
     pub fn merge(polys: &[DenseMultilinearPolynomial<F>]) -> DenseMultilinearPolynomial<F> {
-        // TODO (performance): pre-allocate vector to avoid repeated resizing.
-        let mut z: Vec<FieldElement<F>> = Vec::new();
+        let total: usize = polys.iter().map(|p| p.len()).sum();
+        let capacity = total.next_power_of_two();
+        let mut z: Vec<FieldElement<F>> = Vec::with_capacity(capacity);
         for poly in polys {
             z.extend(poly.evals.iter().cloned());
         }
-        z.resize(z.len().next_power_of_two(), FieldElement::zero());
+        z.resize(capacity, FieldElement::zero());
         DenseMultilinearPolynomial::new(z)
     }
 

--- a/crypto/math/src/polynomial/mod.rs
+++ b/crypto/math/src/polynomial/mod.rs
@@ -17,15 +17,12 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
     /// Creates a new polynomial with the given coefficients
     pub fn new(coefficients: &[FieldElement<F>]) -> Self {
         // Removes trailing zero coefficients at the end
-        let mut unpadded_coefficients = coefficients
+        let end = coefficients
             .iter()
-            .rev()
-            .skip_while(|x| **x == FieldElement::zero())
-            .cloned()
-            .collect::<Vec<FieldElement<F>>>();
-        unpadded_coefficients.reverse();
+            .rposition(|x| *x != FieldElement::zero())
+            .map_or(0, |i| i + 1);
         Polynomial {
-            coefficients: unpadded_coefficients,
+            coefficients: coefficients[..end].to_vec(),
         }
     }
 
@@ -124,11 +121,10 @@ impl<F: IsField> Polynomial<FieldElement<F>> {
 
     /// Returns the coefficient accompanying x^degree
     pub fn leading_coefficient(&self) -> FieldElement<F> {
-        if let Some(coefficient) = self.coefficients.last() {
-            coefficient.clone()
-        } else {
-            FieldElement::zero()
-        }
+        self.coefficients
+            .last()
+            .cloned()
+            .unwrap_or_else(FieldElement::zero)
     }
 
     /// Returns coefficients of the polynomial as an array

--- a/crypto/math/src/polynomial/sparse_multilinear_poly.rs
+++ b/crypto/math/src/polynomial/sparse_multilinear_poly.rs
@@ -32,7 +32,6 @@ where
     /// Chi is the Lagrange basis polynomial evaluated at r
     /// a indicates the binary decomposition of the index of the Lagrange basis polynomial
     fn compute_chi(a: &[bool], r: &[FieldElement<F>]) -> Result<FieldElement<F>, MultilinearError> {
-        assert_eq!(a.len(), r.len());
         if a.len() != r.len() {
             return Err(MultilinearError::ChisAndEvalsLengthMismatch(
                 a.len(),
@@ -40,11 +39,11 @@ where
             ));
         }
         let mut chi_i = FieldElement::one();
-        for j in 0..r.len() {
-            if a[j] {
-                chi_i *= &r[j];
+        for (aj, rj) in a.iter().zip(r.iter()) {
+            if *aj {
+                chi_i *= rj;
             } else {
-                chi_i *= FieldElement::<F>::one() - &r[j];
+                chi_i *= FieldElement::<F>::one() - rj;
             }
         }
         Ok(chi_i)
@@ -89,7 +88,6 @@ where
         evals: &[(usize, FieldElement<F>)],
         r: &[FieldElement<F>],
     ) -> Result<FieldElement<F>, MultilinearError> {
-        assert_eq!(num_vars, r.len());
         if r.len() != num_vars {
             return Err(MultilinearError::IncorrectNumberofEvaluationPoints(
                 r.len(),

--- a/crypto/math/src/unsigned_integer/montgomery.rs
+++ b/crypto/math/src/unsigned_integer/montgomery.rs
@@ -54,13 +54,13 @@ impl MontgomeryAlgorithms {
                 j -= 1;
                 cs = t[j] as u128 + m * (q.limbs[j] as u128) + c;
                 c = cs >> 64;
-                t[j + 1] = ((cs << 64) >> 64) as u64;
+                t[j + 1] = cs as u64;
             }
 
             // (C,t[0]) := t_extra[1] + C
             cs = (t_extra[1] as u128) + c;
             c = cs >> 64;
-            t[0] = ((cs << 64) >> 64) as u64;
+            t[0] = cs as u64;
 
             // t_extra[1] := t_extra[0] + C
             t_extra[1] = t_extra[0] + c as u64;
@@ -125,12 +125,12 @@ impl MontgomeryAlgorithms {
                 j -= 1;
                 cs = t[j] as u128 + m * (q.limbs[j] as u128) + c;
                 c = cs >> 64;
-                t[j + 1] = ((cs << 64) >> 64) as u64;
+                t[j + 1] = cs as u64;
             }
 
             // (C,t[0]) := t_extra + C
             cs = (t_extra as u128) + c;
-            t[0] = ((cs << 64) >> 64) as u64;
+            t[0] = cs as u64;
         }
         let mut result = UnsignedInteger { limbs: t };
 


### PR DESCRIPTION
…provements

Fix two correctness bugs:
- quartic_babybear_u32: BYTES_PER_FIELD was 32 instead of 4 in ByteConversion for [FE;4], causing out-of-bounds reads on deserialization
- u64_prime_field: neg(0) returned MODULUS instead of 0 (non-canonical)

Simplify code:
- Remove custom next_power_of_two, use std usize::next_power_of_two()
- Replace manual hex prefix parsing with strip_prefix("0x")
- Polynomial::new: single-pass rposition instead of double reverse
- leading_coefficient: use .cloned().unwrap_or_else()
- Merge duplicate match arms in errors.rs with | pattern
- Remove dead assert_eq before graceful error returns in sparse_multilinear
- Replace index loops with zip iterators
- Return &[T] instead of &Vec<T> from evals()
- Remove empty impl block in u32_montgomery_backend

Improve performance:
- get_powers_of_primitive_root_coset: O(n) successive mul instead of O(n log n) pow(i)
- Montgomery: remove redundant ((cs << 64) >> 64) bit masking (u128→u64 truncates)
- Cache z.square() intermediates in defining_equation_jacobian (saves 2-3 field muls)
- Use double()+add for 3*px^2 in EC point doubling
- Pre-allocate Vec in point serialization and multilinear merge()