### PR TITLE
Fix LogUp Soundness: First Row Constraint

### DIFF
--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -726,8 +726,18 @@ where
 
             // One boundary constraint per term column at row 0: term_i(0) = initial_terms[i].
             // This makes each term's initial value a verifier-enforced public input.
-            for (i, term_value) in bus_inputs.initial_terms.iter().enumerate() {
-                boundary_constraints.push(BoundaryConstraint::new_aux(i, 0, term_value.clone()));
+            // We iterate over acc_col_idx (= num_interactions) rather than initial_terms.len()
+            // so that a proof with a shorter initial_terms vector — which would otherwise omit
+            // constraints and allow acc[0] to be offset — still produces the full expected set.
+            // Missing entries default to zero; since logup terms equal sign*m/fp with fp ≠ 0
+            // (by Fiat-Shamir), any honest term is non-zero and the mismatch fails verification.
+            for i in 0..acc_col_idx {
+                let expected = bus_inputs
+                    .initial_terms
+                    .get(i)
+                    .cloned()
+                    .unwrap_or_else(FieldElement::zero);
+                boundary_constraints.push(BoundaryConstraint::new_aux(i, 0, expected));
             }
 
             // Boundary constraint for the accumulated column at row 0: acc(0) = Σ initial_terms.

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -682,9 +682,15 @@ where
         let acc_col_idx = num_interactions;
         build_accumulated_column(acc_col_idx, num_interactions, trace);
 
-        // Return single BusPublicInputs for the accumulated column
+        // Collect term column values at row 0 (public inputs for row-0 boundary constraints)
+        let initial_terms: Vec<FieldElement<E>> = (0..num_interactions)
+            .map(|i| trace.get_aux(0, i).clone())
+            .collect();
+
+        // Return BusPublicInputs with initial terms and accumulated column endpoints
         let last_row = trace.num_rows() - 1;
         Some(BusPublicInputs {
+            initial_terms,
             initial_value: trace.get_aux(0, acc_col_idx).clone(),
             final_accumulated: trace.get_aux(last_row, acc_col_idx).clone(),
             #[cfg(feature = "debug-checks")]
@@ -716,23 +722,24 @@ where
     ) -> BoundaryConstraints<E> {
         let mut boundary_constraints = vec![];
 
-        // Boundary constraints for the accumulated column only
-        // (term columns are fully determined by main trace and don't need boundary constraints)
-        if let Some(acc_interaction) = bus_public_inputs {
-            // The accumulated column is at index = num_interactions
+        if let Some(bus_inputs) = bus_public_inputs {
             let acc_col_idx = self.auxiliary_trace_build_data.interactions.len();
 
-            // Constraint for row 0: accumulated column must start with initial_value
-            boundary_constraints.push(BoundaryConstraint::new_aux(
-                acc_col_idx,
-                0,
-                acc_interaction.initial_value.clone(),
-            ));
-            // Constraint for last row: accumulated column must end with final_accumulated
+            // One boundary constraint per term column at row 0: term_i(0) = initial_terms[i].
+            // This makes each term's initial value a verifier-enforced public input.
+            for (i, term_value) in bus_inputs.initial_terms.iter().enumerate() {
+                boundary_constraints.push(BoundaryConstraint::new_aux(i, 0, term_value.clone()));
+            }
+
+            // Boundary constraint for the accumulated column at row 0: acc(0) = Σ initial_terms.
+            let initial_acc: FieldElement<E> = bus_inputs.initial_terms.iter().cloned().sum();
+            boundary_constraints.push(BoundaryConstraint::new_aux(acc_col_idx, 0, initial_acc));
+
+            // Boundary constraint for the accumulated column at last row.
             boundary_constraints.push(BoundaryConstraint::new_aux(
                 acc_col_idx,
                 trace_length - 1,
-                acc_interaction.final_accumulated.clone(),
+                bus_inputs.final_accumulated.clone(),
             ));
         }
 
@@ -907,6 +914,9 @@ pub struct BusPublicInputs<E>
 where
     E: IsField,
 {
+    /// Term column values at row 0 (one per interaction).
+    /// Used for boundary constraints that enforce term_i(0) = initial_terms[i].
+    pub initial_terms: Vec<FieldElement<E>>,
     /// Accumulated column value at row 0
     pub initial_value: FieldElement<E>,
     /// Accumulated column value at last row (total sum of all terms)

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -691,7 +691,6 @@ where
         let last_row = trace.num_rows() - 1;
         Some(BusPublicInputs {
             initial_terms,
-            initial_value: trace.get_aux(0, acc_col_idx).clone(),
             final_accumulated: trace.get_aux(last_row, acc_col_idx).clone(),
             #[cfg(feature = "debug-checks")]
             per_bus_sums,
@@ -917,8 +916,6 @@ where
     /// Term column values at row 0 (one per interaction).
     /// Used for boundary constraints that enforce term_i(0) = initial_terms[i].
     pub initial_terms: Vec<FieldElement<E>>,
-    /// Accumulated column value at row 0
-    pub initial_value: FieldElement<E>,
     /// Accumulated column value at last row (total sum of all terms)
     pub final_accumulated: FieldElement<E>,
     /// Per-bus sums for this table (bus_id → sum) - for debug aggregation

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -731,7 +731,7 @@ where
             // One boundary constraint per term column at row 0: term_i(0) = initial_terms[i].
             // This makes each term's initial value a verifier-enforced public input.
             // The verifier rejects proofs where initial_terms.len() != num_interactions
-            // before reaching constraint evaluation, so the length of initia_term is guaranteed to be correct.
+            // before reaching constraint evaluation, so the length of initial_terms is guaranteed to be correct.
             for (i, expected) in bus_inputs.initial_terms.iter().enumerate() {
                 boundary_constraints.push(BoundaryConstraint::new_aux(i, 0, expected.clone()));
             }

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -631,6 +631,10 @@ where
         self.trace_layout
     }
 
+    fn has_trace_interaction(&self) -> bool {
+        !self.auxiliary_trace_build_data.interactions.is_empty()
+    }
+
     fn composition_poly_degree_bound(&self, trace_length: usize) -> usize {
         trace_length * 2
     }
@@ -726,18 +730,10 @@ where
 
             // One boundary constraint per term column at row 0: term_i(0) = initial_terms[i].
             // This makes each term's initial value a verifier-enforced public input.
-            // We iterate over acc_col_idx (= num_interactions) rather than initial_terms.len()
-            // so that a proof with a shorter initial_terms vector — which would otherwise omit
-            // constraints and allow acc[0] to be offset — still produces the full expected set.
-            // Missing entries default to zero; since logup terms equal sign*m/fp with fp ≠ 0
-            // (by Fiat-Shamir), any honest term is non-zero and the mismatch fails verification.
-            for i in 0..acc_col_idx {
-                let expected = bus_inputs
-                    .initial_terms
-                    .get(i)
-                    .cloned()
-                    .unwrap_or_else(FieldElement::zero);
-                boundary_constraints.push(BoundaryConstraint::new_aux(i, 0, expected));
+            // The verifier rejects proofs where initial_terms.len() != num_interactions
+            // before reaching constraint evaluation, so the length of initia_term is guaranteed to be correct.
+            for (i, expected) in bus_inputs.initial_terms.iter().enumerate() {
+                boundary_constraints.push(BoundaryConstraint::new_aux(i, 0, expected.clone()));
             }
 
             // Boundary constraint for the accumulated column at row 0: acc(0) = Σ initial_terms.

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -575,7 +575,7 @@ pub trait IsStarkProver<
         FieldElement<Field>: AsBytes,
         FieldElement<FieldExtension>: AsBytes,
     {
-        let (aux, aux_evaluations, bus_public_inputs) = if air.has_trace_interaction() {
+        let (aux, aux_evaluations, bus_public_inputs) = if air.has_aux_trace() {
             let bus_public_inputs = air.build_auxiliary_trace(trace, &rap_challenges);
             let Some((
                 aux_trace_polys,
@@ -1195,10 +1195,10 @@ pub trait IsStarkProver<
 
         let num_airs = air_trace_pairs.len();
 
-        // Check if any AIR uses LogUp (has auxiliary trace for running sums)
-        let needs_logup_challenges = air_trace_pairs
+        // Check if any AIR has an auxiliary trace
+        let needs_lookup_challenges = air_trace_pairs
             .iter()
-            .any(|(air, _, _)| air.has_trace_interaction());
+            .any(|(air, _, _)| air.has_aux_trace());
 
         // =====================================================================
         // Round 1, Phase A: Commit all main traces
@@ -1241,7 +1241,7 @@ pub trait IsStarkProver<
         // For the LogUp bus to balance (sum of fingerprints = 0), all tables
         // must use identical (z, α) challenges. We sample them ONCE here.
 
-        let logup_challenges: Vec<FieldElement<FieldExtension>> = if needs_logup_challenges {
+        let lookup_challenges: Vec<FieldElement<FieldExtension>> = if needs_lookup_challenges {
             (0..LOGUP_NUM_CHALLENGES)
                 .map(|_| transcript.sample_field_element())
                 .collect()
@@ -1267,7 +1267,7 @@ pub trait IsStarkProver<
                 transcript,
                 main,
                 main_evaluations,
-                logup_challenges.clone(),
+                lookup_challenges.clone(),
             )?;
             round_1_results.push(round_1_result);
         }

--- a/crypto/stark/src/tests/bus_tests/soundness_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/soundness_tests.rs
@@ -662,9 +662,11 @@ fn test_tampered_accumulator_first_row() {
     // the verifier will enforce term_col_0(ω^0) = corrupted value, but the
     // committed trace has the honest value, causing the composition poly check to fail.
     let add_proof = &mut multi_proof.proofs[1]; // proofs: [cpu=0, add=1, mul=2]
-    if let Some(bus_inputs) = add_proof.bus_public_inputs.as_mut() {
-        bus_inputs.initial_terms[0] = bus_inputs.initial_terms[0].clone() + FieldElement::one();
-    }
+    let bus_inputs = add_proof
+        .bus_public_inputs
+        .as_mut()
+        .expect("ADD table must have bus public inputs");
+    bus_inputs.initial_terms[0] = bus_inputs.initial_terms[0].clone() + FieldElement::one();
 
     let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
         vec![&cpu_air, &add_air, &mul_air];
@@ -732,11 +734,13 @@ fn test_tampered_acc_ood_first_row() {
         Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
 
     // Corrupt the acc column OOD evaluation in the ADD table proof.
-    // ADD has 4 main columns and 1 interaction, so the aux layout is:
+    // ADD has 4 main columns + 1 interaction column + 1 acc column, so the aux layout is:
     //   column 4 (OOD) = term column,  column 5 (OOD) = acc column
     // initial_terms is kept honest, so the verifier's expected value Σ initial_terms
     // is correct. But acc(z) no longer matches it → composition poly check fails.
-    let acc_col_ood_idx = 5; // 4 main + 1 term
+    let num_main = 4usize;
+    let num_interactions = 1usize;
+    let acc_col_ood_idx = num_main + num_interactions;
     let add_proof = &mut multi_proof.proofs[1]; // proofs: [cpu=0, add=1, mul=2]
     let corrupted = add_proof
         .trace_ood_evaluations

--- a/crypto/stark/src/tests/bus_tests/soundness_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/soundness_tests.rs
@@ -596,6 +596,163 @@ fn test_missing_receiver() {
 }
 
 // =============================================================================
+// First-row boundary constraints
+// =============================================================================
+
+/// A proof where initial_terms[0] has been tampered with is rejected.
+///
+/// The ADD table exposes its term column value at row 0 as a public input
+/// (initial_terms[0]). The verifier enforces term_col_0(ω^0) = initial_terms[0]
+/// as a boundary constraint. We simulate a dishonest prover by corrupting
+/// initial_terms[0] in the proof after generation. The composition polynomial
+/// check then fails because the committed trace disagrees with the claimed value.
+#[test_log::test]
+fn test_tampered_accumulator_first_row() {
+    // Simple valid trace: CPU sends (5, 3, 8) to the ADD table.
+    let mut cpu_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::one(), FE::zero(), FE::zero(), FE::zero()], // add_flag
+            vec![FE::zero(); 4],                                 // mul_flag
+            vec![FE::from(5), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(3), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(8), FE::zero(), FE::zero(), FE::zero()],
+        ],
+        1,
+    );
+    let mut add_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::from(5), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(3), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(8), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::one(), FE::zero(), FE::zero(), FE::zero()], // multiplicity = 1
+        ],
+        1,
+    );
+    let mut mul_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+        ],
+        1,
+    );
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = new_cpu_air_with_lookup(&proof_options);
+    let add_air = new_add_air_with_lookup(&proof_options);
+    let mul_air = new_mul_air_with_lookup(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut cpu_trace, &()),
+        (&add_air, &mut add_trace, &()),
+        (&mul_air, &mut mul_trace, &()),
+    ];
+
+    let mut multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    // Corrupt initial_terms[0] in the ADD table's bus public inputs.
+    // ADD has 1 interaction (receiver), so initial_terms has 1 element.
+    // Changing this breaks the boundary constraint for term_col_0 at row 0:
+    // the verifier will enforce term_col_0(ω^0) = corrupted value, but the
+    // committed trace has the honest value, causing the composition poly check to fail.
+    let add_proof = &mut multi_proof.proofs[1]; // proofs: [cpu=0, add=1, mul=2]
+    if let Some(bus_inputs) = add_proof.bus_public_inputs.as_mut() {
+        bus_inputs.initial_terms[0] =
+            bus_inputs.initial_terms[0].clone() + FieldElement::one();
+    }
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&cpu_air, &add_air, &mul_air];
+
+    assert!(
+        !Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[])),
+        "Proof with corrupted initial_terms[0] must be rejected"
+    );
+}
+
+/// A proof where the acc column OOD evaluation at row 0 is tampered with is rejected.
+///
+/// The verifier enforces acc(ω^0) = Σ initial_terms as a boundary constraint.
+/// We keep initial_terms honest but corrupt the acc column's OOD evaluation directly.
+/// The composition polynomial check then fails because the committed acc(z) no longer
+/// matches the expected value Σ initial_terms.
+#[test_log::test]
+fn test_tampered_acc_ood_first_row() {
+    // Simple valid trace: CPU sends (5, 3, 8) to the ADD table.
+    let mut cpu_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::one(), FE::zero(), FE::zero(), FE::zero()], // add_flag
+            vec![FE::zero(); 4],                                 // mul_flag
+            vec![FE::from(5), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(3), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(8), FE::zero(), FE::zero(), FE::zero()],
+        ],
+        1,
+    );
+    let mut add_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::from(5), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(3), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(8), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::one(), FE::zero(), FE::zero(), FE::zero()], // multiplicity = 1
+        ],
+        1,
+    );
+    let mut mul_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+        ],
+        1,
+    );
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = new_cpu_air_with_lookup(&proof_options);
+    let add_air = new_add_air_with_lookup(&proof_options);
+    let mul_air = new_mul_air_with_lookup(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut cpu_trace, &()),
+        (&add_air, &mut add_trace, &()),
+        (&mul_air, &mut mul_trace, &()),
+    ];
+
+    let mut multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    // Corrupt the acc column OOD evaluation in the ADD table proof.
+    // ADD has 4 main columns and 1 interaction, so the aux layout is:
+    //   column 4 (OOD) = term column,  column 5 (OOD) = acc column
+    // initial_terms is kept honest, so the verifier's expected value Σ initial_terms
+    // is correct. But acc(z) no longer matches it → composition poly check fails.
+    let acc_col_ood_idx = 5; // 4 main + 1 term
+    let add_proof = &mut multi_proof.proofs[1]; // proofs: [cpu=0, add=1, mul=2]
+    let corrupted =
+        add_proof.trace_ood_evaluations.get(0, acc_col_ood_idx).clone() + FieldElement::one();
+    add_proof.trace_ood_evaluations.set(0, acc_col_ood_idx, corrupted);
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&cpu_air, &add_air, &mul_air];
+
+    assert!(
+        !Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[])),
+        "Proof with corrupted acc[0] OOD evaluation must be rejected"
+    );
+}
+
+// =============================================================================
 // Complex scenarios
 // =============================================================================
 

--- a/crypto/stark/src/tests/bus_tests/soundness_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/soundness_tests.rs
@@ -663,8 +663,7 @@ fn test_tampered_accumulator_first_row() {
     // committed trace has the honest value, causing the composition poly check to fail.
     let add_proof = &mut multi_proof.proofs[1]; // proofs: [cpu=0, add=1, mul=2]
     if let Some(bus_inputs) = add_proof.bus_public_inputs.as_mut() {
-        bus_inputs.initial_terms[0] =
-            bus_inputs.initial_terms[0].clone() + FieldElement::one();
+        bus_inputs.initial_terms[0] = bus_inputs.initial_terms[0].clone() + FieldElement::one();
     }
 
     let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
@@ -739,9 +738,14 @@ fn test_tampered_acc_ood_first_row() {
     // is correct. But acc(z) no longer matches it → composition poly check fails.
     let acc_col_ood_idx = 5; // 4 main + 1 term
     let add_proof = &mut multi_proof.proofs[1]; // proofs: [cpu=0, add=1, mul=2]
-    let corrupted =
-        add_proof.trace_ood_evaluations.get(0, acc_col_ood_idx).clone() + FieldElement::one();
-    add_proof.trace_ood_evaluations.set(0, acc_col_ood_idx, corrupted);
+    let corrupted = add_proof
+        .trace_ood_evaluations
+        .get(0, acc_col_ood_idx)
+        .clone()
+        + FieldElement::one();
+    add_proof
+        .trace_ood_evaluations
+        .set(0, acc_col_ood_idx, corrupted);
 
     let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
         vec![&cpu_air, &add_air, &mul_air];

--- a/crypto/stark/src/tests/bus_tests/soundness_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/soundness_tests.rs
@@ -761,6 +761,148 @@ fn test_tampered_acc_ood_first_row() {
 }
 
 // =============================================================================
+// Invalid bus public inputs
+// =============================================================================
+
+/// A proof where bus_public_inputs is None for a LogUp AIR is rejected.
+///
+/// The verifier must reject proofs where an AIR declares bus interactions
+/// (has_trace_interaction() = true) but the proof omits bus_public_inputs.
+/// Without this check, a dishonest prover could bypass both the boundary
+/// constraints and the bus balance check.
+#[test_log::test]
+fn test_missing_bus_public_inputs_rejected() {
+    let mut cpu_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::one(), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::zero(); 4],
+            vec![FE::from(5), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(3), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(8), FE::zero(), FE::zero(), FE::zero()],
+        ],
+        1,
+    );
+    let mut add_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::from(5), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(3), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(8), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::one(), FE::zero(), FE::zero(), FE::zero()],
+        ],
+        1,
+    );
+    let mut mul_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+        ],
+        1,
+    );
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = new_cpu_air_with_lookup(&proof_options);
+    let add_air = new_add_air_with_lookup(&proof_options);
+    let mul_air = new_mul_air_with_lookup(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut cpu_trace, &()),
+        (&add_air, &mut add_trace, &()),
+        (&mul_air, &mut mul_trace, &()),
+    ];
+
+    let mut multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    // Remove bus_public_inputs from the ADD table proof entirely.
+    multi_proof.proofs[1].bus_public_inputs = None;
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&cpu_air, &add_air, &mul_air];
+
+    assert!(
+        !Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[])),
+        "Proof with missing bus_public_inputs must be rejected"
+    );
+}
+
+/// A proof where initial_terms has fewer elements than expected is rejected.
+///
+/// The verifier checks that initial_terms.len() == num_interactions before
+/// evaluating boundary constraints. A shorter vector would otherwise cause
+/// some term boundary constraints to be silently skipped.
+#[test_log::test]
+fn test_initial_terms_length_mismatch_rejected() {
+    let mut cpu_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::one(), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::zero(); 4],
+            vec![FE::from(5), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(3), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(8), FE::zero(), FE::zero(), FE::zero()],
+        ],
+        1,
+    );
+    let mut add_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::from(5), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(3), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::from(8), FE::zero(), FE::zero(), FE::zero()],
+            vec![FE::one(), FE::zero(), FE::zero(), FE::zero()],
+        ],
+        1,
+    );
+    let mut mul_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+            vec![FE::zero(); 4],
+        ],
+        1,
+    );
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = new_cpu_air_with_lookup(&proof_options);
+    let add_air = new_add_air_with_lookup(&proof_options);
+    let mul_air = new_mul_air_with_lookup(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut cpu_trace, &()),
+        (&add_air, &mut add_trace, &()),
+        (&mul_air, &mut mul_trace, &()),
+    ];
+
+    let mut multi_proof =
+        Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    // Truncate initial_terms to empty — ADD has 1 interaction so expected length is 1.
+    let add_proof = &mut multi_proof.proofs[1];
+    let bus_inputs = add_proof
+        .bus_public_inputs
+        .as_mut()
+        .expect("ADD table must have bus public inputs");
+    bus_inputs.initial_terms.clear();
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&cpu_air, &add_air, &mul_air];
+
+    assert!(
+        !Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[])),
+        "Proof with initial_terms length mismatch must be rejected"
+    );
+}
+
+// =============================================================================
 // Complex scenarios
 // =============================================================================
 

--- a/crypto/stark/src/traits.rs
+++ b/crypto/stark/src/traits.rs
@@ -103,9 +103,16 @@ pub trait AIR: Send + Sync {
     /// Returns the amount main trace columns and auxiliary trace columns
     fn trace_layout(&self) -> (usize, usize);
 
-    fn has_trace_interaction(&self) -> bool {
+    fn has_aux_trace(&self) -> bool {
         let (_main_trace_columns, aux_trace_columns) = self.trace_layout();
         aux_trace_columns != 0
+    }
+
+    /// Returns true if this AIR interacts with other traces (lookup), such is the case
+    /// of `AirWithBuses` (override to return true).
+    /// Generic RAP AIRs with auxiliary columns but no bus interactions must return false.
+    fn has_trace_interaction(&self) -> bool {
+        false
     }
 
     /// Returns true if this AIR has preprocessed (precomputed) columns.

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -833,8 +833,8 @@ pub trait IsStarkVerifier<
         FieldElement<Field>: AsBytes + Sync + Send,
         FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
-        // Check if any AIR uses LogUp (has auxiliary trace for running sums)
-        let needs_logup_challenges = airs.iter().any(|air| air.has_trace_interaction());
+        // Check if any AIR has an auxiliary trace
+        let needs_lookup_challenges = airs.iter().any(|air| air.has_aux_trace());
 
         // =====================================================================
         // Round 1, Phase A: Replay main trace commitments
@@ -880,7 +880,7 @@ pub trait IsStarkVerifier<
         // =====================================================================
         // Must match exactly what the prover sampled.
 
-        let logup_challenges: Vec<FieldElement<FieldExtension>> = if needs_logup_challenges {
+        let lookup_challenges: Vec<FieldElement<FieldExtension>> = if needs_lookup_challenges {
             (0..LOGUP_NUM_CHALLENGES)
                 .map(|_| transcript.sample_field_element())
                 .collect()
@@ -899,11 +899,45 @@ pub trait IsStarkVerifier<
         }
 
         // =====================================================================
+        // Validate bus_public_inputs presence and length against AIR layout
+        // =====================================================================
+        // A dishonest prover could omit bus_public_inputs entirely (None) to
+        // bypass the bus balance check and boundary constraints, or submit fewer
+        // initial_terms than expected to skip term boundary constraints.
+
+        for (idx, (air, proof)) in airs.iter().zip(&multi_proof.proofs).enumerate() {
+            if air.has_trace_interaction() && proof.bus_public_inputs.is_none() {
+                error!(
+                    "Table {idx}: AIR has LogUp interactions but proof is missing bus_public_inputs"
+                );
+                return false;
+            }
+            if let Some(bus_inputs) = &proof.bus_public_inputs {
+                let num_aux = air.num_auxiliary_rap_columns();
+                if num_aux == 0 {
+                    error!(
+                        "Table {idx}: proof has bus_public_inputs but AIR has no auxiliary columns"
+                    );
+                    return false;
+                }
+                let expected_interactions = num_aux - 1;
+                if bus_inputs.initial_terms.len() != expected_interactions {
+                    error!(
+                        "Table {idx}: initial_terms length mismatch: got {}, expected {}",
+                        bus_inputs.initial_terms.len(),
+                        expected_interactions
+                    );
+                    return false;
+                }
+            }
+        }
+
+        // =====================================================================
         // Rounds 2-4: Verify each proof
         // =====================================================================
 
         for (idx, (air, proof)) in airs.iter().zip(&multi_proof.proofs).enumerate() {
-            if !Self::verify_rounds_2_to_4(*air, proof, transcript, logup_challenges.clone()) {
+            if !Self::verify_rounds_2_to_4(*air, proof, transcript, lookup_challenges.clone()) {
                 error!(
                     "Table {} failed verify_rounds_2_to_4 (num_constraints={}, trace_cols={})",
                     idx,
@@ -921,7 +955,7 @@ pub trait IsStarkVerifier<
         // The sign (sender vs receiver) is already baked into the accumulated values,
         // so the bus balances when the sum of all accumulated values equals zero.
 
-        if needs_logup_challenges {
+        if needs_lookup_challenges {
             let mut total = FieldElement::<FieldExtension>::zero();
             for proof in &multi_proof.proofs {
                 if let Some(interaction) = &proof.bus_public_inputs {


### PR DESCRIPTION
### Motivation

The LogUp accumulator had a soundness hole at row 0. `BusPublicInputs.initial_value` was derived by the prover directly from their own trace (`acc[0]`), and then used as the expected value in a boundary constraint `acc(ω^0) = initial_value`. This is a tautology — the prover supplies both the witness and the expected value, so the constraint is always trivially satisfied. A dishonest prover could set any starting offset for the accumulator without detection.

### Description

The fix replaces the self-referential row-0 boundary constraint with a verifier-enforced chain:

- Each interaction term column value at row 0 is exposed as a public input (`initial_terms[i]`). A boundary constraint enforces `term_i(ω^0) = initial_terms[i]`, tying the public input to the committed trace.
- A boundary constraint enforces `acc(ω^0) = Σ initial_terms`, making the initial accumulator value a deterministic function of the committed terms.

Together these guarantee `acc[0] = Σ term_i[0]` in a way the verifier actually checks.

### Serialization

`BusPublicInputs` has a new field `initial_terms` and the removed field `initial_value`. Proofs generated before this change cannot be deserialized and must be regenerated.



