### PR TITLE
Fix fetch main data on memory/time bench

### DIFF
--- a/.github/workflows/prover-profile.yml
+++ b/.github/workflows/prover-profile.yml
@@ -88,7 +88,7 @@ jobs:
             echo "::notice::No successful run found on main"
             exit 0
           fi
-          gh run download "$RUN_ID" -D baseline/ -p "memory-metrics-*"
+          gh run download "$RUN_ID" -D baseline/ -p "memory-metrics-*" || echo "::warning::Failed to download baseline artifact"
 
       - name: Compare with baseline
         id: compare

--- a/.github/workflows/prover-profile.yml
+++ b/.github/workflows/prover-profile.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   pull-requests: write
 
 jobs:
@@ -76,19 +77,18 @@ jobs:
           retention-days: 90
 
       - name: Download baseline from main
-        id: baseline
         if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          branch: main
-          workflow: prover-profile.yml
-          workflow_conclusion: success
-          name: memory-metrics-.*
-          name_is_regexp: true
-          search_artifacts: true
-          path: baseline/
-          if_no_artifact_found: warn
-        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RUN_ID=$(gh run list -w prover-profile.yml -b main -s completed \
+            --json databaseId,conclusion \
+            -q '[.[] | select(.conclusion=="success")][0].databaseId')
+          if [ -z "$RUN_ID" ]; then
+            echo "::notice::No successful run found on main"
+            exit 0
+          fi
+          gh run download "$RUN_ID" -D baseline/ -p "memory-metrics-*"
 
       - name: Compare with baseline
         id: compare


### PR DESCRIPTION
The "Prover Profile" workflow was never posting comparison comments on PRs. The "Download baseline from main" step used dawidd6/action-download-artifact — a third-party action that calls the GitHub Actions API to find artifacts from previous
  runs. That API requires actions: read permission, but the workflow only had contents: read and pull-requests: write. The step failed with Resource not accessible by integration, and because of continue-on-error: true it silently continued. The
  compare step then found no baseline files and skipped the PR comment.

  What changed:
  1. Added actions: read permission
  2. Replaced the third-party dawidd6/action-download-artifact with gh run list + gh run download (pre-installed on all GitHub runners) — eliminates the third-party dependency entirely

  First run behavior: Since there's no baseline artifact on main yet, the first run after merging will upload metrics but skip comparison. The second PR will be the first to get a comparison comment.