### PR TITLE
Integrate Bowers FFT into prover pipeline

### DIFF
--- a/crypto/math/src/fft/polynomial.rs
+++ b/crypto/math/src/fft/polynomial.rs
@@ -208,10 +208,13 @@ where
     F: IsFFTField + IsSubFieldOf<E>,
     E: IsField,
 {
-    let order = coeffs.len().trailing_zeros();
-    let twiddles = roots_of_unity::get_twiddles::<F>(order.into(), RootsConfig::BitReverse)?;
-    // Bit reverse order is needed for NR DIT FFT.
-    ops::fft(coeffs, &twiddles)
+    let order = coeffs.len().trailing_zeros() as u64;
+    let layer_twiddles = super::cpu::bowers_fft::LayerTwiddles::<F>::new(order)
+        .ok_or(FFTError::DomainSizeError(order as usize))?;
+    let mut results = coeffs.to_vec();
+    super::cpu::bowers_fft::bowers_fft_opt_fused(&mut results, &layer_twiddles)?;
+    super::cpu::bit_reversing::in_place_bit_reverse_permute(&mut results);
+    Ok(results)
 }
 
 pub fn interpolate_fft_cpu<F, E>(
@@ -221,12 +224,13 @@ where
     F: IsFFTField + IsSubFieldOf<E>,
     E: IsField,
 {
-    let order = fft_evals.len().trailing_zeros();
-    let twiddles =
-        roots_of_unity::get_twiddles::<F>(order.into(), RootsConfig::BitReverseInversed)?;
-
-    let coeffs = ops::fft(fft_evals, &twiddles)?;
+    let order = fft_evals.len().trailing_zeros() as u64;
+    let inv_twiddles = super::cpu::bowers_fft::LayerTwiddles::<F>::new_inverse(order)
+        .ok_or(FFTError::DomainSizeError(order as usize))?;
+    let mut results = fft_evals.to_vec();
+    super::cpu::bit_reversing::in_place_bit_reverse_permute(&mut results);
+    super::cpu::bowers_fft::bowers_ifft_opt(&mut results, &inv_twiddles)?;
 
     let scale_factor = FieldElement::from(fft_evals.len() as u64).inv().unwrap();
-    Ok(Polynomial::new(&coeffs).scale_coeffs(&scale_factor))
+    Ok(Polynomial::new(&results).scale_coeffs(&scale_factor))
 }

--- a/crypto/math/src/fft/polynomial.rs
+++ b/crypto/math/src/fft/polynomial.rs
@@ -3,18 +3,13 @@ use crate::fft::errors::FFTError;
 use crate::field::errors::FieldError;
 use crate::field::traits::{IsField, IsSubFieldOf};
 use crate::{
-    field::{
-        element::FieldElement,
-        traits::{IsFFTField, RootsConfig},
-    },
+    field::{element::FieldElement, traits::IsFFTField},
     polynomial::Polynomial,
 };
 use alloc::{vec, vec::Vec};
 
 #[cfg(feature = "cuda")]
 use crate::fft::gpu::cuda::polynomial::{evaluate_fft_cuda, interpolate_fft_cuda};
-
-use super::cpu::{ops, roots_of_unity};
 
 impl<E: IsField> Polynomial<FieldElement<E>> {
     /// Returns `N` evaluations of this polynomial using FFT over a domain in a subfield F of E (so the results

--- a/crypto/math/src/fft/polynomial.rs
+++ b/crypto/math/src/fft/polynomial.rs
@@ -96,6 +96,62 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
         Ok(scaled.scale(&offset.inv().unwrap()))
     }
 
+    /// Like `interpolate_fft` but accepts pre-computed inverse twiddles.
+    pub fn interpolate_fft_with_twiddles<F: IsFFTField + IsSubFieldOf<E>>(
+        fft_evals: &[FieldElement<E>],
+        inv_twiddles: &super::cpu::bowers_fft::LayerTwiddles<F>,
+    ) -> Result<Self, FFTError>
+    where
+        E: Send + Sync,
+        FieldElement<F>: Send + Sync,
+        FieldElement<E>: Send + Sync,
+    {
+        interpolate_fft_cpu_with_twiddles::<F, E>(fft_evals, inv_twiddles)
+    }
+
+    /// Like `evaluate_fft` but accepts pre-computed twiddles.
+    pub fn evaluate_fft_with_twiddles<F: IsFFTField + IsSubFieldOf<E>>(
+        poly: &Polynomial<FieldElement<E>>,
+        blowup_factor: usize,
+        domain_size: Option<usize>,
+        twiddles: &super::cpu::bowers_fft::LayerTwiddles<F>,
+    ) -> Result<Vec<FieldElement<E>>, FFTError>
+    where
+        E: Send + Sync,
+        FieldElement<F>: Send + Sync,
+        FieldElement<E>: Send + Sync,
+    {
+        let domain_size = domain_size.unwrap_or(0);
+        let len = core::cmp::max(poly.coeff_len(), domain_size).next_power_of_two() * blowup_factor;
+        if len.trailing_zeros() as u64 > F::TWO_ADICITY {
+            return Err(FFTError::DomainSizeError(len.trailing_zeros() as usize));
+        }
+        if poly.coefficients().is_empty() {
+            return Ok(vec![FieldElement::zero(); len]);
+        }
+
+        let mut coeffs = poly.coefficients().to_vec();
+        coeffs.resize(len, FieldElement::zero());
+        evaluate_fft_cpu_with_twiddles::<F, E>(&coeffs, twiddles)
+    }
+
+    /// Like `evaluate_offset_fft` but accepts pre-computed twiddles.
+    pub fn evaluate_offset_fft_with_twiddles<F: IsFFTField + IsSubFieldOf<E>>(
+        poly: &Polynomial<FieldElement<E>>,
+        blowup_factor: usize,
+        domain_size: Option<usize>,
+        offset: &FieldElement<F>,
+        twiddles: &super::cpu::bowers_fft::LayerTwiddles<F>,
+    ) -> Result<Vec<FieldElement<E>>, FFTError>
+    where
+        E: Send + Sync,
+        FieldElement<F>: Send + Sync,
+        FieldElement<E>: Send + Sync,
+    {
+        let scaled = poly.scale(offset);
+        Polynomial::evaluate_fft_with_twiddles::<F>(&scaled, blowup_factor, domain_size, twiddles)
+    }
+
     /// Multiplies two polynomials using FFT.
     /// It's faster than naive multiplication when the degree of the polynomials is large enough (>=2**6).
     /// This works best with polynomials whose highest degree is equal to a power of 2 - 1.
@@ -212,6 +268,29 @@ where
     Ok(results)
 }
 
+/// Like `evaluate_fft_cpu` but accepts pre-computed twiddles to avoid redundant computation.
+pub fn evaluate_fft_cpu_with_twiddles<F, E>(
+    coeffs: &[FieldElement<E>],
+    layer_twiddles: &super::cpu::bowers_fft::LayerTwiddles<F>,
+) -> Result<Vec<FieldElement<E>>, FFTError>
+where
+    F: IsFFTField + IsSubFieldOf<E>,
+    E: IsField + Send + Sync,
+    FieldElement<F>: Send + Sync,
+    FieldElement<E>: Send + Sync,
+{
+    let mut results = coeffs.to_vec();
+
+    #[cfg(feature = "parallel")]
+    super::cpu::bowers_fft::bowers_fft_opt_fused_parallel(&mut results, layer_twiddles)?;
+
+    #[cfg(not(feature = "parallel"))]
+    super::cpu::bowers_fft::bowers_fft_opt_fused(&mut results, layer_twiddles)?;
+
+    super::cpu::bit_reversing::in_place_bit_reverse_permute(&mut results);
+    Ok(results)
+}
+
 pub fn interpolate_fft_cpu<F, E>(
     fft_evals: &[FieldElement<E>],
 ) -> Result<Polynomial<FieldElement<E>>, FFTError>
@@ -225,6 +304,30 @@ where
     let mut results = fft_evals.to_vec();
     super::cpu::bit_reversing::in_place_bit_reverse_permute(&mut results);
     super::cpu::bowers_fft::bowers_ifft_opt(&mut results, &inv_twiddles)?;
+
+    let scale_factor = FieldElement::from(fft_evals.len() as u64).inv().unwrap();
+    Ok(Polynomial::new(&results).scale_coeffs(&scale_factor))
+}
+
+/// Like `interpolate_fft_cpu` but accepts pre-computed inverse twiddles.
+pub fn interpolate_fft_cpu_with_twiddles<F, E>(
+    fft_evals: &[FieldElement<E>],
+    inv_twiddles: &super::cpu::bowers_fft::LayerTwiddles<F>,
+) -> Result<Polynomial<FieldElement<E>>, FFTError>
+where
+    F: IsFFTField + IsSubFieldOf<E>,
+    E: IsField + Send + Sync,
+    FieldElement<F>: Send + Sync,
+    FieldElement<E>: Send + Sync,
+{
+    let mut results = fft_evals.to_vec();
+    super::cpu::bit_reversing::in_place_bit_reverse_permute(&mut results);
+
+    #[cfg(feature = "parallel")]
+    super::cpu::bowers_fft::bowers_ifft_opt_parallel(&mut results, inv_twiddles)?;
+
+    #[cfg(not(feature = "parallel"))]
+    super::cpu::bowers_fft::bowers_ifft_opt(&mut results, inv_twiddles)?;
 
     let scale_factor = FieldElement::from(fft_evals.len() as u64).inv().unwrap();
     Ok(Polynomial::new(&results).scale_coeffs(&scale_factor))

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
 use crypto::merkle_tree::traits::IsMerkleTreeBackend;
 use math::fft::cpu::bit_reversing::{in_place_bit_reverse_permute, reverse_index};
+use math::fft::cpu::bowers_fft::LayerTwiddles;
 use math::fft::errors::FFTError;
 
 use log::info;
@@ -193,6 +194,33 @@ where
     E: IsField,
 {
     let evaluations = Polynomial::evaluate_offset_fft(p, blowup_factor, Some(domain_size), offset)?;
+    let step = evaluations.len() / (domain_size * blowup_factor);
+    match step {
+        1 => Ok(evaluations),
+        _ => Ok(evaluations.into_iter().step_by(step).collect()),
+    }
+}
+
+pub fn evaluate_polynomial_on_lde_domain_with_twiddles<F, E>(
+    p: &Polynomial<FieldElement<E>>,
+    blowup_factor: usize,
+    domain_size: usize,
+    offset: &FieldElement<F>,
+    twiddles: &LayerTwiddles<F>,
+) -> Result<Vec<FieldElement<E>>, FFTError>
+where
+    F: IsFFTField + IsSubFieldOf<E>,
+    E: IsField + Send + Sync,
+    FieldElement<F>: Send + Sync,
+    FieldElement<E>: Send + Sync,
+{
+    let evaluations = Polynomial::evaluate_offset_fft_with_twiddles(
+        p,
+        blowup_factor,
+        Some(domain_size),
+        offset,
+        twiddles,
+    )?;
     let step = evaluations.len() / (domain_size * blowup_factor);
     match step {
         1 => Ok(evaluations),
@@ -428,9 +456,14 @@ pub trait IsStarkProver<
         domain: &Domain<Field>,
     ) -> Vec<Vec<FieldElement<E>>>
     where
-        E: IsSubFieldOf<FieldExtension>,
+        E: IsSubFieldOf<FieldExtension> + Send + Sync,
         Field: IsSubFieldOf<E>,
+        FieldElement<E>: Send + Sync,
     {
+        let lde_size = domain.interpolation_domain_size * domain.blowup_factor;
+        let lde_order = lde_size.trailing_zeros() as u64;
+        let twiddles = LayerTwiddles::<Field>::new(lde_order).unwrap();
+
         #[cfg(not(feature = "parallel"))]
         let trace_polys_iter = trace_polys.iter();
         #[cfg(feature = "parallel")]
@@ -438,11 +471,12 @@ pub trait IsStarkProver<
 
         trace_polys_iter
             .map(|poly| {
-                evaluate_polynomial_on_lde_domain(
+                evaluate_polynomial_on_lde_domain_with_twiddles::<Field, E>(
                     poly,
                     domain.blowup_factor,
                     domain.interpolation_domain_size,
                     &domain.coset_offset,
+                    &twiddles,
                 )
             })
             .collect::<Result<Vec<Vec<FieldElement<E>>>, FFTError>>()
@@ -669,14 +703,19 @@ pub trait IsStarkProver<
         let number_of_parts = air.composition_poly_degree_bound(trace_length) / trace_length;
         let composition_poly_parts = composition_poly.break_in_parts(number_of_parts);
 
+        let lde_size = domain.interpolation_domain_size * domain.blowup_factor;
+        let lde_order = lde_size.trailing_zeros() as u64;
+        let twiddles = LayerTwiddles::<Field>::new(lde_order).unwrap();
+
         let lde_composition_poly_parts_evaluations: Vec<_> = composition_poly_parts
             .iter()
             .map(|part| {
-                evaluate_polynomial_on_lde_domain(
+                evaluate_polynomial_on_lde_domain_with_twiddles(
                     part,
                     domain.blowup_factor,
                     domain.interpolation_domain_size,
                     &domain.coset_offset,
+                    &twiddles,
                 )
                 .unwrap()
             })

--- a/crypto/stark/src/trace.rs
+++ b/crypto/stark/src/trace.rs
@@ -1,5 +1,6 @@
 use crate::table::Table;
 use itertools::Itertools;
+use math::fft::cpu::bowers_fft::LayerTwiddles;
 use math::fft::errors::FFTError;
 use math::field::traits::{IsField, IsSubFieldOf};
 use math::{
@@ -192,15 +193,20 @@ where
     pub fn compute_trace_polys_main<S>(&self) -> Vec<Polynomial<FieldElement<F>>>
     where
         S: IsFFTField + IsSubFieldOf<F>,
+        F: Send + Sync,
+        FieldElement<S>: Send + Sync,
         FieldElement<F>: Send + Sync,
     {
         let columns = self.columns_main();
+        let order = self.num_rows().trailing_zeros() as u64;
+        let inv_twiddles = LayerTwiddles::<S>::new_inverse(order).unwrap();
+
         #[cfg(feature = "parallel")]
         let iter = columns.par_iter();
         #[cfg(not(feature = "parallel"))]
         let iter = columns.iter();
 
-        iter.map(|col| Polynomial::interpolate_fft::<S>(col))
+        iter.map(|col| Polynomial::interpolate_fft_with_twiddles::<S>(col, &inv_twiddles))
             .collect::<Result<Vec<Polynomial<FieldElement<F>>>, FFTError>>()
             .unwrap()
     }
@@ -208,15 +214,20 @@ where
     pub fn compute_trace_polys_aux<S>(&self) -> Vec<Polynomial<FieldElement<E>>>
     where
         S: IsFFTField + IsSubFieldOf<F>,
+        E: Send + Sync,
+        FieldElement<F>: Send + Sync,
         FieldElement<E>: Send + Sync,
     {
         let columns = self.columns_aux();
+        let order = self.num_rows().trailing_zeros() as u64;
+        let inv_twiddles = LayerTwiddles::<F>::new_inverse(order).unwrap();
+
         #[cfg(feature = "parallel")]
         let iter = columns.par_iter();
         #[cfg(not(feature = "parallel"))]
         let iter = columns.iter();
 
-        iter.map(|col| Polynomial::interpolate_fft::<F>(col))
+        iter.map(|col| Polynomial::interpolate_fft_with_twiddles::<F>(col, &inv_twiddles))
             .collect::<Result<Vec<Polynomial<FieldElement<E>>>, FFTError>>()
             .unwrap()
     }


### PR DESCRIPTION
Benchmark-only PR to measure end-to-end proving impact of Bowers FFT integration. Based on feat/bowers-fft-cpu (#288) with polynomial.rs wired to use Bowers instead of Cooley-Tukey.