### PR TITLE
Optimize CI - Test only in release

### DIFF
--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -93,17 +93,17 @@ jobs:
         run: |
           make test-flamegraph
 
-      - name: Run ignored executor tests (release)
+      - name: Run ignored executor tests
         run: |
           make prepare-test-data
-          cargo test -p executor --release test_ethrex -- --ignored
-          cargo test -p executor --release test_ckzg -- --ignored
+          cargo test -p executor test_ethrex -- --ignored
+          cargo test -p executor test_ckzg -- --ignored
 
       - name: Run prover and crypto tests
         run: |
-          cargo test -p lambda-vm-prover -p stark -p crypto --release -- --test-threads=1
+          cargo test -p lambda-vm-prover -p stark -p crypto -- --test-threads=1
 
       - name: Run comprehensive prover tests (merge queue only)
         if: github.event_name == 'merge_group'
         run: |
-          cargo test -p lambda-vm-prover --release test_prove_elfs_all_instructions_64_full -- --ignored
+          cargo test -p lambda-vm-prover test_prove_elfs_all_instructions_64_full -- --ignored

--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -83,27 +83,27 @@ jobs:
 
       - name: Run asm tests (no compile)
         run: |
-          make test-asm-no-compile
+          cargo test --release -p executor --test asm
 
       - name: Run rust tests (no compile)
         run: |
-          make test-rust-no-compile
+          cargo test --release -p executor --test rust
 
       - name: Run flamegraph tests
         run: |
-          make test-flamegraph
+          cargo test --release -p executor --test flamegraph
 
       - name: Run ignored executor tests
         run: |
           make prepare-test-data
-          cargo test -p executor test_ethrex -- --ignored
-          cargo test -p executor test_ckzg -- --ignored
+          cargo test --release -p executor test_ethrex -- --ignored
+          cargo test --release -p executor test_ckzg -- --ignored
 
       - name: Run prover and crypto tests
         run: |
-          cargo test -p lambda-vm-prover -p stark -p crypto -- --test-threads=1
+          cargo test --release -p lambda-vm-prover -p stark -p crypto -- --test-threads=1
 
       - name: Run comprehensive prover tests (merge queue only)
         if: github.event_name == 'merge_group'
         run: |
-          cargo test -p lambda-vm-prover test_prove_elfs_all_instructions_64_full -- --ignored
+          cargo test --release -p lambda-vm-prover test_prove_elfs_all_instructions_64_full -- --ignored


### PR DESCRIPTION
Optimize CI - Test only in release

Before prover was being built in release and executor in dev. We change everything to release to avoid having a double compilation

This is a table of times, of the mixed approach, all dev, and all release:

| Step | Original (mixed dev+release) | All dev (no --release) | All release |
  |------|-----|-----|-----|
  | ASM tests | 4m 33s | 4m 36s | 3m 21s |
  | Rust tests | 4s | 4s | 2s |
  | Flamegraph | 2s | 1s | 1s |
  | Ignored executor | 3m 28s | 0m 20s | 0m 17s |
  | Prover + crypto | 7m 55s | 10m 9s | 8m 6s |
  | **Total job** | **~17m 00s** | **~17m 12s** | **~13m 32s** |