### PR TITLE
Eliminate columns2rows transposition copy in Merkle commitment

### DIFF
--- a/crypto/crypto/src/merkle_tree/backends/field_element_vector.rs
+++ b/crypto/crypto/src/merkle_tree/backends/field_element_vector.rs
@@ -1,6 +1,7 @@
 use core::marker::PhantomData;
 
 use crate::hash::poseidon::Poseidon;
+use crate::merkle_tree::merkle::MerkleTree;
 use crate::merkle_tree::traits::IsMerkleTreeBackend;
 use alloc::vec::Vec;
 use digest::{Digest, Output};
@@ -8,6 +9,8 @@ use math::{
     field::{element::FieldElement, traits::IsField},
     traits::AsBytes,
 };
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 /// A backend for Merkle trees that uses fixed-size pairs of field elements.
 /// This is more efficient than `FieldElementVectorBackend` when the batch size is always 2,
@@ -99,6 +102,44 @@ where
         let mut result_hash = [0_u8; NUM_BYTES];
         result_hash.copy_from_slice(&hasher.finalize());
         result_hash
+    }
+}
+
+impl<F, D, const N: usize> MerkleTree<FieldElementVectorBackend<F, D, N>>
+where
+    F: IsField,
+    FieldElement<F>: AsBytes + Sync + Send,
+    D: Digest,
+    [u8; N]: From<Output<D>>,
+    Vec<FieldElement<F>>: Sync + Send,
+{
+    /// Build a Merkle tree by hashing "virtual rows" from column-major data,
+    /// avoiding the allocation of a transposed row-major copy.
+    pub fn build_from_columns(columns: &[Vec<FieldElement<F>>]) -> Option<Self> {
+        if columns.is_empty() {
+            return None;
+        }
+        let num_rows = columns[0].len();
+        if num_rows == 0 {
+            return None;
+        }
+
+        #[cfg(feature = "parallel")]
+        let iter = (0..num_rows).into_par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let iter = 0..num_rows;
+
+        let hashed_leaves: Vec<[u8; N]> = iter
+            .map(|row| {
+                let mut hasher = D::new();
+                for col in columns {
+                    hasher.update(col[row].as_bytes());
+                }
+                hasher.finalize().into()
+            })
+            .collect();
+
+        Self::build_from_hashed_leaves(hashed_leaves)
     }
 }
 

--- a/crypto/crypto/src/merkle_tree/merkle.rs
+++ b/crypto/crypto/src/merkle_tree/merkle.rs
@@ -51,6 +51,14 @@ where
         }
 
         let hashed_leaves: Vec<B::Node> = B::hash_leaves(unhashed_leaves);
+        Self::build_from_hashed_leaves(hashed_leaves)
+    }
+
+    /// Create a Merkle tree from pre-hashed leaves.
+    pub(crate) fn build_from_hashed_leaves(hashed_leaves: Vec<B::Node>) -> Option<Self> {
+        if hashed_leaves.is_empty() {
+            return None;
+        }
 
         //The leaf must be a power of 2 set
         let hashed_leaves = complete_until_power_of_two(hashed_leaves);

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -24,7 +24,7 @@ use crate::fri;
 use crate::lookup::LOGUP_NUM_CHALLENGES;
 use crate::proof::stark::{DeepPolynomialOpenings, PolynomialOpenings};
 use crate::table::Table;
-use crate::trace::{LDETraceTable, columns2rows};
+use crate::trace::LDETraceTable;
 
 use super::config::{BatchedMerkleTree, Commitment};
 use super::constraints::evaluator::ConstraintEvaluator;
@@ -273,8 +273,8 @@ pub trait IsStarkProver<
         }
 
         // Build commitment
-        let rows = columns2rows(lde_permuted);
-        let (_, commitment) = Self::batch_commit_main(&rows)?;
+        let tree = BatchedMerkleTree::build_from_columns(&lde_permuted)?;
+        let commitment = tree.root;
 
         Some(commitment)
     }
@@ -315,10 +315,8 @@ pub trait IsStarkProver<
         }
 
         // Compute commitment.
-        let lde_trace_permuted_rows = columns2rows(lde_trace_permuted);
-
-        let (lde_trace_merkle_tree, lde_trace_merkle_root) =
-            Self::batch_commit_main(&lde_trace_permuted_rows)?;
+        let lde_trace_merkle_tree = BatchedMerkleTree::build_from_columns(&lde_trace_permuted)?;
+        let lde_trace_merkle_root = lde_trace_merkle_tree.root;
 
         // >>>> Send commitment.
         transcript.append_bytes(&lde_trace_merkle_root);
@@ -363,10 +361,8 @@ pub trait IsStarkProver<
         }
 
         // Compute commitment (but don't append to transcript - caller does that).
-        let lde_trace_permuted_rows = columns2rows(lde_trace_permuted);
-
-        let (lde_trace_merkle_tree, lde_trace_merkle_root) =
-            Self::batch_commit_main(&lde_trace_permuted_rows)?;
+        let lde_trace_merkle_tree = BatchedMerkleTree::build_from_columns(&lde_trace_permuted)?;
+        let lde_trace_merkle_root = lde_trace_merkle_tree.root;
 
         Some((
             trace_polys,
@@ -411,10 +407,8 @@ pub trait IsStarkProver<
         }
 
         // Compute commitment.
-        let lde_trace_permuted_rows = columns2rows(lde_trace_permuted);
-
-        let (lde_trace_merkle_tree, lde_trace_merkle_root) =
-            Self::batch_commit_extension(&lde_trace_permuted_rows)?;
+        let lde_trace_merkle_tree = BatchedMerkleTree::build_from_columns(&lde_trace_permuted)?;
+        let lde_trace_merkle_root = lde_trace_merkle_tree.root;
 
         // >>>> Send commitment.
         transcript.append_bytes(&lde_trace_merkle_root);
@@ -518,9 +512,9 @@ pub trait IsStarkProver<
         for col in precomputed_lde_permuted.iter_mut() {
             in_place_bit_reverse_permute(col);
         }
-        let precomputed_rows = columns2rows(precomputed_lde_permuted);
-        let (precomputed_tree, precomputed_root) =
-            Self::batch_commit_main(&precomputed_rows).ok_or(ProvingError::EmptyCommitment)?;
+        let precomputed_tree = BatchedMerkleTree::build_from_columns(&precomputed_lde_permuted)
+            .ok_or(ProvingError::EmptyCommitment)?;
+        let precomputed_root = precomputed_tree.root;
 
         // --- Build MULTIPLICITIES tree (cols num_precomputed..) ---
         let multiplicity_evaluations: Vec<_> = evaluations[num_precomputed_cols..].to_vec();
@@ -528,9 +522,9 @@ pub trait IsStarkProver<
         for col in mult_lde_permuted.iter_mut() {
             in_place_bit_reverse_permute(col);
         }
-        let mult_rows = columns2rows(mult_lde_permuted);
-        let (mult_tree, mult_root) =
-            Self::batch_commit_main(&mult_rows).ok_or(ProvingError::EmptyCommitment)?;
+        let mult_tree = BatchedMerkleTree::build_from_columns(&mult_lde_permuted)
+            .ok_or(ProvingError::EmptyCommitment)?;
+        let mult_root = mult_tree.root;
 
         // Verify that our computed precomputed root matches the hardcoded commitment.
         // This is a sanity check - if they don't match, something is wrong with the trace.

--- a/crypto/stark/src/trace.rs
+++ b/crypto/stark/src/trace.rs
@@ -378,19 +378,3 @@ where
 
     Table::new(table_data, table_width)
 }
-
-pub fn columns2rows<F>(columns: Vec<Vec<F>>) -> Vec<Vec<F>>
-where
-    F: Clone,
-{
-    let num_rows = columns[0].len();
-    let num_cols = columns.len();
-
-    (0..num_rows)
-        .map(|row_index| {
-            (0..num_cols)
-                .map(|col_index| columns[col_index][row_index].clone())
-                .collect()
-        })
-        .collect()
-}

--- a/prover/src/tables/bitwise.rs
+++ b/prover/src/tables/bitwise.rs
@@ -33,7 +33,7 @@ use math::polynomial::Polynomial;
 use stark::config::{BatchedMerkleTree, Commitment};
 use stark::lookup::{BusInteraction, BusValue, Multiplicity, Packing};
 use stark::prover::evaluate_polynomial_on_lde_domain;
-use stark::trace::{TraceTable, columns2rows};
+use stark::trace::TraceTable;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
@@ -285,11 +285,8 @@ fn compute_preprocessed_commitment() -> Commitment {
         in_place_bit_reverse_permute(col);
     }
 
-    // Step 5: Convert columns to rows for Merkle tree
-    let lde_rows = columns2rows(lde_columns);
-
-    // Step 6: Build Merkle tree over LDE (N * blowup leaves)
-    let tree = BatchedMerkleTree::<GoldilocksField>::build(&lde_rows)
+    // Step 5: Build Merkle tree over LDE (N * blowup leaves)
+    let tree = BatchedMerkleTree::<GoldilocksField>::build_from_columns(&lde_columns)
         .expect("Failed to build Merkle tree for bitwise LDE");
 
     tree.root

--- a/prover/src/tables/decode.rs
+++ b/prover/src/tables/decode.rs
@@ -44,7 +44,7 @@ use stark::config::{BatchedMerkleTree, Commitment};
 use stark::lookup::{BusInteraction, BusValue, Multiplicity, Packing};
 use stark::proof::options::ProofOptions;
 use stark::prover::evaluate_polynomial_on_lde_domain;
-use stark::trace::{TraceTable, columns2rows};
+use stark::trace::TraceTable;
 
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 
@@ -289,11 +289,8 @@ pub fn compute_precomputed_commitment(
         in_place_bit_reverse_permute(col);
     }
 
-    // Step 6: Convert columns to rows for Merkle tree
-    let lde_rows = columns2rows(lde_columns);
-
-    // Step 7: Build Merkle tree over LDE (N * blowup leaves)
-    let tree = BatchedMerkleTree::<GoldilocksField>::build(&lde_rows)
+    // Step 6: Build Merkle tree over LDE (N * blowup leaves)
+    let tree = BatchedMerkleTree::<GoldilocksField>::build_from_columns(&lde_columns)
         .expect("Failed to build Merkle tree for decode LDE");
 
     tree.root


### PR DESCRIPTION
Adds `MerkleTree::build_from_columns` that hashes virtual rows by striding into column-major data, avoiding the full `columns2rows` transposition allocation. Removes the `columns2rows` function entirely.