### PR TITLE
Remove proof_options from prove/verify API

### DIFF
--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -14,7 +14,6 @@ use executor::{
     vm::execution::Executor,
 };
 use sha3::{Digest, Sha3_256};
-use stark::proof::options::ProofOptions;
 
 use proof_bundle::{PROOF_BUNDLE_VERSION, ProofBundle};
 
@@ -170,16 +169,9 @@ fn cmd_prove(elf_path: PathBuf, output_path: PathBuf) -> ExitCode {
     };
 
     let elf_hash: [u8; 32] = Sha3_256::digest(&elf_data).into();
-    // Provable 100-bit security.
-    let proof_options = ProofOptions {
-        blowup_factor: 4,
-        fri_number_of_queries: 104,
-        coset_offset: 3,
-        grinding_factor: 20,
-    };
 
     eprintln!("Generating proof (this may take a while)...");
-    let multi_proof = match prover::prove(&elf_data, &proof_options) {
+    let multi_proof = match prover::prove(&elf_data) {
         Ok(proof) => proof,
         Err(e) => {
             eprintln!("Proof generation failed: {}", e);
@@ -187,7 +179,7 @@ fn cmd_prove(elf_path: PathBuf, output_path: PathBuf) -> ExitCode {
         }
     };
 
-    let bundle = ProofBundle::new(multi_proof, proof_options, elf_hash);
+    let bundle = ProofBundle::new(multi_proof, elf_hash);
 
     eprintln!("Writing proof bundle...");
     let file = match File::create(&output_path) {
@@ -264,7 +256,7 @@ fn cmd_verify(proof_path: PathBuf, elf_path: PathBuf) -> ExitCode {
     eprintln!("  Version: {}", bundle.metadata.version);
     eprintln!("  ELF hash: {}", truncated_hex(&bundle.metadata.elf_hash));
     eprintln!("Verifying proof...");
-    let result = match prover::verify(&bundle.multi_proof, &elf_data, &bundle.proof_options) {
+    let result = match prover::verify(&bundle.multi_proof, &elf_data) {
         Ok(valid) => valid,
         Err(e) => {
             eprintln!("Verification error: {}", e);

--- a/bin/cli/src/proof_bundle.rs
+++ b/bin/cli/src/proof_bundle.rs
@@ -2,7 +2,6 @@
 
 use prover::tables::types::{GoldilocksExtension, GoldilocksField};
 use serde::{Deserialize, Serialize};
-use stark::proof::options::ProofOptions;
 use stark::proof::stark::MultiProof;
 
 /// Current version of the proof bundle format.
@@ -18,19 +17,16 @@ pub struct ProofMetadata {
 #[serde(bound = "")]
 pub struct ProofBundle {
     pub multi_proof: MultiProof<GoldilocksField, GoldilocksExtension, ()>,
-    pub proof_options: ProofOptions,
     pub metadata: ProofMetadata,
 }
 
 impl ProofBundle {
     pub fn new(
         multi_proof: MultiProof<GoldilocksField, GoldilocksExtension, ()>,
-        proof_options: ProofOptions,
         elf_hash: [u8; 32],
     ) -> Self {
         Self {
             multi_proof,
-            proof_options,
             metadata: ProofMetadata {
                 version: PROOF_BUNDLE_VERSION,
                 elf_hash,

--- a/crypto/stark/src/proof/options.rs
+++ b/crypto/stark/src/proof/options.rs
@@ -90,16 +90,6 @@ impl ProofOptions {
 
         Ok(())
     }
-
-    /// Insecure proof options for fast tests only. Never use in production.
-    pub fn default_test_options() -> Self {
-        Self {
-            blowup_factor: 4,
-            fri_number_of_queries: 3,
-            coset_offset: 3,
-            grinding_factor: 1,
-        }
-    }
 }
 
 /// Production-secure defaults (100-bit provable security).

--- a/crypto/stark/src/proof/options.rs
+++ b/crypto/stark/src/proof/options.rs
@@ -91,14 +91,25 @@ impl ProofOptions {
         Ok(())
     }
 
-    /// Default proof options used for testing purposes.
-    /// These options should never be used in production.
+    /// Insecure proof options for fast tests only. Never use in production.
     pub fn default_test_options() -> Self {
         Self {
             blowup_factor: 4,
             fri_number_of_queries: 3,
             coset_offset: 3,
             grinding_factor: 1,
+        }
+    }
+}
+
+/// Production-secure defaults (100-bit provable security).
+impl Default for ProofOptions {
+    fn default() -> Self {
+        Self {
+            blowup_factor: 4,
+            fri_number_of_queries: 104,
+            coset_offset: 3,
+            grinding_factor: 20,
         }
     }
 }

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1759,7 +1759,7 @@ mod tests {
         let claimed_index = 3;
         let col = 0;
         let claimed_value = *trace.get_main(claimed_index, col);
-        let mut proof_options = ProofOptions::default_test_options();
+        let mut proof_options = ProofOptions::default();
         proof_options.blowup_factor = 4;
         proof_options.coset_offset = 3;
         proof_options.grinding_factor = 0;
@@ -2169,7 +2169,7 @@ mod tests {
         let claimed_index = 420;
         let col = 0;
         let claimed_value = *trace.get_main(claimed_index, col);
-        let mut proof_options = ProofOptions::default_test_options();
+        let mut proof_options = ProofOptions::default();
         proof_options.blowup_factor = 1 << 6;
         proof_options.coset_offset = 3;
         proof_options.grinding_factor = 0;

--- a/crypto/stark/src/tests/air_tests.rs
+++ b/crypto/stark/src/tests/air_tests.rs
@@ -40,7 +40,7 @@ use crate::examples::read_only_memory_logup::{
 fn test_prove_fib() {
     let mut trace = simple_fibonacci::fibonacci_trace([Felt252::from(1), Felt252::from(1)], 8);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let pub_inputs = FibonacciPublicInputs {
         a0: Felt252::one(),
@@ -67,7 +67,7 @@ fn test_prove_fib() {
 fn test_prove_simple_periodic_8() {
     let mut trace = simple_periodic_cols::simple_periodic_trace::<Stark252PrimeField>(8);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let pub_inputs = SimplePeriodicPublicInputs {
         a0: Felt252::one(),
@@ -94,7 +94,7 @@ fn test_prove_simple_periodic_8() {
 fn test_prove_simple_periodic_32() {
     let mut trace = simple_periodic_cols::simple_periodic_trace::<Stark252PrimeField>(32);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let pub_inputs = SimplePeriodicPublicInputs {
         a0: Felt252::one(),
@@ -122,7 +122,7 @@ fn test_prove_simple_periodic_32() {
 fn test_prove_fib_2_cols() {
     let mut trace = fibonacci_2_columns::compute_trace([Felt252::from(1), Felt252::from(1)], 16);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let pub_inputs = FibonacciPublicInputs {
         a0: Felt252::one(),
         a1: Felt252::one(),
@@ -151,7 +151,7 @@ fn test_prove_fib_2_cols_shifted() {
 
     let claimed_index = 14;
     let claimed_value = trace.main_table.get_row(claimed_index)[0];
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let pub_inputs = fibonacci_2_cols_shifted::PublicInputs {
         claimed_value,
@@ -179,7 +179,7 @@ fn test_prove_fib_2_cols_shifted() {
 fn test_prove_quadratic() {
     let mut trace = quadratic_air::quadratic_trace(Felt252::from(3), 32);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let pub_inputs = QuadraticPublicInputs {
         a0: Felt252::from(3),
@@ -207,7 +207,7 @@ fn test_prove_rap_fib() {
     let steps = 16;
     let mut trace = fibonacci_rap_trace([Felt252::from(1), Felt252::from(1)], steps);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let pub_inputs = FibonacciRAPPublicInputs {
         steps,
@@ -237,7 +237,7 @@ fn test_prove_dummy() {
     let trace_length = 16;
     let mut trace = dummy_air::dummy_trace(trace_length);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let air = DummyAIR::new(&proof_options);
 
@@ -253,7 +253,7 @@ fn test_prove_dummy() {
 #[test_log::test]
 fn test_prove_bit_flags() {
     let mut trace = bit_flags::bit_prefix_flag_trace(32);
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let air = BitFlagsAIR::new(&proof_options);
 
@@ -296,7 +296,7 @@ fn test_prove_read_only_memory() {
         v_sorted0: FieldElement::<Stark252PrimeField>::from(7), // v6
     };
     let mut trace = sort_rap_trace(address_col, value_col);
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let air = ReadOnlyRAP::<Stark252PrimeField>::new(&proof_options);
 
@@ -346,7 +346,7 @@ fn test_prove_log_read_only_memory() {
         m0: FieldElement::<Babybear31PrimeField>::from(1),
     };
     let mut trace = read_only_logup_trace(address_col, value_col);
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let air =
         LogReadOnlyRAP::<Babybear31PrimeField, Degree4BabyBearExtensionField>::new(&proof_options);
@@ -371,7 +371,7 @@ fn test_multi_prove_fib_3_tables() {
     let mut trace_1 = simple_fibonacci::fibonacci_trace([Felt252::from(1), Felt252::from(1)], 8);
     let mut trace_2 = simple_fibonacci::fibonacci_trace([Felt252::from(1), Felt252::from(1)], 16);
     let mut trace_3 = simple_fibonacci::fibonacci_trace([Felt252::from(1), Felt252::from(1)], 32);
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let pub_inputs_1 = FibonacciPublicInputs {
         a0: Felt252::one(),
@@ -483,7 +483,7 @@ fn test_multi_prove_2_tables_small_field() {
 
     let mut trace_1 = read_only_logup_trace(address_col_1, value_col_1);
     let mut trace_2 = read_only_logup_trace(address_col_2, value_col_2);
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let air_1 =
         LogReadOnlyRAP::<Babybear31PrimeField, Degree4BabyBearExtensionField>::new(&proof_options);
@@ -528,7 +528,7 @@ fn test_multi_prove_2_tables_small_field() {
 fn test_multi_prove_different_airs() {
     let mut trace_1 = dummy_air::dummy_trace(16);
     let mut trace_2 = bit_flags::bit_prefix_flag_trace(32);
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     let air_1 = DummyAIR::new(&proof_options);
     let air_2 = BitFlagsAIR::new(&proof_options);
@@ -560,7 +560,7 @@ type GoldilocksFE = FieldElement<GoldilocksField>;
 
 #[test]
 fn test_multi_column_fibonacci_2_cols() {
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let num_columns = 2;
     let trace_length = 16;
 
@@ -601,7 +601,7 @@ fn test_multi_column_fibonacci_2_cols() {
 
 #[test]
 fn test_multi_column_fibonacci_4_cols() {
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let num_columns = 4;
     let trace_length = 16;
 

--- a/crypto/stark/src/tests/bus_tests/completeness_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/completeness_tests.rs
@@ -106,7 +106,7 @@ fn test_multi_table_proof() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -168,7 +168,7 @@ fn test_all_padding() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -230,7 +230,7 @@ fn test_single_operation() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -292,7 +292,7 @@ fn test_duplicate_operations() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -354,7 +354,7 @@ fn test_serialization_roundtrip() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -421,7 +421,7 @@ fn test_bus_value_features() {
                 values,
             )],
         };
-        let proof_options = ProofOptions::default_test_options();
+        let proof_options = ProofOptions::default();
         AirWithBuses::<F, E, NullBoundaryConstraintBuilder, ()>::new(
             5,
             build_data,
@@ -450,7 +450,7 @@ fn test_bus_value_features() {
                 values,
             )],
         };
-        let proof_options = ProofOptions::default_test_options();
+        let proof_options = ProofOptions::default();
         AirWithBuses::<F, E, NullBoundaryConstraintBuilder, ()>::new(
             5,
             build_data,

--- a/crypto/stark/src/tests/bus_tests/multiplicity_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/multiplicity_tests.rs
@@ -99,7 +99,7 @@ fn test_multiplicity_one() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender = sender_air(&proof_options);
     let receiver = receiver_air(&proof_options);
 
@@ -204,7 +204,7 @@ fn test_multiplicity_sum() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender = sender_air(&proof_options);
     let receiver = receiver_air(&proof_options);
 
@@ -307,7 +307,7 @@ fn test_multiplicity_negated() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender = sender_air(&proof_options);
     let receiver = receiver_air(&proof_options);
 

--- a/crypto/stark/src/tests/bus_tests/packing_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/packing_tests.rs
@@ -316,7 +316,7 @@ fn test_air_layout_single_interaction() {
         interactions: vec![interaction],
     };
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let air = AirWithBuses::<F, E, NullBoundaryConstraintBuilder, ()>::new(
         4,
         build_data,
@@ -347,7 +347,7 @@ fn test_air_layout_multiple_interactions() {
         interactions: vec![interaction1, interaction2],
     };
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let air = AirWithBuses::<F, E, NullBoundaryConstraintBuilder, ()>::new(
         5,
         build_data,

--- a/crypto/stark/src/tests/bus_tests/soundness_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/soundness_tests.rs
@@ -63,7 +63,7 @@ fn test_wrong_result_value() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -125,7 +125,7 @@ fn test_off_by_one() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -187,7 +187,7 @@ fn test_swapped_operands() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -249,7 +249,7 @@ fn test_single_column_wrong() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -315,7 +315,7 @@ fn test_over_report_multiplicity() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -377,7 +377,7 @@ fn test_under_report_multiplicity() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -439,7 +439,7 @@ fn test_zero_multiplicity_skip() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -505,7 +505,7 @@ fn test_phantom_receive() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -567,7 +567,7 @@ fn test_missing_receiver() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -633,7 +633,7 @@ fn test_one_of_many_wrong() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -740,7 +740,7 @@ fn test_full_scenario_wrong_add() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -813,7 +813,7 @@ fn test_wrong_table_consumes_value_rejected() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
@@ -926,7 +926,7 @@ fn test_packing_mismatch_direct_vs_word2l() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender = sender_air_direct(&proof_options);
     let receiver = receiver_air_word2l(&proof_options);
 
@@ -1026,7 +1026,7 @@ fn test_packing_mismatch_element_count() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender = sender_air_3_direct(&proof_options);
     let receiver = receiver_air_word2l_direct(&proof_options);
 
@@ -1123,7 +1123,7 @@ fn test_packing_mismatch_shift_constant() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender = sender_air_word4l(&proof_options);
     let receiver = receiver_air_dwordhl(&proof_options);
 
@@ -1221,7 +1221,7 @@ fn test_compound_mismatch_dwordhhw_vs_dwordwhh() {
     // Receiver DWordWHH: [0x1000 + 0x2000*2^16, 0x3000] = [0x20001000, 0x3000]
     // Completely different bus elements!
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender = sender_air_dwordhhw(&proof_options);
     let receiver = receiver_air_dwordwhh(&proof_options);
 
@@ -1309,7 +1309,7 @@ fn test_compound_equals_primitive_expansion() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender = sender_air_compound(&proof_options);
     let receiver = receiver_air_primitives(&proof_options);
 
@@ -1418,7 +1418,7 @@ fn test_full_scenario_wrong_mul() {
         1,
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);

--- a/crypto/stark/src/tests/prove_verify_roundtrip_tests.rs
+++ b/crypto/stark/src/tests/prove_verify_roundtrip_tests.rs
@@ -118,7 +118,7 @@ fn test_verify_serialized_multi_table_proofs() {
         let mut mul_trace =
             crate::trace::TraceTable::from_columns_main(vec![mul_a, mul_b, mul_c, mul_m], 1);
 
-        let proof_options = ProofOptions::default_test_options();
+        let proof_options = ProofOptions::default();
 
         // Create AIRs - prover passes num_main_columns from trace
         let cpu_air = create_cpu_air(&proof_options);
@@ -157,7 +157,7 @@ fn test_verify_serialized_multi_table_proofs() {
     // The verifier knows the AIR structure (columns, interactions) as part of
     // the protocol definition.
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     // Reconstruct AIRs - verifier knows the structure
     let cpu_air = create_cpu_air(&proof_options);

--- a/crypto/stark/src/tests/small_trace_tests.rs
+++ b/crypto/stark/src/tests/small_trace_tests.rs
@@ -24,7 +24,7 @@ type Felt252 = FieldElement<Stark252PrimeField>;
 fn test_prove_verify_single_row() {
     let mut trace = simple_addition_trace::<Stark252PrimeField>(1);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     // For row 0: col0=1, col1=2, col2=3 (1+2=3)
     let pub_inputs = SimpleAdditionPublicInputs {
@@ -54,7 +54,7 @@ fn test_prove_verify_single_row() {
 fn test_prove_verify_two_rows() {
     let mut trace = simple_addition_trace::<Stark252PrimeField>(2);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     // For row 0: col0=1, col1=2, col2=3 (1+2=3)
     let pub_inputs = SimpleAdditionPublicInputs {
@@ -84,7 +84,7 @@ fn test_prove_verify_two_rows() {
 fn test_verify_fails_with_wrong_inputs() {
     let mut trace = simple_addition_trace::<Stark252PrimeField>(2);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     // Correct public inputs for proving
     let correct_pub_inputs = SimpleAdditionPublicInputs {

--- a/prover/benches/vm_prover_benchmark.rs
+++ b/prover/benches/vm_prover_benchmark.rs
@@ -8,7 +8,6 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 
 use lambda_vm_prover::test_utils::asm_elf_bytes;
-use stark::proof::options::ProofOptions;
 
 /// Configuration for a benchmark case
 struct BenchConfig {
@@ -34,39 +33,34 @@ const CONFIGS: &[BenchConfig] = &[
 /// Benchmark prove (ELF execution + trace generation + proving)
 fn bench_prove(c: &mut Criterion, config: &BenchConfig) {
     let elf_bytes = asm_elf_bytes(config.elf_name);
-    let proof_options = ProofOptions::default_test_options();
 
     c.bench_with_input(
         BenchmarkId::new("vm_prover/prove", config.name),
         config,
-        |b, _config| b.iter(|| lambda_vm_prover::prove(&elf_bytes, &proof_options).unwrap()),
+        |b, _config| b.iter(|| lambda_vm_prover::prove(&elf_bytes).unwrap()),
     );
 }
 
 /// Benchmark verify only (proof pre-generated)
 fn bench_verify(c: &mut Criterion, config: &BenchConfig) {
     let elf_bytes = asm_elf_bytes(config.elf_name);
-    let proof_options = ProofOptions::default_test_options();
-    let proof = lambda_vm_prover::prove(&elf_bytes, &proof_options).unwrap();
+    let proof = lambda_vm_prover::prove(&elf_bytes).unwrap();
 
     c.bench_with_input(
         BenchmarkId::new("vm_prover/verify", config.name),
         &proof,
-        |b, proof| b.iter(|| lambda_vm_prover::verify(proof, &elf_bytes, &proof_options).unwrap()),
+        |b, proof| b.iter(|| lambda_vm_prover::verify(proof, &elf_bytes).unwrap()),
     );
 }
 
 /// Benchmark full pipeline (prove + verify)
 fn bench_prove_and_verify(c: &mut Criterion, config: &BenchConfig) {
     let elf_bytes = asm_elf_bytes(config.elf_name);
-    let proof_options = ProofOptions::default_test_options();
 
     c.bench_with_input(
         BenchmarkId::new("vm_prover/prove_and_verify", config.name),
         config,
-        |b, _config| {
-            b.iter(|| lambda_vm_prover::prove_and_verify(&elf_bytes, &proof_options).unwrap())
-        },
+        |b, _config| b.iter(|| lambda_vm_prover::prove_and_verify(&elf_bytes).unwrap()),
     );
 }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -6,9 +6,8 @@
 //! # Example
 //! ```ignore
 //! let elf_bytes = std::fs::read("program.elf").unwrap();
-//! let options = stark::proof::options::ProofOptions::default_test_options();
-//! let proof = lambda_vm_prover::prove(&elf_bytes, &options).unwrap();
-//! assert!(lambda_vm_prover::verify(&proof, &elf_bytes, &options).unwrap());
+//! let proof = lambda_vm_prover::prove(&elf_bytes).unwrap();
+//! assert!(lambda_vm_prover::verify(&proof, &elf_bytes).unwrap());
 //! ```
 
 #[cfg(feature = "dhat-heap")]
@@ -167,10 +166,8 @@ impl VmAirs {
 }
 
 /// Prove an ELF binary execution. Returns a serializable proof.
-pub fn prove(
-    elf_bytes: &[u8],
-    proof_options: &ProofOptions,
-) -> Result<MultiProof<F, E, ()>, Error> {
+pub fn prove(elf_bytes: &[u8]) -> Result<MultiProof<F, E, ()>, Error> {
+    let proof_options = ProofOptions::default();
     let program = Elf::load(elf_bytes).map_err(|e| Error::ElfLoad(format!("{e}")))?;
     let executor = Executor::new(&program, vec![]).map_err(|e| Error::Execution(format!("{e}")))?;
     let result = executor
@@ -178,7 +175,7 @@ pub fn prove(
         .map_err(|e| Error::Execution(format!("{e}")))?;
 
     let mut traces = Traces::from_logs(&result.logs, result.instructions)?;
-    let airs = VmAirs::new(&program, proof_options, false);
+    let airs = VmAirs::new(&program, &proof_options, false);
 
     Prover::multi_prove(
         airs.air_trace_pairs(&mut traces),
@@ -188,13 +185,10 @@ pub fn prove(
 }
 
 /// Verify a proof produced by [`prove`].
-pub fn verify(
-    proof: &MultiProof<F, E, ()>,
-    elf_bytes: &[u8],
-    proof_options: &ProofOptions,
-) -> Result<bool, Error> {
+pub fn verify(proof: &MultiProof<F, E, ()>, elf_bytes: &[u8]) -> Result<bool, Error> {
+    let proof_options = ProofOptions::default();
     let program = Elf::load(elf_bytes).map_err(|e| Error::ElfLoad(format!("{e}")))?;
-    let airs = VmAirs::new(&program, proof_options, false);
+    let airs = VmAirs::new(&program, &proof_options, false);
 
     Ok(Verifier::multi_verify(
         &airs.air_refs(),
@@ -204,7 +198,7 @@ pub fn verify(
 }
 
 /// Prove and verify in one call (convenience).
-pub fn prove_and_verify(elf_bytes: &[u8], proof_options: &ProofOptions) -> Result<bool, Error> {
-    let proof = prove(elf_bytes, proof_options)?;
-    verify(&proof, elf_bytes, proof_options)
+pub fn prove_and_verify(elf_bytes: &[u8]) -> Result<bool, Error> {
+    let proof = prove(elf_bytes)?;
+    verify(&proof, elf_bytes)
 }

--- a/prover/src/tests/bitwise_bus_tests.rs
+++ b/prover/src/tests/bitwise_bus_tests.rs
@@ -182,7 +182,7 @@ fn prove_and_verify(sender_lookups: &[(u8, u8, u8)]) -> bool {
     let mut sender_trace = create_sender_trace(sender_lookups);
     let mut receiver_trace = create_receiver_trace(sender_lookups);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender_air = new_sender_air(&proof_options);
     let receiver_air = new_receiver_air(&proof_options);
 
@@ -287,7 +287,7 @@ fn prove_and_verify_custom(
     let mut sender_trace = create_sender_trace(sender_lookups);
     let mut receiver_trace = create_custom_receiver_trace(receiver_rows);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender_air = new_sender_air(&proof_options);
     let receiver_air = new_receiver_air(&proof_options);
 

--- a/prover/src/tests/bitwise_tests.rs
+++ b/prover/src/tests/bitwise_tests.rs
@@ -577,7 +577,7 @@ mod soundness_tests {
         let mut sender_trace = create_sender_trace(x, y, correct_result);
         let mut receiver_trace = create_honest_receiver_trace(x, y);
 
-        let proof_options = ProofOptions::default_test_options();
+        let proof_options = ProofOptions::default();
         let sender_air = create_sender_air(&proof_options);
         let receiver_air = create_receiver_air(&proof_options);
 
@@ -620,7 +620,7 @@ mod soundness_tests {
         let mut sender_trace = create_sender_trace(x, y, fake_result);
         let mut receiver_trace = create_malicious_receiver_trace(x, y, fake_result);
 
-        let proof_options = ProofOptions::default_test_options();
+        let proof_options = ProofOptions::default();
         let sender_air = create_sender_air(&proof_options);
         // NOT using preprocessed - verifier trusts proof's commitment
         let receiver_air = create_receiver_air(&proof_options);
@@ -665,7 +665,7 @@ mod soundness_tests {
         let y = 3u8;
         let fake_result = 99u8; // WRONG! Real answer is 5 & 3 = 1
 
-        let proof_options = ProofOptions::default_test_options();
+        let proof_options = ProofOptions::default();
 
         // Compute commitment to the HONEST table (what verifier expects)
         let honest_trace = create_honest_receiver_trace(x, y);

--- a/prover/src/tests/branch_bus_tests.rs
+++ b/prover/src/tests/branch_bus_tests.rs
@@ -325,7 +325,7 @@ fn prove_and_verify(ops: &[BranchOperation]) -> bool {
     let mut sender_trace = create_sender_trace(ops);
     let mut receiver_trace = create_receiver_trace(ops);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender_air = new_sender_air(&proof_options);
     let receiver_air = new_receiver_air(&proof_options);
 
@@ -410,7 +410,7 @@ fn prove_and_verify_custom(ops: &[BranchOperation], receiver_rows: &[CustomBranc
     let mut sender_trace = create_sender_trace(ops);
     let mut receiver_trace = create_custom_receiver_trace(receiver_rows);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender_air = new_sender_air(&proof_options);
     let receiver_air = new_receiver_air(&proof_options);
 

--- a/prover/src/tests/decode_tests.rs
+++ b/prover/src/tests/decode_tests.rs
@@ -641,7 +641,7 @@ fn test_compute_precomputed_commitment_deterministic() {
         },
     );
 
-    let options = ProofOptions::default_test_options();
+    let options = ProofOptions::default();
 
     let commitment1 = compute_precomputed_commitment(&instructions, &options);
     let commitment2 = compute_precomputed_commitment(&instructions, &options);
@@ -657,7 +657,7 @@ fn test_compute_precomputed_commitment_different_programs() {
     use crate::tables::decode::compute_precomputed_commitment;
     use stark::proof::options::ProofOptions;
 
-    let options = ProofOptions::default_test_options();
+    let options = ProofOptions::default();
 
     // Program A: ADD instruction
     let mut program_a = U64HashMap::default();
@@ -697,7 +697,7 @@ fn test_compute_precomputed_commitment_different_pc() {
     use crate::tables::decode::compute_precomputed_commitment;
     use stark::proof::options::ProofOptions;
 
-    let options = ProofOptions::default_test_options();
+    let options = ProofOptions::default();
 
     // Program A: instruction at PC 0x1000
     let mut program_a = U64HashMap::default();
@@ -883,7 +883,7 @@ fn test_decode_soundness_different_elf_rejected() {
     type F = GoldilocksField;
     type E = GoldilocksExtension;
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     // Load two DIFFERENT ELF files
     let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -1012,7 +1012,7 @@ fn test_decode_soundness_same_elf_accepted() {
     type F = GoldilocksField;
     type E = GoldilocksExtension;
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     // Load the SAME ELF for both prover and verifier
     let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/prover/src/tests/lt_bus_tests.rs
+++ b/prover/src/tests/lt_bus_tests.rs
@@ -278,7 +278,7 @@ fn prove_and_verify(ops: &[LtOperation]) -> bool {
     let mut sender_trace = create_sender_trace(ops);
     let mut receiver_trace = create_receiver_trace(ops);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender_air = new_sender_air(&proof_options);
     let receiver_air = new_receiver_air(&proof_options);
 
@@ -357,7 +357,7 @@ fn prove_and_verify_custom(ops: &[LtOperation], receiver_rows: &[CustomLtRow]) -
     let mut sender_trace = create_sender_trace(ops);
     let mut receiver_trace = create_custom_receiver_trace(receiver_rows);
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let sender_air = new_sender_air(&proof_options);
     let receiver_air = new_receiver_air(&proof_options);
 

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -42,7 +42,7 @@ type E = GoldilocksExtension;
 ///
 /// Uses minimal bitwise (no full 2^20 preprocessed table) but DECODE is always preprocessed.
 fn prove_and_verify_vm_minimal(elf: &Elf, traces: &mut Traces) -> bool {
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
     let airs = VmAirs::new(elf, &proof_options, true);
 
     let multi_proof = match Prover::multi_prove(
@@ -78,7 +78,7 @@ fn test_cpu_only_no_bus() {
         cpu_trace.main_table.height, cpu_trace.main_table.width
     );
 
-    let proof_options = ProofOptions::default_test_options();
+    let proof_options = ProofOptions::default();
 
     // Create AIR with NO bus interactions
     let transition_constraints: Vec<Box<dyn TransitionConstraint<F, E>>> = vec![];
@@ -529,9 +529,7 @@ fn test_prove_elfs_all_instructions_64_full() {
     let _ = env_logger::builder().is_test(true).try_init();
 
     let elf_bytes = crate::test_utils::asm_elf_bytes("all_instructions_64");
-    let proof_options = ProofOptions::default_test_options();
-    let result =
-        crate::prove_and_verify(&elf_bytes, &proof_options).expect("prove_and_verify failed");
+    let result = crate::prove_and_verify(&elf_bytes).expect("prove_and_verify failed");
     assert!(
         result,
         "all_instructions_64_full failed - comprehensive test with full bitwise table"


### PR DESCRIPTION
Hardcode production-secure proof options (100-bit provable security) inside `prove`, `verify`, and `prove_and_verify`. Callers no longer pass `ProofOptions`.

- Add `Default` impl for `ProofOptions` with production values (104 FRI queries, grinding 20, blowup 4)
- Remove `proof_options` from `ProofBundle`
- Remove `default_test_options()` — all tests use `ProofOptions::default()`