### PR TITLE
feat(prover):  Fork Fiat-Shamir transcript per table after shared LogUp challenges

### DIFF
--- a/crypto/crypto/src/fiat_shamir/default_transcript.rs
+++ b/crypto/crypto/src/fiat_shamir/default_transcript.rs
@@ -16,6 +16,15 @@ pub struct DefaultTranscript<F: HasDefaultTranscript> {
     phantom: PhantomData<F>,
 }
 
+impl<F: HasDefaultTranscript> Clone for DefaultTranscript<F> {
+    fn clone(&self) -> Self {
+        Self {
+            hasher: self.hasher.clone(),
+            phantom: PhantomData,
+        }
+    }
+}
+
 impl<F> DefaultTranscript<F>
 where
     F: HasDefaultTranscript,

--- a/crypto/crypto/src/tests/default_transcript_tests.rs
+++ b/crypto/crypto/src/tests/default_transcript_tests.rs
@@ -71,3 +71,63 @@ fn quartic_baby_bear_transcript_distinguish_different_fe() {
     assert!(sample_1 != sample_2);
     assert!(sample_1 == sample_3);
 }
+
+#[test]
+fn fork_determinism() {
+    // Cloning a transcript twice and running the same operations must produce identical challenges.
+    let mut base = DefaultTranscript::<FrField>::default();
+    base.append_bytes(&[0x01, 0x02, 0x03]);
+    let _ = base.sample();
+    base.append_bytes(&[0xAA, 0xBB]);
+
+    let mut fork_a = base.clone();
+    let mut fork_b = base.clone();
+
+    fork_a.append_bytes(&[0x00]);
+    fork_b.append_bytes(&[0x00]);
+
+    assert_eq!(fork_a.sample(), fork_b.sample());
+    assert_eq!(fork_a.sample(), fork_b.sample());
+}
+
+#[test]
+fn fork_domain_separator_differentiates() {
+    // Two forks from the same base with different domain separators must produce different challenges.
+    let mut base = DefaultTranscript::<FrField>::default();
+    base.append_bytes(&[0x01, 0x02, 0x03]);
+    let _ = base.sample();
+    base.append_bytes(&[0xAA, 0xBB]);
+
+    let mut fork_0 = base.clone();
+    fork_0.append_bytes(&(0u64).to_le_bytes());
+
+    let mut fork_1 = base.clone();
+    fork_1.append_bytes(&(1u64).to_le_bytes());
+
+    assert_ne!(fork_0.sample(), fork_1.sample());
+}
+
+#[test]
+fn fork_isolation() {
+    // Appending data to one fork must not affect challenges sampled from another.
+    let mut base = DefaultTranscript::<FrField>::default();
+    base.append_bytes(&[0x01, 0x02, 0x03]);
+    let _ = base.sample();
+
+    let mut fork_a = base.clone();
+    fork_a.append_bytes(&(0u64).to_le_bytes());
+
+    let mut fork_b = base.clone();
+    fork_b.append_bytes(&(1u64).to_le_bytes());
+
+    // Pollute fork_b with extra data
+    fork_b.append_bytes(&[0xFF; 64]);
+    let _ = fork_b.sample();
+    fork_b.append_bytes(&[0xEE; 128]);
+
+    // fork_a should still produce the same challenge as a fresh identical fork
+    let mut fork_a_fresh = base.clone();
+    fork_a_fresh.append_bytes(&(0u64).to_le_bytes());
+
+    assert_eq!(fork_a.sample(), fork_a_fresh.sample());
+}

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1247,12 +1247,11 @@ pub trait IsStarkProver<
         let mut all_bus_public_inputs: Vec<Option<BusPublicInputs<FieldExtension>>> =
             Vec::with_capacity(num_airs);
 
-        for (idx, (((air, trace, pub_inputs), (main, main_evaluations)), domain)) in
-            air_trace_pairs
-                .iter_mut()
-                .zip(main_commitments)
-                .zip(domains.iter())
-                .enumerate()
+        for (idx, (((air, trace, pub_inputs), (main, main_evaluations)), domain)) in air_trace_pairs
+            .iter_mut()
+            .zip(main_commitments)
+            .zip(domains.iter())
+            .enumerate()
         {
             // Fork transcript with domain separator
             let mut table_transcript = transcript.clone();

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1167,7 +1167,7 @@ pub trait IsStarkProver<
     /// The transcript must be safely initialized before passing it to this method.
     fn multi_prove(
         mut air_trace_pairs: Vec<AirTracePair<'_, Field, FieldExtension, PI>>,
-        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone),
     ) -> Result<MultiProof<Field, FieldExtension, PI>, ProvingError>
     where
         FieldElement<Field>: AsBytes,
@@ -1233,43 +1233,58 @@ pub trait IsStarkProver<
         };
 
         // =====================================================================
-        // Round 1, Phase C: Build and commit auxiliary traces
+        // Phase C + Rounds 2-4: Forked per table
         // =====================================================================
-        // Each AIR builds its LogUp running-sum columns using the shared challenges.
+        // Each table gets an independent transcript fork (cloned from the shared
+        // state after Phase B, domain-separated by table index). This makes
+        // per-table proving independent — each table's challenges only depend
+        // on the shared Phase A+B prefix and that table's own commitments.
+        //
+        // As a side effect, each Round1 is consumed immediately (memory win).
 
-        let mut round_1_results: Vec<Round1<Field, FieldExtension>> = Vec::with_capacity(num_airs);
-        for (((air, trace, _pub_inputs), (main, main_evaluations)), domain) in air_trace_pairs
-            .iter_mut()
-            .zip(main_commitments)
-            .zip(domains.iter())
+        let mut proofs = Vec::with_capacity(num_airs);
+        #[cfg(feature = "debug-checks")]
+        let mut all_bus_public_inputs: Vec<Option<BusPublicInputs<FieldExtension>>> =
+            Vec::with_capacity(num_airs);
+
+        for (idx, (((air, trace, pub_inputs), (main, main_evaluations)), domain)) in
+            air_trace_pairs
+                .iter_mut()
+                .zip(main_commitments)
+                .zip(domains.iter())
+                .enumerate()
         {
+            // Fork transcript with domain separator
+            let mut table_transcript = transcript.clone();
+            table_transcript.append_bytes(&(idx as u64).to_le_bytes());
+
+            // Phase C: build and commit aux trace
             let round_1_result = Self::round_1_build_auxiliary_trace(
                 *air,
                 *trace,
                 domain,
-                transcript,
+                &mut table_transcript,
                 main,
                 main_evaluations,
                 logup_challenges.clone(),
             )?;
-            round_1_results.push(round_1_result);
+
+            #[cfg(feature = "debug-checks")]
+            all_bus_public_inputs.push(round_1_result.bus_public_inputs.clone());
+
+            // Rounds 2-4 for this table (immediately, then Round1 is dropped)
+            let proof = Self::prove_rounds_2_to_4(
+                *air,
+                *pub_inputs,
+                &round_1_result,
+                &mut table_transcript,
+                domain,
+            )?;
+            proofs.push(proof);
         }
 
         #[cfg(feature = "debug-checks")]
-        print_bus_balance_report(&round_1_results);
-
-        // =====================================================================
-        // Rounds 2-4: Standard STARK protocol for each AIR
-        // =====================================================================
-
-        let mut proofs = Vec::with_capacity(num_airs);
-        for (((air, _, pub_inputs), round_1_result), domain) in
-            air_trace_pairs.iter().zip(round_1_results).zip(domains)
-        {
-            let proof =
-                Self::prove_rounds_2_to_4(*air, *pub_inputs, &round_1_result, transcript, &domain)?;
-            proofs.push(proof);
-        }
+        print_bus_balance_report(&all_bus_public_inputs);
 
         Ok(MultiProof::new(proofs))
     }
@@ -1280,7 +1295,7 @@ pub trait IsStarkProver<
         air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
         trace: &mut TraceTable<Field, FieldExtension>,
         pub_inputs: &PI,
-        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone),
     ) -> Result<StarkProof<Field, FieldExtension, PI>, ProvingError>
     where
         FieldElement<Field>: AsBytes,
@@ -1493,19 +1508,14 @@ pub trait IsStarkProver<
 /// Uses numeric bus IDs only (no VM-specific names) to keep the stark crate generic.
 /// For bus ID → name mapping, see `BusId` in the prover crate.
 #[cfg(feature = "debug-checks")]
-fn print_bus_balance_report<Field, FieldExtension>(
-    round_1_results: &[Round1<Field, FieldExtension>],
+fn print_bus_balance_report<FieldExtension>(
+    all_bus_public_inputs: &[Option<BusPublicInputs<FieldExtension>>],
 ) where
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField,
     FieldExtension: IsField,
-    FieldElement<Field>: AsBytes,
-    FieldElement<FieldExtension>: AsBytes,
 {
     use std::collections::HashMap;
 
-    let has_logup = round_1_results
-        .iter()
-        .any(|r| r.bus_public_inputs.is_some());
+    let has_logup = all_bus_public_inputs.iter().any(|r| r.is_some());
     if !has_logup {
         return;
     }
@@ -1517,31 +1527,29 @@ fn print_bus_balance_report<Field, FieldExtension>(
     let mut global_sender_sums: HashMap<u64, FieldElement<FieldExtension>> = HashMap::new();
     let mut global_receiver_sums: HashMap<u64, FieldElement<FieldExtension>> = HashMap::new();
 
-    for round_1_result in round_1_results {
-        if let Some(bus_inputs) = &round_1_result.bus_public_inputs {
-            for (&bus_id, sum) in &bus_inputs.per_bus_sums {
-                *global_bus_sums
-                    .entry(bus_id)
-                    .or_insert(FieldElement::zero()) += sum.clone();
-            }
-            for (&bus_id, sum) in &bus_inputs.per_bus_sender_sums {
-                *global_sender_sums
-                    .entry(bus_id)
-                    .or_insert(FieldElement::zero()) += sum.clone();
-                bus_senders
-                    .entry(bus_id)
-                    .or_default()
-                    .push((bus_inputs.table_name.clone(), sum.clone()));
-            }
-            for (&bus_id, sum) in &bus_inputs.per_bus_receiver_sums {
-                *global_receiver_sums
-                    .entry(bus_id)
-                    .or_insert(FieldElement::zero()) += sum.clone();
-                bus_receivers
-                    .entry(bus_id)
-                    .or_default()
-                    .push((bus_inputs.table_name.clone(), sum.clone()));
-            }
+    for bus_inputs in all_bus_public_inputs.iter().flatten() {
+        for (&bus_id, sum) in &bus_inputs.per_bus_sums {
+            *global_bus_sums
+                .entry(bus_id)
+                .or_insert(FieldElement::zero()) += sum.clone();
+        }
+        for (&bus_id, sum) in &bus_inputs.per_bus_sender_sums {
+            *global_sender_sums
+                .entry(bus_id)
+                .or_insert(FieldElement::zero()) += sum.clone();
+            bus_senders
+                .entry(bus_id)
+                .or_default()
+                .push((bus_inputs.table_name.clone(), sum.clone()));
+        }
+        for (&bus_id, sum) in &bus_inputs.per_bus_receiver_sums {
+            *global_receiver_sums
+                .entry(bus_id)
+                .or_insert(FieldElement::zero()) += sum.clone();
+            bus_receivers
+                .entry(bus_id)
+                .or_default()
+                .push((bus_inputs.table_name.clone(), sum.clone()));
         }
     }
 

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1253,9 +1253,13 @@ pub trait IsStarkProver<
             .zip(domains.iter())
             .enumerate()
         {
-            // Fork transcript with domain separator
+            // For multi-table proofs, fork the transcript with a domain separator
+            // so each table derives independent challenges. Single-table proofs
+            // use the original transcript directly (no fork, no separator).
             let mut table_transcript = transcript.clone();
-            table_transcript.append_bytes(&(idx as u64).to_le_bytes());
+            if num_airs > 1 {
+                table_transcript.append_bytes(&(idx as u64).to_le_bytes());
+            }
 
             // Phase C: build and commit aux trace
             let round_1_result = Self::round_1_build_auxiliary_trace(

--- a/crypto/stark/src/transcript.rs
+++ b/crypto/stark/src/transcript.rs
@@ -17,6 +17,17 @@ pub struct StoneProverTranscript {
     spare_bytes: Vec<u8>,
 }
 
+impl Clone for StoneProverTranscript {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state,
+            seed_increment: self.seed_increment,
+            counter: self.counter,
+            spare_bytes: self.spare_bytes.clone(),
+        }
+    }
+}
+
 impl StoneProverTranscript {
     /// The maximum multiple of the modulus of `p` that fits in 256 bits, where
     /// `p = 0x800000000000011000000000000000000000000000000000000000000000001`

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -827,7 +827,7 @@ pub trait IsStarkVerifier<
     fn multi_verify(
         airs: &[&dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>],
         multi_proof: &MultiProof<Field, FieldExtension, PI>,
-        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone),
     ) -> bool
     where
         FieldElement<Field>: AsBytes + Sync + Send,
@@ -889,21 +889,29 @@ pub trait IsStarkVerifier<
         };
 
         // =====================================================================
-        // Round 1, Phase C: Replay auxiliary trace commitments
+        // Phase C + Rounds 2-4: Forked per table
         // =====================================================================
-
-        for proof in &multi_proof.proofs {
-            if let Some(root) = proof.lde_trace_aux_merkle_root {
-                transcript.append_bytes(&root);
-            }
-        }
-
-        // =====================================================================
-        // Rounds 2-4: Verify each proof
-        // =====================================================================
+        // Each table gets an independent transcript fork (cloned from the shared
+        // state after Phase B, domain-separated by table index). This matches
+        // the prover's forking and makes per-table verification independent.
 
         for (idx, (air, proof)) in airs.iter().zip(&multi_proof.proofs).enumerate() {
-            if !Self::verify_rounds_2_to_4(*air, proof, transcript, logup_challenges.clone()) {
+            // Fork transcript with domain separator (must match prover)
+            let mut table_transcript = transcript.clone();
+            table_transcript.append_bytes(&(idx as u64).to_le_bytes());
+
+            // Phase C: replay aux commitment
+            if let Some(root) = proof.lde_trace_aux_merkle_root {
+                table_transcript.append_bytes(&root);
+            }
+
+            // Rounds 2-4: verify
+            if !Self::verify_rounds_2_to_4(
+                *air,
+                proof,
+                &mut table_transcript,
+                logup_challenges.clone(),
+            ) {
                 error!(
                     "Table {} failed verify_rounds_2_to_4 (num_constraints={}, trace_cols={})",
                     idx,
@@ -949,7 +957,7 @@ pub trait IsStarkVerifier<
     fn verify(
         proof: &StarkProof<Field, FieldExtension, PI>,
         air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
-        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone),
     ) -> bool
     where
         FieldElement<Field>: AsBytes + Sync + Send,

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -896,9 +896,13 @@ pub trait IsStarkVerifier<
         // the prover's forking and makes per-table verification independent.
 
         for (idx, (air, proof)) in airs.iter().zip(&multi_proof.proofs).enumerate() {
-            // Fork transcript with domain separator (must match prover)
+            // Must match prover: fork with domain separator for multi-table,
+            // use original transcript directly for single-table.
+            let num_tables = airs.len();
             let mut table_transcript = transcript.clone();
-            table_transcript.append_bytes(&(idx as u64).to_le_bytes());
+            if num_tables > 1 {
+                table_transcript.append_bytes(&(idx as u64).to_le_bytes());
+            }
 
             // Phase C: replay aux commitment
             if let Some(root) = proof.lde_trace_aux_merkle_root {


### PR DESCRIPTION
  Summary

  - After Phase B (main trace commitments + shared LogUp challenge sampling), the transcript is cloned per
   table with a domain separator (table_index as u64 LE). Each table then independently runs Phase C (aux
  trace) and Rounds 2-4 (composition poly, OOD, FRI) on its own fork.
  - This replaces the previous sequential design where all tables shared a single transcript through
  Phases C and Rounds 2-4.

  Motivation

  - Parallelization: Tables are now fully independent after Phase B, enabling future parallel proving
  (threads or distributed).
  - Memory: Each Round1 is built, consumed, and dropped before the next table starts — no need to hold all
   auxiliary data simultaneously.

  Changes

  - DefaultTranscript, StoneProverTranscript: added Clone impl
  - multi_prove / prove: + Clone bound, merged Phase C + Rounds 2-4 into single forked loop
  - multi_verify / verify: same treatment, matching prover fork logic
  - print_bus_balance_report: simplified signature (&[Option<BusPublicInputs>])
  - Added 3 unit tests: fork determinism, domain separator differentiation, fork isolation

  Protocol change

  Proofs generated by this branch are incompatible with the previous verifier (different Fiat-Shamir
  challenges). The proof format/structure is unchanged.
  