### PR TITLE
Fix security options

### DIFF
--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -79,8 +79,18 @@ fn main() -> ExitCode {
 
     match cli.command {
         Commands::Execute { elf, flamegraph } => cmd_execute(elf, flamegraph),
-        Commands::Prove { elf, output, blowup, time } => cmd_prove(elf, output, blowup, time),
-        Commands::Verify { proof, elf, blowup, time } => cmd_verify(proof, elf, blowup, time),
+        Commands::Prove {
+            elf,
+            output,
+            blowup,
+            time,
+        } => cmd_prove(elf, output, blowup, time),
+        Commands::Verify {
+            proof,
+            elf,
+            blowup,
+            time,
+        } => cmd_verify(proof, elf, blowup, time),
     }
 }
 
@@ -181,8 +191,17 @@ fn cmd_prove(elf_path: PathBuf, output_path: PathBuf, blowup: Option<u8>, time: 
     let start = Instant::now();
     let proof = match blowup {
         Some(b) => {
-            let opts = GoldilocksCubicProofOptions::with_blowup(b);
-            eprintln!("Generating proof (blowup={b}, queries={})...", opts.fri_number_of_queries);
+            let opts = match GoldilocksCubicProofOptions::with_blowup(b) {
+                Ok(opts) => opts,
+                Err(e) => {
+                    eprintln!("Invalid proof options: {e}");
+                    return ExitCode::FAILURE;
+                }
+            };
+            eprintln!(
+                "Generating proof (blowup={b}, queries={})...",
+                opts.fri_number_of_queries
+            );
             prover::prove_with_options(&elf_data, &opts)
         }
         None => {
@@ -260,7 +279,13 @@ fn cmd_verify(proof_path: PathBuf, elf_path: PathBuf, blowup: Option<u8>, time: 
     let start = Instant::now();
     let result = match blowup {
         Some(b) => {
-            let opts = GoldilocksCubicProofOptions::with_blowup(b);
+            let opts = match GoldilocksCubicProofOptions::with_blowup(b) {
+                Ok(opts) => opts,
+                Err(e) => {
+                    eprintln!("Invalid proof options: {e}");
+                    return ExitCode::FAILURE;
+                }
+            };
             prover::verify_with_options(&proof, &elf_data, &opts)
         }
         None => prover::verify(&proof, &elf_data),

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -4,6 +4,7 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::time::Instant;
 
 use clap::{Parser, Subcommand, ValueHint};
 use executor::{
@@ -12,6 +13,7 @@ use executor::{
     vm::execution::Executor,
 };
 use prover::VmProof;
+use stark::proof::options::GoldilocksCubicProofOptions;
 
 #[derive(Parser)]
 #[command(author, version, about = "Lambda VM - RISC-V zkVM", long_about = None)]
@@ -42,6 +44,14 @@ enum Commands {
         /// Output path for the proof bundle
         #[arg(short, long, value_hint = ValueHint::FilePath)]
         output: PathBuf,
+
+        /// Blowup factor (power of 2). Higher = fewer queries, smaller proof, slower proving.
+        #[arg(long)]
+        blowup: Option<u8>,
+
+        /// Print timing breakdown
+        #[arg(long)]
+        time: bool,
     },
 
     /// Verify a proof bundle
@@ -53,6 +63,14 @@ enum Commands {
         /// Path to the ELF file (required for DECODE table verification)
         #[arg(value_parser, value_hint = ValueHint::FilePath)]
         elf: PathBuf,
+
+        /// Blowup factor used during proving (must match)
+        #[arg(long)]
+        blowup: Option<u8>,
+
+        /// Print timing breakdown
+        #[arg(long)]
+        time: bool,
     },
 }
 
@@ -61,8 +79,8 @@ fn main() -> ExitCode {
 
     match cli.command {
         Commands::Execute { elf, flamegraph } => cmd_execute(elf, flamegraph),
-        Commands::Prove { elf, output } => cmd_prove(elf, output),
-        Commands::Verify { proof, elf } => cmd_verify(proof, elf),
+        Commands::Prove { elf, output, blowup, time } => cmd_prove(elf, output, blowup, time),
+        Commands::Verify { proof, elf, blowup, time } => cmd_verify(proof, elf, blowup, time),
     }
 }
 
@@ -150,7 +168,7 @@ fn cmd_execute(elf_path: PathBuf, flamegraph_path: Option<PathBuf>) -> ExitCode 
     ExitCode::SUCCESS
 }
 
-fn cmd_prove(elf_path: PathBuf, output_path: PathBuf) -> ExitCode {
+fn cmd_prove(elf_path: PathBuf, output_path: PathBuf, blowup: Option<u8>, time: bool) -> ExitCode {
     eprintln!("Reading ELF file...");
     let elf_data = match std::fs::read(&elf_path) {
         Ok(data) => data,
@@ -160,8 +178,20 @@ fn cmd_prove(elf_path: PathBuf, output_path: PathBuf) -> ExitCode {
         }
     };
 
-    eprintln!("Generating proof (this may take a while)...");
-    let proof = match prover::prove(&elf_data) {
+    let start = Instant::now();
+    let proof = match blowup {
+        Some(b) => {
+            let opts = GoldilocksCubicProofOptions::with_blowup(b);
+            eprintln!("Generating proof (blowup={b}, queries={})...", opts.fri_number_of_queries);
+            prover::prove_with_options(&elf_data, &opts)
+        }
+        None => {
+            eprintln!("Generating proof...");
+            prover::prove(&elf_data)
+        }
+    };
+    let prove_elapsed = start.elapsed();
+    let proof = match proof {
         Ok(proof) => proof,
         Err(e) => {
             eprintln!("Proof generation failed: {}", e);
@@ -193,10 +223,13 @@ fn cmd_prove(elf_path: PathBuf, output_path: PathBuf) -> ExitCode {
     }
 
     eprintln!("Proof written to {:?}", output_path);
+    if time {
+        println!("Proving time: {:.3}s", prove_elapsed.as_secs_f64());
+    }
     ExitCode::SUCCESS
 }
 
-fn cmd_verify(proof_path: PathBuf, elf_path: PathBuf) -> ExitCode {
+fn cmd_verify(proof_path: PathBuf, elf_path: PathBuf, blowup: Option<u8>, time: bool) -> ExitCode {
     eprintln!("Reading ELF file...");
     let elf_data = match std::fs::read(&elf_path) {
         Ok(data) => data,
@@ -224,7 +257,16 @@ fn cmd_verify(proof_path: PathBuf, elf_path: PathBuf) -> ExitCode {
     };
 
     eprintln!("Verifying proof...");
-    let result = match prover::verify(&proof, &elf_data) {
+    let start = Instant::now();
+    let result = match blowup {
+        Some(b) => {
+            let opts = GoldilocksCubicProofOptions::with_blowup(b);
+            prover::verify_with_options(&proof, &elf_data, &opts)
+        }
+        None => prover::verify(&proof, &elf_data),
+    };
+    let verify_elapsed = start.elapsed();
+    let result = match result {
         Ok(valid) => valid,
         Err(e) => {
             eprintln!("Verification error: {}", e);
@@ -234,6 +276,9 @@ fn cmd_verify(proof_path: PathBuf, elf_path: PathBuf) -> ExitCode {
 
     if result {
         eprintln!("Verification succeeded!");
+        if time {
+            println!("Verification time: {:.3}s", verify_elapsed.as_secs_f64());
+        }
         ExitCode::SUCCESS
     } else {
         eprintln!("Verification failed!");

--- a/crypto/stark/src/proof/errors.rs
+++ b/crypto/stark/src/proof/errors.rs
@@ -1,7 +1,0 @@
-#[derive(Debug)]
-pub enum InsecureOptionError {
-    /// Field Size is not big enough
-    FieldSize,
-    /// Number of security bits is not enough
-    LowSecurityBits,
-}

--- a/crypto/stark/src/proof/mod.rs
+++ b/crypto/stark/src/proof/mod.rs
@@ -1,3 +1,2 @@
-pub mod errors;
 pub mod options;
 pub mod stark;

--- a/crypto/stark/src/proof/options.rs
+++ b/crypto/stark/src/proof/options.rs
@@ -1,6 +1,3 @@
-use super::errors::InsecureOptionError;
-use math::field::traits::IsPrimeField;
-
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -20,87 +17,6 @@ pub struct ProofOptions {
 }
 
 impl ProofOptions {
-    // TODO: Make it work for extended fields
-    const EXTENSION_DEGREE: usize = 1;
-    // Estimated maximum domain size. 2^40 = 1 TB
-    const NUM_BITS_MAX_DOMAIN_SIZE: usize = 40;
-
-    /// Checks security of proof options given 128 bits of security
-    pub fn new_with_checked_security<F: IsPrimeField>(
-        blowup_factor: u8,
-        fri_number_of_queries: usize,
-        coset_offset: u64,
-        grinding_factor: u8,
-        security_target: u8,
-    ) -> Result<Self, InsecureOptionError> {
-        Self::check_field_security::<F>(security_target)?;
-
-        let num_bits_blowup_factor = blowup_factor.trailing_zeros() as usize;
-
-        if security_target as usize
-            >= grinding_factor as usize + num_bits_blowup_factor * fri_number_of_queries - 1
-        {
-            return Err(InsecureOptionError::LowSecurityBits);
-        }
-
-        Ok(ProofOptions {
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
-        })
-    }
-
-    /// Checks provable security of proof options given 128 bits of security
-    /// This is an approximation. It's stricter than the formula in the paper.
-    /// See https://eprint.iacr.org/2021/582.pdf
-    pub fn new_with_checked_provable_security<F: IsPrimeField>(
-        blowup_factor: u8,
-        fri_number_of_queries: usize,
-        coset_offset: u64,
-        grinding_factor: u8,
-        security_target: u8,
-    ) -> Result<Self, InsecureOptionError> {
-        Self::check_field_security::<F>(security_target)?;
-
-        let num_bits_blowup_factor = blowup_factor.leading_zeros() as usize;
-
-        if (security_target as usize)
-            < grinding_factor as usize + num_bits_blowup_factor * fri_number_of_queries / 2
-        {
-            return Err(InsecureOptionError::LowSecurityBits);
-        }
-
-        Ok(ProofOptions {
-            blowup_factor,
-            fri_number_of_queries,
-            coset_offset,
-            grinding_factor,
-        })
-    }
-
-    fn check_field_security<F: IsPrimeField>(
-        security_target: u8,
-    ) -> Result<(), InsecureOptionError> {
-        if F::field_bit_size() * Self::EXTENSION_DEGREE
-            <= security_target as usize + Self::NUM_BITS_MAX_DOMAIN_SIZE
-        {
-            return Err(InsecureOptionError::FieldSize);
-        }
-
-        Ok(())
-    }
-
-    /// Default proof options with provable 100-bit security.
-    pub fn default_proving_options() -> Self {
-        Self {
-            blowup_factor: 4,
-            fri_number_of_queries: 104,
-            coset_offset: 3,
-            grinding_factor: 20,
-        }
-    }
-
     /// Default proof options used for testing purposes.
     /// These options should never be used in production.
     pub fn default_test_options() -> Self {
@@ -113,86 +29,54 @@ impl ProofOptions {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use math::field::fields::{
-        fft_friendly::stark_252_prime_field::Stark252PrimeField, u64_prime_field::F17,
-    };
+/// Proof options builder for Goldilocks **cubic** extension field (degree 3).
+///
+/// Goldilocks base field: 64 bits (p = 2^64 - 2^32 + 1)
+/// Cubic extension: degree 3 (w^3 = 2), giving 192-bit effective field size.
+///
+/// Computes FRI query count using the Johnson Bound Regime (JBR):
+///   proximity = 1 - sqrt(1/blowup) - 1/300
+///   bits_per_query = -log2(1 - proximity)
+///   queries = ceil((security_bits - grinding) / bits_per_query)
+///
+/// The 192-bit effective field comfortably supports up to 152-bit security
+/// (192 - 40 bits max domain), so the FRI query count is always the
+/// security bottleneck — field size is not.
+pub struct GoldilocksCubicProofOptions;
 
-    use crate::proof::errors::InsecureOptionError;
+#[allow(clippy::new_ret_no_self)]
+impl GoldilocksCubicProofOptions {
+    const DEFAULT_GRINDING: u8 = 20;
 
-    use super::ProofOptions;
-
-    const BLOWUP_FACTOR: u8 = 4;
-    const COSET_OFFSET: u64 = 1;
-    const GRINDING_FACTOR: u8 = 20;
-
-    // FRI queries needed per security level (conjecturable).
-    // See section 5.10.1 of https://eprint.iacr.org/2021/582.pdf
-    const FRI_QUERIES_80_BITS: usize = 31;
-    const FRI_QUERIES_100_BITS: usize = 41;
-    const FRI_QUERIES_128_BITS: usize = 55;
-
-    #[test]
-    fn u64_prime_field_is_not_large_enough_to_be_secure() {
-        let u64_options = ProofOptions::new_with_checked_security::<F17>(
-            BLOWUP_FACTOR,
-            FRI_QUERIES_128_BITS,
-            COSET_OFFSET,
-            GRINDING_FACTOR,
-            128,
-        );
-        assert!(matches!(u64_options, Err(InsecureOptionError::FieldSize)));
+    /// Create proof options targeting 128-bit security with default grinding (20 bits).
+    ///
+    /// `blowup_factor` must be a power of 2 >= 2 (e.g., 2, 4, 8, 16, 32, 64).
+    pub fn new(blowup_factor: u8) -> ProofOptions {
+        Self::with_params(blowup_factor, 128, Self::DEFAULT_GRINDING)
     }
 
-    #[test]
-    fn conjecturable_128_bits_are_secure() {
-        let secure_options = ProofOptions::new_with_checked_security::<Stark252PrimeField>(
-            BLOWUP_FACTOR,
-            FRI_QUERIES_128_BITS,
-            COSET_OFFSET,
-            GRINDING_FACTOR,
-            128,
+    /// Create proof options with custom security target and grinding factor.
+    pub fn with_params(
+        blowup_factor: u8,
+        security_bits: u8,
+        grinding_factor: u8,
+    ) -> ProofOptions {
+        assert!(
+            blowup_factor.is_power_of_two() && blowup_factor >= 2,
+            "blowup_factor must be a power of 2 >= 2, got {blowup_factor}"
         );
-        assert!(secure_options.is_ok());
-    }
 
-    #[test]
-    fn conjecturable_128_bits_with_one_fri_query_less_are_insecure() {
-        let insecure_options = ProofOptions::new_with_checked_security::<Stark252PrimeField>(
-            BLOWUP_FACTOR,
-            FRI_QUERIES_128_BITS - 1,
-            COSET_OFFSET,
-            GRINDING_FACTOR,
-            128,
-        );
-        assert!(matches!(
-            insecure_options,
-            Err(InsecureOptionError::LowSecurityBits)
-        ));
-    }
+        let rate = 1.0 / blowup_factor as f64;
+        let proximity = 1.0 - rate.sqrt() - 1.0 / 300.0;
+        let bits_per_query = -(1.0 - proximity).log2();
+        let fri_number_of_queries =
+            ((security_bits as f64 - grinding_factor as f64) / bits_per_query).ceil() as usize;
 
-    #[test]
-    fn conjecturable_100_bits_are_secure() {
-        let secure_options = ProofOptions::new_with_checked_security::<Stark252PrimeField>(
-            BLOWUP_FACTOR,
-            FRI_QUERIES_100_BITS,
-            COSET_OFFSET,
-            GRINDING_FACTOR,
-            100,
-        );
-        assert!(secure_options.is_ok());
-    }
-
-    #[test]
-    fn conjecturable_80_bits_are_secure() {
-        let secure_options = ProofOptions::new_with_checked_security::<Stark252PrimeField>(
-            BLOWUP_FACTOR,
-            FRI_QUERIES_80_BITS,
-            COSET_OFFSET,
-            GRINDING_FACTOR,
-            80,
-        );
-        assert!(secure_options.is_ok());
+        ProofOptions {
+            blowup_factor,
+            fri_number_of_queries,
+            coset_offset: 3,
+            grinding_factor,
+        }
     }
 }

--- a/crypto/stark/src/proof/options.rs
+++ b/crypto/stark/src/proof/options.rs
@@ -1,5 +1,36 @@
+use core::fmt;
+
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
+
+/// Error returned when proof options are invalid.
+#[derive(Debug, Clone)]
+pub enum ProofOptionsError {
+    /// blowup_factor must be a power of 2 >= 2
+    InvalidBlowup(u8),
+    /// security_bits must exceed grinding_factor
+    SecurityTooLow {
+        security_bits: u8,
+        grinding_factor: u8,
+    },
+}
+
+impl fmt::Display for ProofOptionsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidBlowup(b) => {
+                write!(f, "blowup_factor must be a power of 2 >= 2, got {b}")
+            }
+            Self::SecurityTooLow {
+                security_bits,
+                grinding_factor,
+            } => write!(
+                f,
+                "security_bits ({security_bits}) must exceed grinding_factor ({grinding_factor})"
+            ),
+        }
+    }
+}
 
 /// The options for the proof
 ///
@@ -50,7 +81,7 @@ impl GoldilocksCubicProofOptions {
     /// Create proof options targeting 128-bit security with default grinding (20 bits).
     ///
     /// `blowup_factor` must be a power of 2 >= 2 (e.g., 2, 4, 8, 16, 32, 64).
-    pub fn with_blowup(blowup_factor: u8) -> ProofOptions {
+    pub fn with_blowup(blowup_factor: u8) -> Result<ProofOptions, ProofOptionsError> {
         Self::with_params(blowup_factor, 128, Self::DEFAULT_GRINDING)
     }
 
@@ -59,11 +90,16 @@ impl GoldilocksCubicProofOptions {
         blowup_factor: u8,
         security_bits: u8,
         grinding_factor: u8,
-    ) -> ProofOptions {
-        assert!(
-            blowup_factor.is_power_of_two() && blowup_factor >= 2,
-            "blowup_factor must be a power of 2 >= 2, got {blowup_factor}"
-        );
+    ) -> Result<ProofOptions, ProofOptionsError> {
+        if !blowup_factor.is_power_of_two() || blowup_factor < 2 {
+            return Err(ProofOptionsError::InvalidBlowup(blowup_factor));
+        }
+        if security_bits <= grinding_factor {
+            return Err(ProofOptionsError::SecurityTooLow {
+                security_bits,
+                grinding_factor,
+            });
+        }
 
         let rate = 1.0 / blowup_factor as f64;
         let proximity = 1.0 - rate.sqrt() - 1.0 / 300.0;
@@ -71,11 +107,11 @@ impl GoldilocksCubicProofOptions {
         let fri_number_of_queries =
             ((security_bits as f64 - grinding_factor as f64) / bits_per_query).ceil() as usize;
 
-        ProofOptions {
+        Ok(ProofOptions {
             blowup_factor,
             fri_number_of_queries,
             coset_offset: 3,
             grinding_factor,
-        }
+        })
     }
 }

--- a/crypto/stark/src/proof/options.rs
+++ b/crypto/stark/src/proof/options.rs
@@ -21,7 +21,7 @@ impl ProofOptions {
     /// These options should never be used in production.
     pub fn default_test_options() -> Self {
         Self {
-            blowup_factor: 4,
+            blowup_factor: 2,
             fri_number_of_queries: 3,
             coset_offset: 3,
             grinding_factor: 1,
@@ -44,14 +44,13 @@ impl ProofOptions {
 /// security bottleneck — field size is not.
 pub struct GoldilocksCubicProofOptions;
 
-#[allow(clippy::new_ret_no_self)]
 impl GoldilocksCubicProofOptions {
     const DEFAULT_GRINDING: u8 = 20;
 
     /// Create proof options targeting 128-bit security with default grinding (20 bits).
     ///
     /// `blowup_factor` must be a power of 2 >= 2 (e.g., 2, 4, 8, 16, 32, 64).
-    pub fn new(blowup_factor: u8) -> ProofOptions {
+    pub fn with_blowup(blowup_factor: u8) -> ProofOptions {
         Self::with_params(blowup_factor, 128, Self::DEFAULT_GRINDING)
     }
 

--- a/crypto/stark/src/tests/mod.rs
+++ b/crypto/stark/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod air_tests;
 pub mod bus_tests;
+pub mod proof_options_tests;
 pub mod prove_verify_roundtrip_tests;
 pub mod small_trace_tests;

--- a/crypto/stark/src/tests/proof_options_tests.rs
+++ b/crypto/stark/src/tests/proof_options_tests.rs
@@ -3,21 +3,21 @@ use crate::proof::options::{GoldilocksCubicProofOptions, ProofOptions};
 #[test]
 fn jbr_queries_match_expected_values() {
     // Verified against zisk's pil2-proofman-js security calculator
-    assert_eq!(GoldilocksCubicProofOptions::new(2).fri_number_of_queries, 219);
-    assert_eq!(GoldilocksCubicProofOptions::new(4).fri_number_of_queries, 110);
-    assert_eq!(GoldilocksCubicProofOptions::new(8).fri_number_of_queries, 73);
+    assert_eq!(GoldilocksCubicProofOptions::with_blowup(2).fri_number_of_queries, 219);
+    assert_eq!(GoldilocksCubicProofOptions::with_blowup(4).fri_number_of_queries, 110);
+    assert_eq!(GoldilocksCubicProofOptions::with_blowup(8).fri_number_of_queries, 73);
     // with_params allows custom grinding — zisk uses 22 for final layers
     assert_eq!(GoldilocksCubicProofOptions::with_params(32, 128, 22).fri_number_of_queries, 43);
     assert_eq!(GoldilocksCubicProofOptions::with_params(64, 128, 22).fri_number_of_queries, 36);
     // default grinding=20 gives slightly more queries
-    assert_eq!(GoldilocksCubicProofOptions::new(32).fri_number_of_queries, 44);
-    assert_eq!(GoldilocksCubicProofOptions::new(64).fri_number_of_queries, 37);
+    assert_eq!(GoldilocksCubicProofOptions::with_blowup(32).fri_number_of_queries, 44);
+    assert_eq!(GoldilocksCubicProofOptions::with_blowup(64).fri_number_of_queries, 37);
 }
 
 #[test]
 fn default_grinding_is_20() {
-    assert_eq!(GoldilocksCubicProofOptions::new(4).grinding_factor, 20);
-    assert_eq!(GoldilocksCubicProofOptions::new(64).grinding_factor, 20);
+    assert_eq!(GoldilocksCubicProofOptions::with_blowup(4).grinding_factor, 20);
+    assert_eq!(GoldilocksCubicProofOptions::with_blowup(64).grinding_factor, 20);
 }
 
 #[test]
@@ -25,33 +25,33 @@ fn custom_grinding() {
     let opts = GoldilocksCubicProofOptions::with_params(4, 128, 22);
     assert_eq!(opts.grinding_factor, 22);
     // More grinding → fewer queries needed
-    assert!(opts.fri_number_of_queries < GoldilocksCubicProofOptions::new(4).fri_number_of_queries);
+    assert!(opts.fri_number_of_queries < GoldilocksCubicProofOptions::with_blowup(4).fri_number_of_queries);
 }
 
 #[test]
 fn higher_blowup_means_fewer_queries() {
-    let q2 = GoldilocksCubicProofOptions::new(2).fri_number_of_queries;
-    let q4 = GoldilocksCubicProofOptions::new(4).fri_number_of_queries;
-    let q8 = GoldilocksCubicProofOptions::new(8).fri_number_of_queries;
+    let q2 = GoldilocksCubicProofOptions::with_blowup(2).fri_number_of_queries;
+    let q4 = GoldilocksCubicProofOptions::with_blowup(4).fri_number_of_queries;
+    let q8 = GoldilocksCubicProofOptions::with_blowup(8).fri_number_of_queries;
     assert!(q2 > q4 && q4 > q8);
 }
 
 #[test]
 #[should_panic(expected = "blowup_factor must be a power of 2")]
 fn rejects_non_power_of_two() {
-    GoldilocksCubicProofOptions::new(3);
+    GoldilocksCubicProofOptions::with_blowup(3);
 }
 
 #[test]
 #[should_panic(expected = "blowup_factor must be a power of 2")]
 fn rejects_blowup_one() {
-    GoldilocksCubicProofOptions::new(1);
+    GoldilocksCubicProofOptions::with_blowup(1);
 }
 
 #[test]
 fn test_options_unchanged() {
     let opts = ProofOptions::default_test_options();
-    assert_eq!(opts.blowup_factor, 4);
+    assert_eq!(opts.blowup_factor, 2);
     assert_eq!(opts.fri_number_of_queries, 3);
     assert_eq!(opts.grinding_factor, 1);
 }

--- a/crypto/stark/src/tests/proof_options_tests.rs
+++ b/crypto/stark/src/tests/proof_options_tests.rs
@@ -1,0 +1,57 @@
+use crate::proof::options::{GoldilocksCubicProofOptions, ProofOptions};
+
+#[test]
+fn jbr_queries_match_expected_values() {
+    // Verified against zisk's pil2-proofman-js security calculator
+    assert_eq!(GoldilocksCubicProofOptions::new(2).fri_number_of_queries, 219);
+    assert_eq!(GoldilocksCubicProofOptions::new(4).fri_number_of_queries, 110);
+    assert_eq!(GoldilocksCubicProofOptions::new(8).fri_number_of_queries, 73);
+    // with_params allows custom grinding — zisk uses 22 for final layers
+    assert_eq!(GoldilocksCubicProofOptions::with_params(32, 128, 22).fri_number_of_queries, 43);
+    assert_eq!(GoldilocksCubicProofOptions::with_params(64, 128, 22).fri_number_of_queries, 36);
+    // default grinding=20 gives slightly more queries
+    assert_eq!(GoldilocksCubicProofOptions::new(32).fri_number_of_queries, 44);
+    assert_eq!(GoldilocksCubicProofOptions::new(64).fri_number_of_queries, 37);
+}
+
+#[test]
+fn default_grinding_is_20() {
+    assert_eq!(GoldilocksCubicProofOptions::new(4).grinding_factor, 20);
+    assert_eq!(GoldilocksCubicProofOptions::new(64).grinding_factor, 20);
+}
+
+#[test]
+fn custom_grinding() {
+    let opts = GoldilocksCubicProofOptions::with_params(4, 128, 22);
+    assert_eq!(opts.grinding_factor, 22);
+    // More grinding → fewer queries needed
+    assert!(opts.fri_number_of_queries < GoldilocksCubicProofOptions::new(4).fri_number_of_queries);
+}
+
+#[test]
+fn higher_blowup_means_fewer_queries() {
+    let q2 = GoldilocksCubicProofOptions::new(2).fri_number_of_queries;
+    let q4 = GoldilocksCubicProofOptions::new(4).fri_number_of_queries;
+    let q8 = GoldilocksCubicProofOptions::new(8).fri_number_of_queries;
+    assert!(q2 > q4 && q4 > q8);
+}
+
+#[test]
+#[should_panic(expected = "blowup_factor must be a power of 2")]
+fn rejects_non_power_of_two() {
+    GoldilocksCubicProofOptions::new(3);
+}
+
+#[test]
+#[should_panic(expected = "blowup_factor must be a power of 2")]
+fn rejects_blowup_one() {
+    GoldilocksCubicProofOptions::new(1);
+}
+
+#[test]
+fn test_options_unchanged() {
+    let opts = ProofOptions::default_test_options();
+    assert_eq!(opts.blowup_factor, 4);
+    assert_eq!(opts.fri_number_of_queries, 3);
+    assert_eq!(opts.grinding_factor, 1);
+}

--- a/crypto/stark/src/tests/proof_options_tests.rs
+++ b/crypto/stark/src/tests/proof_options_tests.rs
@@ -1,51 +1,119 @@
-use crate::proof::options::{GoldilocksCubicProofOptions, ProofOptions};
+use crate::proof::options::{GoldilocksCubicProofOptions, ProofOptions, ProofOptionsError};
 
 #[test]
 fn jbr_queries_match_expected_values() {
     // Verified against zisk's pil2-proofman-js security calculator
-    assert_eq!(GoldilocksCubicProofOptions::with_blowup(2).fri_number_of_queries, 219);
-    assert_eq!(GoldilocksCubicProofOptions::with_blowup(4).fri_number_of_queries, 110);
-    assert_eq!(GoldilocksCubicProofOptions::with_blowup(8).fri_number_of_queries, 73);
+    assert_eq!(
+        GoldilocksCubicProofOptions::with_blowup(2)
+            .unwrap()
+            .fri_number_of_queries,
+        219
+    );
+    assert_eq!(
+        GoldilocksCubicProofOptions::with_blowup(4)
+            .unwrap()
+            .fri_number_of_queries,
+        110
+    );
+    assert_eq!(
+        GoldilocksCubicProofOptions::with_blowup(8)
+            .unwrap()
+            .fri_number_of_queries,
+        73
+    );
     // with_params allows custom grinding — zisk uses 22 for final layers
-    assert_eq!(GoldilocksCubicProofOptions::with_params(32, 128, 22).fri_number_of_queries, 43);
-    assert_eq!(GoldilocksCubicProofOptions::with_params(64, 128, 22).fri_number_of_queries, 36);
+    assert_eq!(
+        GoldilocksCubicProofOptions::with_params(32, 128, 22)
+            .unwrap()
+            .fri_number_of_queries,
+        43
+    );
+    assert_eq!(
+        GoldilocksCubicProofOptions::with_params(64, 128, 22)
+            .unwrap()
+            .fri_number_of_queries,
+        36
+    );
     // default grinding=20 gives slightly more queries
-    assert_eq!(GoldilocksCubicProofOptions::with_blowup(32).fri_number_of_queries, 44);
-    assert_eq!(GoldilocksCubicProofOptions::with_blowup(64).fri_number_of_queries, 37);
+    assert_eq!(
+        GoldilocksCubicProofOptions::with_blowup(32)
+            .unwrap()
+            .fri_number_of_queries,
+        44
+    );
+    assert_eq!(
+        GoldilocksCubicProofOptions::with_blowup(64)
+            .unwrap()
+            .fri_number_of_queries,
+        37
+    );
 }
 
 #[test]
 fn default_grinding_is_20() {
-    assert_eq!(GoldilocksCubicProofOptions::with_blowup(4).grinding_factor, 20);
-    assert_eq!(GoldilocksCubicProofOptions::with_blowup(64).grinding_factor, 20);
+    assert_eq!(
+        GoldilocksCubicProofOptions::with_blowup(4)
+            .unwrap()
+            .grinding_factor,
+        20
+    );
+    assert_eq!(
+        GoldilocksCubicProofOptions::with_blowup(64)
+            .unwrap()
+            .grinding_factor,
+        20
+    );
 }
 
 #[test]
 fn custom_grinding() {
-    let opts = GoldilocksCubicProofOptions::with_params(4, 128, 22);
+    let opts = GoldilocksCubicProofOptions::with_params(4, 128, 22).unwrap();
     assert_eq!(opts.grinding_factor, 22);
     // More grinding → fewer queries needed
-    assert!(opts.fri_number_of_queries < GoldilocksCubicProofOptions::with_blowup(4).fri_number_of_queries);
+    assert!(
+        opts.fri_number_of_queries
+            < GoldilocksCubicProofOptions::with_blowup(4)
+                .unwrap()
+                .fri_number_of_queries
+    );
 }
 
 #[test]
 fn higher_blowup_means_fewer_queries() {
-    let q2 = GoldilocksCubicProofOptions::with_blowup(2).fri_number_of_queries;
-    let q4 = GoldilocksCubicProofOptions::with_blowup(4).fri_number_of_queries;
-    let q8 = GoldilocksCubicProofOptions::with_blowup(8).fri_number_of_queries;
+    let q2 = GoldilocksCubicProofOptions::with_blowup(2)
+        .unwrap()
+        .fri_number_of_queries;
+    let q4 = GoldilocksCubicProofOptions::with_blowup(4)
+        .unwrap()
+        .fri_number_of_queries;
+    let q8 = GoldilocksCubicProofOptions::with_blowup(8)
+        .unwrap()
+        .fri_number_of_queries;
     assert!(q2 > q4 && q4 > q8);
 }
 
 #[test]
-#[should_panic(expected = "blowup_factor must be a power of 2")]
 fn rejects_non_power_of_two() {
-    GoldilocksCubicProofOptions::with_blowup(3);
+    assert!(matches!(
+        GoldilocksCubicProofOptions::with_blowup(3),
+        Err(ProofOptionsError::InvalidBlowup(3))
+    ));
 }
 
 #[test]
-#[should_panic(expected = "blowup_factor must be a power of 2")]
 fn rejects_blowup_one() {
-    GoldilocksCubicProofOptions::with_blowup(1);
+    assert!(matches!(
+        GoldilocksCubicProofOptions::with_blowup(1),
+        Err(ProofOptionsError::InvalidBlowup(1))
+    ));
+}
+
+#[test]
+fn rejects_security_below_grinding() {
+    assert!(matches!(
+        GoldilocksCubicProofOptions::with_params(4, 10, 20),
+        Err(ProofOptionsError::SecurityTooLow { .. })
+    ));
 }
 
 #[test]

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -43,7 +43,7 @@ use crate::test_utils::{
 };
 
 use crate::tables::page::DEFAULT_STACK_SIZE;
-use stark::proof::options::ProofOptions;
+use stark::proof::options::{GoldilocksCubicProofOptions, ProofOptions};
 use stark::proof::stark::MultiProof;
 
 /// A complete VM proof bundle containing the STARK proof and metadata
@@ -222,7 +222,7 @@ impl VmAirs {
 
 /// Prove an ELF binary execution. Returns a serializable proof bundle.
 pub fn prove(elf_bytes: &[u8]) -> Result<VmProof, Error> {
-    prove_with_options(elf_bytes, &ProofOptions::default_proving_options())
+    prove_with_options(elf_bytes, &GoldilocksCubicProofOptions::new(2))
 }
 
 /// Prove an ELF binary execution with custom proof options and stack size.
@@ -255,7 +255,7 @@ pub fn prove_with_options(
 
 /// Verify a proof produced by [`prove`] using default proof options.
 ///
-/// Uses [`ProofOptions::default_proving_options`] for verification — the
+/// Uses [`GoldilocksCubicProofOptions::new(4)`] for verification — the
 /// `proof_options` stored in [`VmProof`] are metadata only and NOT trusted.
 /// `stack_size` is extracted from the proof; it is safe to trust because
 /// preprocessed commitments bind the verifier to the correct page layout.
@@ -263,7 +263,7 @@ pub fn verify(vm_proof: &VmProof, elf_bytes: &[u8]) -> Result<bool, Error> {
     verify_with_options(
         vm_proof,
         elf_bytes,
-        &ProofOptions::default_proving_options(),
+        &GoldilocksCubicProofOptions::new(2),
     )
 }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -222,7 +222,10 @@ impl VmAirs {
 
 /// Prove an ELF binary execution. Returns a serializable proof bundle.
 pub fn prove(elf_bytes: &[u8]) -> Result<VmProof, Error> {
-    prove_with_options(elf_bytes, &GoldilocksCubicProofOptions::with_blowup(2))
+    prove_with_options(
+        elf_bytes,
+        &GoldilocksCubicProofOptions::with_blowup(2).expect("blowup=2 is always valid"),
+    )
 }
 
 /// Prove an ELF binary execution with custom proof options and stack size.
@@ -255,7 +258,7 @@ pub fn prove_with_options(
 
 /// Verify a proof produced by [`prove`] using default proof options.
 ///
-/// Uses [`GoldilocksCubicProofOptions::new(4)`] for verification — the
+/// Uses [`GoldilocksCubicProofOptions::with_blowup(2)`] for verification — the
 /// `proof_options` stored in [`VmProof`] are metadata only and NOT trusted.
 /// `stack_size` is extracted from the proof; it is safe to trust because
 /// preprocessed commitments bind the verifier to the correct page layout.
@@ -263,7 +266,7 @@ pub fn verify(vm_proof: &VmProof, elf_bytes: &[u8]) -> Result<bool, Error> {
     verify_with_options(
         vm_proof,
         elf_bytes,
-        &GoldilocksCubicProofOptions::with_blowup(2),
+        &GoldilocksCubicProofOptions::with_blowup(2).expect("blowup=2 is always valid"),
     )
 }
 

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -222,7 +222,7 @@ impl VmAirs {
 
 /// Prove an ELF binary execution. Returns a serializable proof bundle.
 pub fn prove(elf_bytes: &[u8]) -> Result<VmProof, Error> {
-    prove_with_options(elf_bytes, &GoldilocksCubicProofOptions::new(2))
+    prove_with_options(elf_bytes, &GoldilocksCubicProofOptions::with_blowup(2))
 }
 
 /// Prove an ELF binary execution with custom proof options and stack size.
@@ -263,7 +263,7 @@ pub fn verify(vm_proof: &VmProof, elf_bytes: &[u8]) -> Result<bool, Error> {
     verify_with_options(
         vm_proof,
         elf_bytes,
-        &GoldilocksCubicProofOptions::new(2),
+        &GoldilocksCubicProofOptions::with_blowup(2),
     )
 }
 


### PR DESCRIPTION
## Security options

Options where hardcoded to work for Stark field, this fixes it, sets the default for blowup factor 2, and also adds a time flag to bench

## What changed

  crypto/stark/src/proof/options.rs — Replaced the old security checking API with a new GoldilocksCubicProofOptions builder that computes FRI query counts using the Johnson Bound Regime (JBR) formula:
  - Removed new_with_checked_security, new_with_checked_provable_security, check_field_security, default_proving_options and the InsecureOptionError type
  - Added GoldilocksCubicProofOptions::with_blowup(blowup) — targets 128-bit security with default grinding (20 bits)
  - Added GoldilocksCubicProofOptions::with_params(blowup, security_bits, grinding) — full customization
  - Both return Result<ProofOptions, ProofOptionsError> instead of panicking
  - New ProofOptionsError enum with InvalidBlowup and SecurityTooLow variants

  bin/cli/src/main.rs — Added --blowup and --time flags to prove and verify commands:
  - --blowup <N>: custom blowup factor (power of 2, >= 2)
  - --time: print proving/verification time
  - Invalid blowup values produce clean error messages (no panics)

  prover/src/lib.rs:
  - prove() and verify() default to blowup=2 (219 queries, 128-bit security)
  - Fixed incorrect doc comment (new(4) → with_blowup(2))

  crypto/stark/src/tests/proof_options_tests.rs — New test file with 8 tests:
  - JBR query counts verified against zisk's pil2-proofman-js calculator
  - Rejection tests for invalid blowup and security < grinding
  - Monotonicity test (higher blowup → fewer queries)