### PR TITLE
Remove SecurityLevel enum and security presets

### DIFF
--- a/bin/cli/README.md
+++ b/bin/cli/README.md
@@ -27,22 +27,8 @@ See [Guest Program Flamegraphs](#guest-program-flamegraphs) for profiling execut
 Generate a STARK proof for a RISC-V ELF program execution.
 
 ```bash
-# Generate proof with default security (standard)
 cargo run -p cli --release -- prove <PROGRAM.elf> -o proof.cbor
-
-# Generate proof with specific security level
-cargo run -p cli --release -- prove <PROGRAM.elf> -o proof.cbor --security fast
-cargo run -p cli --release -- prove <PROGRAM.elf> -o proof.cbor --security standard
-cargo run -p cli --release -- prove <PROGRAM.elf> -o proof.cbor --security maximum
 ```
-
-#### Security Levels
-
-| Level | Security | FRI Queries | Use Case |
-|-------|----------|-------------|----------|
-| `fast` | Conjecturable 100-bit | 41 | Development, testing, iteration |
-| `standard` | Provable 100-bit | 104 | Production (default) |
-| `maximum` | Provable 128-bit | 140 | High-value applications |
 
 ### Verify
 
@@ -74,7 +60,7 @@ make compile-programs-asm
 cargo run -p cli --release -- execute executor/program_artifacts/asm/add.elf
 
 # Generate and verify a proof
-cargo run -p cli --release -- prove executor/program_artifacts/asm/add.elf -o /tmp/proof.cbor --security fast
+cargo run -p cli --release -- prove executor/program_artifacts/asm/add.elf -o /tmp/proof.cbor
 cargo run -p cli --release -- verify /tmp/proof.cbor executor/program_artifacts/asm/add.elf
 ```
 

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -170,7 +170,13 @@ fn cmd_prove(elf_path: PathBuf, output_path: PathBuf) -> ExitCode {
     };
 
     let elf_hash: [u8; 32] = Sha3_256::digest(&elf_data).into();
-    let proof_options = ProofOptions::default_test_options();
+    // Provable 100-bit security.
+    let proof_options = ProofOptions {
+        blowup_factor: 4,
+        fri_number_of_queries: 104,
+        coset_offset: 3,
+        grinding_factor: 20,
+    };
 
     eprintln!("Generating proof (this may take a while)...");
     let multi_proof = match prover::prove_with_options(&elf_data, &proof_options) {

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -264,14 +264,13 @@ fn cmd_verify(proof_path: PathBuf, elf_path: PathBuf) -> ExitCode {
     eprintln!("  Version: {}", bundle.metadata.version);
     eprintln!("  ELF hash: {}", truncated_hex(&bundle.metadata.elf_hash));
     eprintln!("Verifying proof...");
-    let result =
-        match prover::verify(&bundle.multi_proof, &elf_data, &bundle.proof_options) {
-            Ok(valid) => valid,
-            Err(e) => {
-                eprintln!("Verification error: {}", e);
-                return ExitCode::FAILURE;
-            }
-        };
+    let result = match prover::verify(&bundle.multi_proof, &elf_data, &bundle.proof_options) {
+        Ok(valid) => valid,
+        Err(e) => {
+            eprintln!("Verification error: {}", e);
+            return ExitCode::FAILURE;
+        }
+    };
 
     if result {
         eprintln!("Verification succeeded!");

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -179,7 +179,7 @@ fn cmd_prove(elf_path: PathBuf, output_path: PathBuf) -> ExitCode {
     };
 
     eprintln!("Generating proof (this may take a while)...");
-    let multi_proof = match prover::prove_with_options(&elf_data, &proof_options) {
+    let multi_proof = match prover::prove(&elf_data, &proof_options) {
         Ok(proof) => proof,
         Err(e) => {
             eprintln!("Proof generation failed: {}", e);
@@ -253,7 +253,7 @@ fn cmd_verify(proof_path: PathBuf, elf_path: PathBuf) -> ExitCode {
     }
 
     // Detect wrong ELF early with a clear error message.
-    // The cryptographic binding happens inside verify_with_options via the DECODE table.
+    // The cryptographic binding happens inside verify via the DECODE table.
     let elf_hash: [u8; 32] = Sha3_256::digest(&elf_data).into();
     if elf_hash != bundle.metadata.elf_hash {
         eprintln!("ELF hash mismatch: the proof was generated for a different program");
@@ -265,7 +265,7 @@ fn cmd_verify(proof_path: PathBuf, elf_path: PathBuf) -> ExitCode {
     eprintln!("  ELF hash: {}", truncated_hex(&bundle.metadata.elf_hash));
     eprintln!("Verifying proof...");
     let result =
-        match prover::verify_with_options(&bundle.multi_proof, &elf_data, &bundle.proof_options) {
+        match prover::verify(&bundle.multi_proof, &elf_data, &bundle.proof_options) {
             Ok(valid) => valid,
             Err(e) => {
                 eprintln!("Verification error: {}", e);

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -7,14 +7,14 @@ use std::io::{BufReader, BufWriter, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use clap::{Parser, Subcommand, ValueEnum, ValueHint};
+use clap::{Parser, Subcommand, ValueHint};
 use executor::{
     elf::{Elf, SymbolTable},
     flamegraph::FlamegraphGenerator,
     vm::execution::Executor,
 };
 use sha3::{Digest, Sha3_256};
-use stark::proof::options::{ProofOptions, SecurityLevel};
+use stark::proof::options::ProofOptions;
 
 use proof_bundle::{PROOF_BUNDLE_VERSION, ProofBundle};
 
@@ -51,10 +51,6 @@ enum Commands {
         /// Output path for the proof bundle
         #[arg(short, long, value_hint = ValueHint::FilePath)]
         output: PathBuf,
-
-        /// Security level preset
-        #[arg(long, value_enum, default_value = "standard")]
-        security: SecurityPreset,
     },
 
     /// Verify a proof bundle
@@ -69,43 +65,12 @@ enum Commands {
     },
 }
 
-#[derive(Clone, Copy, ValueEnum)]
-enum SecurityPreset {
-    /// Conjecturable 100-bit security (development)
-    Fast,
-    /// Provable 100-bit security (default)
-    Standard,
-    /// Provable 128-bit security (production)
-    Maximum,
-}
-
-impl SecurityPreset {
-    fn to_proof_options(self) -> ProofOptions {
-        const COSET_OFFSET: u64 = 3;
-        match self {
-            SecurityPreset::Fast => {
-                ProofOptions::new_secure(SecurityLevel::Conjecturable100Bits, COSET_OFFSET)
-            }
-            SecurityPreset::Standard => {
-                ProofOptions::new_secure(SecurityLevel::Provable100Bits, COSET_OFFSET)
-            }
-            SecurityPreset::Maximum => {
-                ProofOptions::new_secure(SecurityLevel::Provable128Bits, COSET_OFFSET)
-            }
-        }
-    }
-}
-
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
     match cli.command {
         Commands::Execute { elf, flamegraph } => cmd_execute(elf, flamegraph),
-        Commands::Prove {
-            elf,
-            output,
-            security,
-        } => cmd_prove(elf, output, security),
+        Commands::Prove { elf, output } => cmd_prove(elf, output),
         Commands::Verify { proof, elf } => cmd_verify(proof, elf),
     }
 }
@@ -194,7 +159,7 @@ fn cmd_execute(elf_path: PathBuf, flamegraph_path: Option<PathBuf>) -> ExitCode 
     ExitCode::SUCCESS
 }
 
-fn cmd_prove(elf_path: PathBuf, output_path: PathBuf, security: SecurityPreset) -> ExitCode {
+fn cmd_prove(elf_path: PathBuf, output_path: PathBuf) -> ExitCode {
     eprintln!("Reading ELF file...");
     let elf_data = match std::fs::read(&elf_path) {
         Ok(data) => data,
@@ -205,7 +170,7 @@ fn cmd_prove(elf_path: PathBuf, output_path: PathBuf, security: SecurityPreset) 
     };
 
     let elf_hash: [u8; 32] = Sha3_256::digest(&elf_data).into();
-    let proof_options = security.to_proof_options();
+    let proof_options = ProofOptions::default_test_options();
 
     eprintln!("Generating proof (this may take a while)...");
     let multi_proof = match prover::prove_with_options(&elf_data, &proof_options) {

--- a/crypto/stark/src/proof/options.rs
+++ b/crypto/stark/src/proof/options.rs
@@ -4,15 +4,6 @@ use math::field::traits::IsPrimeField;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
-pub enum SecurityLevel {
-    Conjecturable80Bits,
-    Conjecturable100Bits,
-    Conjecturable128Bits,
-    Provable80Bits,
-    Provable100Bits,
-    Provable128Bits,
-}
-
 /// The options for the proof
 ///
 /// - `blowup_factor`: the blowup factor for the trace
@@ -33,48 +24,6 @@ impl ProofOptions {
     const EXTENSION_DEGREE: usize = 1;
     // Estimated maximum domain size. 2^40 = 1 TB
     const NUM_BITS_MAX_DOMAIN_SIZE: usize = 40;
-
-    /// See section 5.10.1 of https://eprint.iacr.org/2021/582.pdf
-    pub fn new_secure(security_level: SecurityLevel, coset_offset: u64) -> Self {
-        match security_level {
-            SecurityLevel::Conjecturable80Bits => ProofOptions {
-                blowup_factor: 4,
-                fri_number_of_queries: 31,
-                coset_offset,
-                grinding_factor: 20,
-            },
-            SecurityLevel::Conjecturable100Bits => ProofOptions {
-                blowup_factor: 4,
-                fri_number_of_queries: 41,
-                coset_offset,
-                grinding_factor: 20,
-            },
-            SecurityLevel::Conjecturable128Bits => ProofOptions {
-                blowup_factor: 4,
-                fri_number_of_queries: 55,
-                coset_offset,
-                grinding_factor: 20,
-            },
-            SecurityLevel::Provable80Bits => ProofOptions {
-                blowup_factor: 4,
-                fri_number_of_queries: 80,
-                coset_offset,
-                grinding_factor: 20,
-            },
-            SecurityLevel::Provable100Bits => ProofOptions {
-                blowup_factor: 4,
-                fri_number_of_queries: 104,
-                coset_offset,
-                grinding_factor: 20,
-            },
-            SecurityLevel::Provable128Bits => ProofOptions {
-                blowup_factor: 4,
-                fri_number_of_queries: 140,
-                coset_offset,
-                grinding_factor: 20,
-            },
-        }
-    }
 
     /// Checks security of proof options given 128 bits of security
     pub fn new_with_checked_security<F: IsPrimeField>(
@@ -160,67 +109,53 @@ mod tests {
         fft_friendly::stark_252_prime_field::Stark252PrimeField, u64_prime_field::F17,
     };
 
-    use crate::proof::{errors::InsecureOptionError, options::SecurityLevel};
+    use crate::proof::errors::InsecureOptionError;
 
     use super::ProofOptions;
 
+    const BLOWUP_FACTOR: u8 = 4;
+    const COSET_OFFSET: u64 = 1;
+    const GRINDING_FACTOR: u8 = 20;
+
+    // FRI queries needed per security level (conjecturable).
+    // See section 5.10.1 of https://eprint.iacr.org/2021/582.pdf
+    const FRI_QUERIES_80_BITS: usize = 31;
+    const FRI_QUERIES_100_BITS: usize = 41;
+    const FRI_QUERIES_128_BITS: usize = 55;
+
     #[test]
     fn u64_prime_field_is_not_large_enough_to_be_secure() {
-        let ProofOptions {
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
-        } = ProofOptions::new_secure(SecurityLevel::Conjecturable128Bits, 1);
-
         let u64_options = ProofOptions::new_with_checked_security::<F17>(
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
+            BLOWUP_FACTOR,
+            FRI_QUERIES_128_BITS,
+            COSET_OFFSET,
+            GRINDING_FACTOR,
             128,
         );
-
         assert!(matches!(u64_options, Err(InsecureOptionError::FieldSize)));
     }
 
     #[test]
-    fn generated_stark_proof_options_for_128_bits_are_secure() {
-        let ProofOptions {
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
-        } = ProofOptions::new_secure(SecurityLevel::Conjecturable128Bits, 1);
-
+    fn conjecturable_128_bits_are_secure() {
         let secure_options = ProofOptions::new_with_checked_security::<Stark252PrimeField>(
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
+            BLOWUP_FACTOR,
+            FRI_QUERIES_128_BITS,
+            COSET_OFFSET,
+            GRINDING_FACTOR,
             128,
         );
-
         assert!(secure_options.is_ok());
     }
 
     #[test]
-    fn generated_proof_options_for_128_bits_with_one_fri_query_less_are_insecure() {
-        let ProofOptions {
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
-        } = ProofOptions::new_secure(SecurityLevel::Conjecturable128Bits, 1);
-
+    fn conjecturable_128_bits_with_one_fri_query_less_are_insecure() {
         let insecure_options = ProofOptions::new_with_checked_security::<Stark252PrimeField>(
-            blowup_factor,
-            fri_number_of_queries - 1,
-            coset_offset,
-            grinding_factor,
+            BLOWUP_FACTOR,
+            FRI_QUERIES_128_BITS - 1,
+            COSET_OFFSET,
+            GRINDING_FACTOR,
             128,
         );
-
         assert!(matches!(
             insecure_options,
             Err(InsecureOptionError::LowSecurityBits)
@@ -228,42 +163,26 @@ mod tests {
     }
 
     #[test]
-    fn generated_stark_proof_options_for_100_bits_are_secure_for_100_target_bits() {
-        let ProofOptions {
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
-        } = ProofOptions::new_secure(SecurityLevel::Conjecturable100Bits, 1);
-
+    fn conjecturable_100_bits_are_secure() {
         let secure_options = ProofOptions::new_with_checked_security::<Stark252PrimeField>(
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
+            BLOWUP_FACTOR,
+            FRI_QUERIES_100_BITS,
+            COSET_OFFSET,
+            GRINDING_FACTOR,
             100,
         );
-
         assert!(secure_options.is_ok());
     }
 
     #[test]
-    fn generated_stark_proof_options_for_80_bits_are_secure_for_80_target_bits() {
-        let ProofOptions {
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
-        } = ProofOptions::new_secure(SecurityLevel::Conjecturable80Bits, 1);
-
+    fn conjecturable_80_bits_are_secure() {
         let secure_options = ProofOptions::new_with_checked_security::<Stark252PrimeField>(
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
+            BLOWUP_FACTOR,
+            FRI_QUERIES_80_BITS,
+            COSET_OFFSET,
+            GRINDING_FACTOR,
             80,
         );
-
         assert!(secure_options.is_ok());
     }
 }

--- a/prover/benches/vm_prover_benchmark.rs
+++ b/prover/benches/vm_prover_benchmark.rs
@@ -52,9 +52,7 @@ fn bench_verify(c: &mut Criterion, config: &BenchConfig) {
     c.bench_with_input(
         BenchmarkId::new("vm_prover/verify", config.name),
         &proof,
-        |b, proof| {
-            b.iter(|| lambda_vm_prover::verify(proof, &elf_bytes, &proof_options).unwrap())
-        },
+        |b, proof| b.iter(|| lambda_vm_prover::verify(proof, &elf_bytes, &proof_options).unwrap()),
     );
 }
 

--- a/prover/benches/vm_prover_benchmark.rs
+++ b/prover/benches/vm_prover_benchmark.rs
@@ -8,6 +8,7 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
 use lambda_vm_prover::test_utils::asm_elf_bytes;
+use stark::proof::options::ProofOptions;
 
 /// Configuration for a benchmark case
 struct BenchConfig {
@@ -33,34 +34,41 @@ const CONFIGS: &[BenchConfig] = &[
 /// Benchmark prove (ELF execution + trace generation + proving)
 fn bench_prove(c: &mut Criterion, config: &BenchConfig) {
     let elf_bytes = asm_elf_bytes(config.elf_name);
+    let proof_options = ProofOptions::default_test_options();
 
     c.bench_with_input(
         BenchmarkId::new("vm_prover/prove", config.name),
         config,
-        |b, _config| b.iter(|| lambda_vm_prover::prove(&elf_bytes).unwrap()),
+        |b, _config| b.iter(|| lambda_vm_prover::prove(&elf_bytes, &proof_options).unwrap()),
     );
 }
 
 /// Benchmark verify only (proof pre-generated)
 fn bench_verify(c: &mut Criterion, config: &BenchConfig) {
     let elf_bytes = asm_elf_bytes(config.elf_name);
-    let proof = lambda_vm_prover::prove(&elf_bytes).unwrap();
+    let proof_options = ProofOptions::default_test_options();
+    let proof = lambda_vm_prover::prove(&elf_bytes, &proof_options).unwrap();
 
     c.bench_with_input(
         BenchmarkId::new("vm_prover/verify", config.name),
         &proof,
-        |b, proof| b.iter(|| lambda_vm_prover::verify(proof, &elf_bytes).unwrap()),
+        |b, proof| {
+            b.iter(|| lambda_vm_prover::verify(proof, &elf_bytes, &proof_options).unwrap())
+        },
     );
 }
 
 /// Benchmark full pipeline (prove + verify)
 fn bench_prove_and_verify(c: &mut Criterion, config: &BenchConfig) {
     let elf_bytes = asm_elf_bytes(config.elf_name);
+    let proof_options = ProofOptions::default_test_options();
 
     c.bench_with_input(
         BenchmarkId::new("vm_prover/prove_and_verify", config.name),
         config,
-        |b, _config| b.iter(|| lambda_vm_prover::prove_and_verify(&elf_bytes).unwrap()),
+        |b, _config| {
+            b.iter(|| lambda_vm_prover::prove_and_verify(&elf_bytes, &proof_options).unwrap())
+        },
     );
 }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -6,8 +6,9 @@
 //! # Example
 //! ```ignore
 //! let elf_bytes = std::fs::read("program.elf").unwrap();
-//! let proof = lambda_vm_prover::prove(&elf_bytes).unwrap();
-//! assert!(lambda_vm_prover::verify(&proof, &elf_bytes).unwrap());
+//! let options = stark::proof::options::ProofOptions::default_test_options();
+//! let proof = lambda_vm_prover::prove(&elf_bytes, &options).unwrap();
+//! assert!(lambda_vm_prover::verify(&proof, &elf_bytes, &options).unwrap());
 //! ```
 
 #[cfg(feature = "dhat-heap")]
@@ -166,12 +167,7 @@ impl VmAirs {
 }
 
 /// Prove an ELF binary execution. Returns a serializable proof.
-pub fn prove(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
-    prove_with_options(elf_bytes, &ProofOptions::default_test_options())
-}
-
-/// Prove an ELF binary execution with custom proof options.
-pub fn prove_with_options(
+pub fn prove(
     elf_bytes: &[u8],
     proof_options: &ProofOptions,
 ) -> Result<MultiProof<F, E, ()>, Error> {
@@ -192,12 +188,7 @@ pub fn prove_with_options(
 }
 
 /// Verify a proof produced by [`prove`].
-pub fn verify(proof: &MultiProof<F, E, ()>, elf_bytes: &[u8]) -> Result<bool, Error> {
-    verify_with_options(proof, elf_bytes, &ProofOptions::default_test_options())
-}
-
-/// Verify a proof with custom proof options.
-pub fn verify_with_options(
+pub fn verify(
     proof: &MultiProof<F, E, ()>,
     elf_bytes: &[u8],
     proof_options: &ProofOptions,
@@ -213,7 +204,7 @@ pub fn verify_with_options(
 }
 
 /// Prove and verify in one call (convenience).
-pub fn prove_and_verify(elf_bytes: &[u8]) -> Result<bool, Error> {
-    let proof = prove(elf_bytes)?;
-    verify(&proof, elf_bytes)
+pub fn prove_and_verify(elf_bytes: &[u8], proof_options: &ProofOptions) -> Result<bool, Error> {
+    let proof = prove(elf_bytes, proof_options)?;
+    verify(&proof, elf_bytes, proof_options)
 }

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -529,7 +529,9 @@ fn test_prove_elfs_all_instructions_64_full() {
     let _ = env_logger::builder().is_test(true).try_init();
 
     let elf_bytes = crate::test_utils::asm_elf_bytes("all_instructions_64");
-    let result = crate::prove_and_verify(&elf_bytes).expect("prove_and_verify failed");
+    let proof_options = ProofOptions::default_test_options();
+    let result =
+        crate::prove_and_verify(&elf_bytes, &proof_options).expect("prove_and_verify failed");
     assert!(
         result,
         "all_instructions_64_full failed - comprehensive test with full bitwise table"


### PR DESCRIPTION
- Remove `SecurityLevel` enum and `ProofOptions::new_secure` from the stark crate.
- Remove `SecurityPreset` enum from the CLI. Hardcode provable 100-bit security options.
- Remove `prove_with_options` and `verify_with_options`. `prove`, `verify`, and `prove_and_verify` now take `&ProofOptions` directly.