### PR TITLE
Bitwise comm blowup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,7 +2157,6 @@ dependencies = [
  "dhat",
  "env_logger",
  "executor",
- "lazy_static",
  "math",
  "rayon",
  "stark",

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -14,7 +14,6 @@ stark = { path = "../crypto/stark" }
 crypto = { path = "../crypto/crypto" }
 math = { path = "../crypto/math" }
 executor = { path = "../executor" }
-lazy_static = "1.5.0"
 dhat = { version = "0.3", optional = true }
 rayon = { version = "1.8.0", optional = true }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -156,7 +156,7 @@ impl VmAirs {
             create_bitwise_air(proof_options)
         } else {
             create_bitwise_air(proof_options).with_preprocessed(
-                bitwise::preprocessed_commitment(),
+                bitwise::preprocessed_commitment(proof_options),
                 bitwise::NUM_PRECOMPUTED_COLS,
             )
         };

--- a/prover/src/tables/bitwise.rs
+++ b/prover/src/tables/bitwise.rs
@@ -27,11 +27,13 @@
 //! All lookups are provided as receivers with negative multiplicity,
 //! meaning other tables send to this table.
 
-use lazy_static::lazy_static;
+use std::sync::OnceLock;
+
 use math::fft::cpu::bit_reversing::in_place_bit_reverse_permute;
 use math::polynomial::Polynomial;
 use stark::config::{BatchedMerkleTree, Commitment};
 use stark::lookup::{BusInteraction, BusValue, Multiplicity, Packing};
+use stark::proof::options::ProofOptions;
 use stark::prover::evaluate_polynomial_on_lde_domain;
 use stark::trace::{TraceTable, columns2rows};
 
@@ -172,39 +174,23 @@ pub const fn is_preprocessed() -> bool {
 // Preprocessed commitment (computed once, cached)
 // =========================================================================
 
-lazy_static! {
-    /// Commitment to the LDE of the precomputed bitwise table columns.
-    ///
-    /// This is a Merkle root over 2^22 rows (2^20 * blowup_factor=4) of the
-    /// LDE-evaluated 11 precomputed columns (X, Y, Z, AND, OR, XOR, MSB8,
-    /// MSB16, ZERO, SLL, SLLC).
-    ///
-    /// The commitment is over LDE values (not raw values) because FRI queries
-    /// can target any index in the extended domain [0, N*blowup). The verifier
-    /// checks that proofs open against this exact commitment.
-    ///
-    /// Computed once on first access and cached. Both prover and verifier
-    /// use this same value in the Fiat-Shamir transcript.
-    pub static ref BITWISE_TABLE_COMMITMENT: Commitment = compute_preprocessed_commitment();
-}
-
-/// Standard blowup factor for LDE domain (matches proof options).
-const LDE_BLOWUP_FACTOR: usize = 4;
-
-/// Standard coset offset for LDE domain (matches proof options).
-const LDE_COSET_OFFSET: u64 = 3;
+/// Cached commitment for the BITWISE preprocessed columns.
+///
+/// INVARIANT: All callers within a process must use identical `ProofOptions`.
+/// The cache is keyed only by table content, not by options.
+static BITWISE_COMMITMENT: OnceLock<Commitment> = OnceLock::new();
 
 /// Computes the Merkle commitment over the precomputed bitwise table columns.
 ///
 /// This builds a Merkle tree over the LDE (Low Degree Extension) of the precomputed
 /// columns, matching exactly how the prover commits to traces. The tree has
-/// NUM_ROWS * LDE_BLOWUP_FACTOR = 2^22 leaves, enabling FRI queries at any index
+/// NUM_ROWS * blowup_factor leaves, enabling FRI queries at any index
 /// in the extended domain.
 ///
 /// Critical for security: the commitment must be over LDE values (not raw values)
 /// because FRI queries can target any index in [0, N*blowup). A raw-value commitment
 /// would only have N leaves, unable to verify queries at indices >= N.
-fn compute_preprocessed_commitment() -> Commitment {
+fn compute_preprocessed_commitment(options: &ProofOptions) -> Commitment {
     // Step 1: Generate precomputed columns in parallel
     // Each column is generated independently by iterating over all row indices
     #[cfg(feature = "parallel")]
@@ -254,13 +240,14 @@ fn compute_preprocessed_commitment() -> Commitment {
         .collect();
 
     // Step 3: Evaluate polynomials on LDE domain (parallel)
-    let coset_offset = FE::from(LDE_COSET_OFFSET);
+    let blowup_factor = options.blowup_factor as usize;
+    let coset_offset = FE::from(options.coset_offset);
 
     #[cfg(feature = "parallel")]
     let mut lde_columns: Vec<Vec<FE>> = polys
         .par_iter()
         .map(|poly| {
-            evaluate_polynomial_on_lde_domain(poly, LDE_BLOWUP_FACTOR, NUM_ROWS, &coset_offset)
+            evaluate_polynomial_on_lde_domain(poly, blowup_factor, NUM_ROWS, &coset_offset)
                 .expect("LDE evaluation failed for bitwise polynomial")
         })
         .collect();
@@ -269,7 +256,7 @@ fn compute_preprocessed_commitment() -> Commitment {
     let mut lde_columns: Vec<Vec<FE>> = polys
         .iter()
         .map(|poly| {
-            evaluate_polynomial_on_lde_domain(poly, LDE_BLOWUP_FACTOR, NUM_ROWS, &coset_offset)
+            evaluate_polynomial_on_lde_domain(poly, blowup_factor, NUM_ROWS, &coset_offset)
                 .expect("LDE evaluation failed for bitwise polynomial")
         })
         .collect();
@@ -295,12 +282,10 @@ fn compute_preprocessed_commitment() -> Commitment {
     tree.root
 }
 
-/// Returns the preprocessed commitment for the bitwise table.
-///
-/// This is a convenience function that dereferences the lazy_static.
+/// Returns the preprocessed commitment for the bitwise table, with caching.
 #[inline]
-pub fn preprocessed_commitment() -> Commitment {
-    *BITWISE_TABLE_COMMITMENT
+pub fn preprocessed_commitment(options: &ProofOptions) -> Commitment {
+    *BITWISE_COMMITMENT.get_or_init(|| compute_preprocessed_commitment(options))
 }
 
 // =========================================================================

--- a/prover/src/tests/bitwise_tests.rs
+++ b/prover/src/tests/bitwise_tests.rs
@@ -1,11 +1,11 @@
 //! Tests for the BITWISE precomputed table.
 
 use crate::tables::bitwise::{
-    BITWISE_TABLE_COMMITMENT, NUM_PRECOMPUTED_COLS, NUM_ROWS, bus_interactions, cols,
-    generate_bitwise_row, generate_bitwise_trace, is_preprocessed, preprocessed_commitment,
-    row_index,
+    NUM_PRECOMPUTED_COLS, NUM_ROWS, bus_interactions, cols, generate_bitwise_row,
+    generate_bitwise_trace, is_preprocessed, preprocessed_commitment, row_index,
 };
 use crate::tables::types::FE;
+use stark::proof::options::ProofOptions;
 
 #[test]
 fn test_row_index() {
@@ -332,20 +332,18 @@ fn test_generate_bitwise_row_exhaustive_sample() {
 
 #[test]
 fn test_preprocessed_commitment_is_deterministic() {
+    let options = ProofOptions::default_test_options();
     // The commitment should be the same every time we access it
-    let c1 = preprocessed_commitment();
-    let c2 = preprocessed_commitment();
+    let c1 = preprocessed_commitment(&options);
+    let c2 = preprocessed_commitment(&options);
     assert_eq!(c1, c2, "Preprocessed commitment must be deterministic");
-
-    // Also verify via the lazy_static directly
-    let c3 = *BITWISE_TABLE_COMMITMENT;
-    assert_eq!(c1, c3);
 }
 
 #[test]
 fn test_preprocessed_commitment_is_nonzero() {
+    let options = ProofOptions::default_test_options();
     // The commitment should not be all zeros
-    let commitment = preprocessed_commitment();
+    let commitment = preprocessed_commitment(&options);
     assert!(
         commitment.iter().any(|&b| b != 0),
         "Preprocessed commitment should not be all zeros"


### PR DESCRIPTION
The bitwise table's preprocessed commitment was using hardcoded LDE_BLOWUP_FACTOR = 4 and LDE_COSET_OFFSET = 3, while all other tables (PAGE, REGISTER, DECODE) read these values from ProofOptions.

  Changes:
  - Replace lazy_static! with OnceLock (matching the pattern used by PAGE and REGISTER tables)
  - preprocessed_commitment() now takes &ProofOptions, reading blowup_factor and coset_offset from it
  - Remove lazy_static dependency from the prover crate
  - Update caller in lib.rs and tests
