### PR TITLE
Remove dead code and unnecessary allow annotations

### DIFF
--- a/crypto/math/src/fft/cpu/fft.rs
+++ b/crypto/math/src/fft/cpu/fft.rs
@@ -54,21 +54,8 @@ where
     }
 }
 
-/// In-Place Radix-2 RN DIT FFT algorithm over a slice of two-adic field elements.
-/// It's required that the twiddle factors are naturally ordered (so w[i] = w^i). Else this
-/// function will not return fourier transformed values.
-/// Also the input size needs to be a power of two.
-/// It's recommended to use the current safe abstractions instead of this function.
-///
-/// Performs a fast fourier transform with the next attributes:
-/// - In-Place: an auxiliary vector of data isn't needed for storing the results.
-/// - Radix-2: the algorithm halves the problem size log(n) times.
-/// - RN: reverse to natural order, meaning that the input is bit-reversed ordered and the output will
-///   be naturally ordered.
-/// - DIT: decimation in time
-///
-/// It supports values in a field E and domain in a subfield F.
-#[allow(dead_code)]
+/// In-Place Radix-2 RN DIT FFT algorithm. Only used in tests.
+#[cfg(test)]
 pub fn in_place_rn_2radix_fft<F>(input: &mut [FieldElement<F>], twiddles: &[FieldElement<F>])
 where
     F: IsFFTField,

--- a/crypto/stark/src/constraints/boundary.rs
+++ b/crypto/stark/src/constraints/boundary.rs
@@ -65,13 +65,6 @@ pub struct BoundaryConstraints<F: IsField> {
 }
 
 impl<F: IsField> BoundaryConstraints<F> {
-    #[allow(dead_code)]
-    pub fn new() -> Self {
-        Self {
-            constraints: Vec::<BoundaryConstraint<F>>::new(),
-        }
-    }
-
     /// To instantiate from a vector of BoundaryConstraint elements
     pub fn from_constraints(constraints: Vec<BoundaryConstraint<F>>) -> Self {
         Self { constraints }

--- a/crypto/stark/src/fri/fri_functions.rs
+++ b/crypto/stark/src/fri/fri_functions.rs
@@ -1,65 +1,6 @@
 use super::Polynomial;
 use math::field::{element::FieldElement, traits::IsField};
 
-/// FRI polynomial folding: computes P_even(x) + beta * P_odd(x)
-/// where P(x) = P_even(x^2) + x * P_odd(x^2)
-#[allow(unused)]
-pub fn fold_polynomial<F>(
-    poly: &Polynomial<FieldElement<F>>,
-    beta: &FieldElement<F>,
-) -> Polynomial<FieldElement<F>>
-where
-    F: IsField,
-{
-    let coefficients = poly.coefficients();
-    if coefficients.is_empty() {
-        return Polynomial::new(&[]);
-    }
-
-    let mut result = Vec::with_capacity(coefficients.len().div_ceil(2));
-
-    for chunk in coefficients.chunks(2) {
-        let folded = if chunk.len() == 2 {
-            &chunk[0] + &(&chunk[1] * beta)
-        } else {
-            chunk[0].clone()
-        };
-        result.push(folded);
-    }
-
-    Polynomial::new(&result)
-}
-
-/// FRI polynomial folding with fused doubling: 2 * (P_even(x) + beta * P_odd(x))
-///
-/// Uses `double()` which is more efficient than multiplication by 2.
-#[allow(unused)]
-pub fn fold_polynomial_doubled<F>(
-    poly: &Polynomial<FieldElement<F>>,
-    beta: &FieldElement<F>,
-) -> Polynomial<FieldElement<F>>
-where
-    F: IsField,
-{
-    let coefficients = poly.coefficients();
-    if coefficients.is_empty() {
-        return Polynomial::new(&[]);
-    }
-
-    let mut result = Vec::with_capacity(coefficients.len().div_ceil(2));
-
-    for chunk in coefficients.chunks(2) {
-        let folded = if chunk.len() == 2 {
-            (&chunk[0] + &(&chunk[1] * beta)).double()
-        } else {
-            chunk[0].double()
-        };
-        result.push(folded);
-    }
-
-    Polynomial::new(&result)
-}
-
 /// In-place FRI polynomial folding with fused doubling: 2 * (P_even(x) + beta * P_odd(x))
 ///
 /// This modifies the polynomial in place, avoiding memory allocation.
@@ -94,13 +35,70 @@ pub fn fold_polynomial_doubled_inplace<F>(
 
 #[cfg(test)]
 mod tests {
-    use super::{fold_polynomial, fold_polynomial_doubled, fold_polynomial_doubled_inplace};
+    use super::fold_polynomial_doubled_inplace;
     use math::field::element::FieldElement;
     use math::field::fields::u64_prime_field::U64PrimeField;
     use math::polynomial::Polynomial;
 
     const MODULUS: u64 = 293;
     type FE = FieldElement<U64PrimeField<MODULUS>>;
+
+    /// FRI polynomial folding: computes P_even(x) + beta * P_odd(x)
+    /// where P(x) = P_even(x^2) + x * P_odd(x^2)
+    fn fold_polynomial<F>(
+        poly: &Polynomial<FieldElement<F>>,
+        beta: &FieldElement<F>,
+    ) -> Polynomial<FieldElement<F>>
+    where
+        F: math::field::traits::IsField,
+    {
+        let coefficients = poly.coefficients();
+        if coefficients.is_empty() {
+            return Polynomial::new(&[]);
+        }
+
+        let mut result = Vec::with_capacity(coefficients.len().div_ceil(2));
+
+        for chunk in coefficients.chunks(2) {
+            let folded = if chunk.len() == 2 {
+                &chunk[0] + &(&chunk[1] * beta)
+            } else {
+                chunk[0].clone()
+            };
+            result.push(folded);
+        }
+
+        Polynomial::new(&result)
+    }
+
+    /// FRI polynomial folding with fused doubling: 2 * (P_even(x) + beta * P_odd(x))
+    ///
+    /// Uses `double()` which is more efficient than multiplication by 2.
+    fn fold_polynomial_doubled<F>(
+        poly: &Polynomial<FieldElement<F>>,
+        beta: &FieldElement<F>,
+    ) -> Polynomial<FieldElement<F>>
+    where
+        F: math::field::traits::IsField,
+    {
+        let coefficients = poly.coefficients();
+        if coefficients.is_empty() {
+            return Polynomial::new(&[]);
+        }
+
+        let mut result = Vec::with_capacity(coefficients.len().div_ceil(2));
+
+        for chunk in coefficients.chunks(2) {
+            let folded = if chunk.len() == 2 {
+                (&chunk[0] + &(&chunk[1] * beta)).double()
+            } else {
+                chunk[0].double()
+            };
+            result.push(folded);
+        }
+
+        Polynomial::new(&result)
+    }
 
     #[test]
     fn test_fold_power_of_2() {

--- a/prover/src/tables/load.rs
+++ b/prover/src/tables/load.rs
@@ -474,25 +474,6 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
 
     interactions
 }
-
-// =========================================================================
-// Virtual column computations
-// =========================================================================
-
-/// Compute virtual read1 = μ - read2 - read4 - read8
-#[allow(dead_code)]
-fn compute_read1<F, E>(step: &TableView<F, E>) -> FieldElement<F>
-where
-    F: IsSubFieldOf<E>,
-    E: IsField,
-{
-    let mu = step.get_main_evaluation_element(0, cols::MU).clone();
-    let read2 = step.get_main_evaluation_element(0, cols::READ2).clone();
-    let read4 = step.get_main_evaluation_element(0, cols::READ4).clone();
-    let read8 = step.get_main_evaluation_element(0, cols::READ8).clone();
-    mu - read2 - read4 - read8
-}
-
 // =========================================================================
 // Constraints
 // =========================================================================

--- a/prover/src/tables/memw.rs
+++ b/prover/src/tables/memw.rs
@@ -1081,18 +1081,6 @@ where
     write2 + write4 + write8
 }
 
-/// Compute virtual w4 = write4 + write8
-#[allow(dead_code)]
-fn compute_w4<F, E>(step: &TableView<F, E>) -> FieldElement<F>
-where
-    F: IsSubFieldOf<E>,
-    E: IsField,
-{
-    let write4 = step.get_main_evaluation_element(0, cols::WRITE4).clone();
-    let write8 = step.get_main_evaluation_element(0, cols::WRITE8).clone();
-    write4 + write8
-}
-
 /// Compute virtual μ_sum = μ_read + μ_write
 fn compute_mu_sum<F, E>(step: &TableView<F, E>) -> FieldElement<F>
 where


### PR DESCRIPTION
Remove dead code items flagged by `#[allow(dead_code)]` and `#[allow(unused)]`.

- Remove unused `BoundaryConstraints::new()` (redundant with `Default` derive)
- Remove unused `compute_read1` (load table) and `compute_w4` (memw table)
- Move test-only `in_place_rn_2radix_fft` behind `#[cfg(test)]`
- Move test-only `fold_polynomial` and `fold_polynomial_doubled` into test module