### PR TITLE
Implement ByteConversion for Goldilocks extension fields

### DIFF
--- a/crypto/math/src/field/extensions_goldilocks.rs
+++ b/crypto/math/src/field/extensions_goldilocks.rs
@@ -14,52 +14,88 @@ use crate::traits::{AsBytes, ByteConversion};
 impl ByteConversion for [FpE; 2] {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
-        unimplemented!()
+        let mut bytes = ByteConversion::to_bytes_be(&self[0]);
+        bytes.extend(ByteConversion::to_bytes_be(&self[1]));
+        bytes
     }
 
     #[cfg(feature = "alloc")]
     fn to_bytes_le(&self) -> alloc::vec::Vec<u8> {
-        unimplemented!()
+        let mut bytes = ByteConversion::to_bytes_le(&self[0]);
+        bytes.extend(ByteConversion::to_bytes_le(&self[1]));
+        bytes
     }
 
-    fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        unimplemented!()
+        const N: usize = 8;
+        if bytes.len() < N * 2 {
+            return Err(crate::errors::ByteConversionError::FromBEBytesError);
+        }
+        let x0 = FieldElement::from_bytes_be(&bytes[0..N])?;
+        let x1 = FieldElement::from_bytes_be(&bytes[N..N * 2])?;
+        Ok([x0, x1])
     }
 
-    fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        unimplemented!()
+        const N: usize = 8;
+        if bytes.len() < N * 2 {
+            return Err(crate::errors::ByteConversionError::FromLEBytesError);
+        }
+        let x0 = FieldElement::from_bytes_le(&bytes[0..N])?;
+        let x1 = FieldElement::from_bytes_le(&bytes[N..N * 2])?;
+        Ok([x0, x1])
     }
 }
 
 impl ByteConversion for [FpE; 3] {
     #[cfg(feature = "alloc")]
     fn to_bytes_be(&self) -> alloc::vec::Vec<u8> {
-        unimplemented!()
+        let mut bytes = ByteConversion::to_bytes_be(&self[0]);
+        bytes.extend(ByteConversion::to_bytes_be(&self[1]));
+        bytes.extend(ByteConversion::to_bytes_be(&self[2]));
+        bytes
     }
 
     #[cfg(feature = "alloc")]
     fn to_bytes_le(&self) -> alloc::vec::Vec<u8> {
-        unimplemented!()
+        let mut bytes = ByteConversion::to_bytes_le(&self[0]);
+        bytes.extend(ByteConversion::to_bytes_le(&self[1]));
+        bytes.extend(ByteConversion::to_bytes_le(&self[2]));
+        bytes
     }
 
-    fn from_bytes_be(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_be(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        unimplemented!()
+        const N: usize = 8;
+        if bytes.len() < N * 3 {
+            return Err(crate::errors::ByteConversionError::FromBEBytesError);
+        }
+        let x0 = FieldElement::from_bytes_be(&bytes[0..N])?;
+        let x1 = FieldElement::from_bytes_be(&bytes[N..N * 2])?;
+        let x2 = FieldElement::from_bytes_be(&bytes[N * 2..N * 3])?;
+        Ok([x0, x1, x2])
     }
 
-    fn from_bytes_le(_bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
+    fn from_bytes_le(bytes: &[u8]) -> Result<Self, crate::errors::ByteConversionError>
     where
         Self: Sized,
     {
-        unimplemented!()
+        const N: usize = 8;
+        if bytes.len() < N * 3 {
+            return Err(crate::errors::ByteConversionError::FromLEBytesError);
+        }
+        let x0 = FieldElement::from_bytes_le(&bytes[0..N])?;
+        let x1 = FieldElement::from_bytes_le(&bytes[N..N * 2])?;
+        let x2 = FieldElement::from_bytes_le(&bytes[N * 2..N * 3])?;
+        Ok([x0, x1, x2])
     }
 }
 

--- a/crypto/math/src/tests/fft_friendly_extensions_goldilocks_tests.rs
+++ b/crypto/math/src/tests/fft_friendly_extensions_goldilocks_tests.rs
@@ -1,8 +1,9 @@
 use crate::field::{
     element::FieldElement,
-    extensions_goldilocks::{Fp2E, Fp3E},
+    extensions_goldilocks::{Degree3GoldilocksExtensionField, Fp2E, Fp3E},
     goldilocks::GoldilocksField,
 };
+use crate::traits::ByteConversion;
 
 type FpE = FieldElement<GoldilocksField>;
 
@@ -481,4 +482,86 @@ fn test_fp3_from_i64_arithmetic() {
     let a = Fp3E::from_i64(10);
     let b = Fp3E::from_i64(-3);
     assert_eq!(a + b, Fp3E::from_i64(7));
+}
+
+// ByteConversion tests
+
+#[test]
+fn fp2_byte_roundtrip_be() {
+    let elem = [FpE::from(42u64), FpE::from(99u64)];
+    let bytes = elem.to_bytes_be();
+    let recovered = <[FpE; 2]>::from_bytes_be(&bytes).unwrap();
+    assert_eq!(elem, recovered);
+}
+
+#[test]
+fn fp2_byte_roundtrip_le() {
+    let elem = [FpE::from(42u64), FpE::from(99u64)];
+    let bytes = elem.to_bytes_le();
+    let recovered = <[FpE; 2]>::from_bytes_le(&bytes).unwrap();
+    assert_eq!(elem, recovered);
+}
+
+#[test]
+fn fp2_from_bytes_be_short_input_errors() {
+    let bytes = [0u8; 15];
+    assert!(<[FpE; 2]>::from_bytes_be(&bytes).is_err());
+}
+
+#[test]
+fn fp2_from_bytes_le_short_input_errors() {
+    let bytes = [0u8; 15];
+    assert!(<[FpE; 2]>::from_bytes_le(&bytes).is_err());
+}
+
+#[test]
+fn fp3_byte_roundtrip_be() {
+    let elem = [FpE::from(1u64), FpE::from(2u64), FpE::from(3u64)];
+    let bytes = elem.to_bytes_be();
+    let recovered = <[FpE; 3]>::from_bytes_be(&bytes).unwrap();
+    assert_eq!(elem, recovered);
+}
+
+#[test]
+fn fp3_byte_roundtrip_le() {
+    let elem = [FpE::from(1u64), FpE::from(2u64), FpE::from(3u64)];
+    let bytes = elem.to_bytes_le();
+    let recovered = <[FpE; 3]>::from_bytes_le(&bytes).unwrap();
+    assert_eq!(elem, recovered);
+}
+
+#[test]
+fn fp3_from_bytes_be_short_input_errors() {
+    let bytes = [0u8; 23];
+    assert!(<[FpE; 3]>::from_bytes_be(&bytes).is_err());
+}
+
+#[test]
+fn fp3_from_bytes_le_short_input_errors() {
+    let bytes = [0u8; 23];
+    assert!(<[FpE; 3]>::from_bytes_le(&bytes).is_err());
+}
+
+#[test]
+fn fp3_element_byte_roundtrip_be() {
+    let elem = FieldElement::<Degree3GoldilocksExtensionField>::new([
+        FpE::from(10u64),
+        FpE::from(20u64),
+        FpE::from(30u64),
+    ]);
+    let bytes = elem.to_bytes_be();
+    let recovered = FieldElement::<Degree3GoldilocksExtensionField>::from_bytes_be(&bytes).unwrap();
+    assert_eq!(elem, recovered);
+}
+
+#[test]
+fn fp3_element_byte_roundtrip_le() {
+    let elem = FieldElement::<Degree3GoldilocksExtensionField>::new([
+        FpE::from(10u64),
+        FpE::from(20u64),
+        FpE::from(30u64),
+    ]);
+    let bytes = elem.to_bytes_le();
+    let recovered = FieldElement::<Degree3GoldilocksExtensionField>::from_bytes_le(&bytes).unwrap();
+    assert_eq!(elem, recovered);
 }


### PR DESCRIPTION
Replaces unimplemented!() stubs with working ByteConversion implementations for [FpE; 2], [FpE; 3], and adds roundtrip + error tests.

Extracted from #358 to keep the refactoring PR focused on structural changes.