### PR TITLE
Fix ci cache build

### DIFF
--- a/.github/workflows/hyperfine.yaml
+++ b/.github/workflows/hyperfine.yaml
@@ -78,7 +78,8 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "lambda-vm"
+          shared-key: "lambda-vm-bench"
+          cache-all-crates: "true"
 
       - name: Build binary
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "lambda-vm"
+          cache-all-crates: "true"
 
       - name: Run lint checks
         run: make lint
@@ -52,6 +53,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "lambda-vm"
+          cache-all-crates: "true"
 
       - name: Cache compiled ASM ELF artifacts
         id: cache-asm-elfs
@@ -83,27 +85,27 @@ jobs:
 
       - name: Run asm tests (no compile)
         run: |
-          make test-asm-no-compile
+          cargo test --release -p executor --test asm
 
       - name: Run rust tests (no compile)
         run: |
-          make test-rust-no-compile
+          cargo test --release -p executor --test rust
 
       - name: Run flamegraph tests
         run: |
-          make test-flamegraph
+          cargo test --release -p executor --test flamegraph
 
-      - name: Run ignored executor tests (release)
+      - name: Run ignored executor tests
         run: |
           make prepare-test-data
-          cargo test -p executor --release test_ethrex -- --ignored
-          cargo test -p executor --release test_ckzg -- --ignored
+          cargo test --release -p executor test_ethrex -- --ignored
+          cargo test --release -p executor test_ckzg -- --ignored
 
       - name: Run prover and crypto tests
         run: |
-          cargo test -p lambda-vm-prover -p stark -p crypto --release -- --test-threads=1
+          cargo test --release -p lambda-vm-prover -p stark -p crypto -- --test-threads=1
 
       - name: Run comprehensive prover tests (merge queue only)
         if: github.event_name == 'merge_group'
         run: |
-          cargo test -p lambda-vm-prover --release test_prove_elfs_all_instructions_64_full -- --ignored
+          cargo test --release -p lambda-vm-prover test_prove_elfs_all_instructions_64_full -- --ignored

--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Cache cargo build artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "lambda-vm"
+          shared-key: "lambda-vm-lint"
           cache-all-crates: "true"
 
       - name: Run lint checks
@@ -52,7 +52,7 @@ jobs:
       - name: Cache cargo build artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "lambda-vm"
+          shared-key: "lambda-vm-test"
           cache-all-crates: "true"
 
       - name: Cache compiled ASM ELF artifacts


### PR DESCRIPTION
Cache wasn't workign as expected and was takign too much time. This fixes it.

Errors:

- Cache was shared between al jobs, but some run in release and some in dev, so they will re compile most of the time

This gives a new 50% more of time:

  | Step | Original (mixed, no cache) | All release (no cache) | Cached |
  |------|:-:|:-:|:-:|
  | ASM tests | 4m 33s | 3m 21s | 3s |
  | Rust tests | 4s | 2s | 3s |
  | Flamegraph | 2s | 1s | 1s |
  | Ignored executor | 3m 28s | 17s | 18s |
  | Prover + crypto | 7m 55s | 8m 6s | 6m 32s |
  | **Total job** | **~17m** | **~13m 32s** | **~8m 16s** |