### PR TITLE
feat/logup column batching

### DIFF
--- a/crypto/stark/src/constraints/evaluator.rs
+++ b/crypto/stark/src/constraints/evaluator.rs
@@ -2,8 +2,7 @@ use super::boundary::BoundaryConstraints;
 #[cfg(all(debug_assertions, not(feature = "parallel")))]
 use crate::debug::check_boundary_polys_divisibility;
 use crate::domain::Domain;
-use crate::lookup::BusPublicInputs;
-use crate::lookup::{LOGUP_CHALLENGE_ALPHA, compute_alpha_powers};
+use crate::lookup::{BusPublicInputs, LOGUP_CHALLENGE_ALPHA, compute_alpha_powers};
 use crate::trace::LDETraceTable;
 use crate::traits::{AIR, TransitionEvaluationContext, ZerofierEvaluations};
 use crate::{frame::Frame, prover::evaluate_polynomial_on_lde_domain};
@@ -27,6 +26,7 @@ pub struct ConstraintEvaluator<
     PI,
 > {
     boundary_constraints: BoundaryConstraints<FieldExtension>,
+    logup_table_offset: FieldElement<FieldExtension>,
     phantom: PhantomData<(Field, PI)>,
 }
 impl<Field, FieldExtension, PI> ConstraintEvaluator<Field, FieldExtension, PI>
@@ -50,16 +50,17 @@ where
         num_transition: usize,
         num_periodic: usize,
         offsets: &[usize],
+        logup_table_offset: &FieldElement<FieldExtension>,
     ) -> Vec<FieldElement<FieldExtension>> {
         let is_uniform = zerofier_data.is_uniform();
 
         // Pre-compute LogUp alpha powers once for all LDE domain points.
-        // Each LookupTermConstraint::evaluate reuses these instead of computing
-        // incremental alpha_power = alpha_power * alpha per call.
-        // 32 powers is generous (max bus elements per interaction is ~15).
         let logup_alpha_powers: Vec<FieldElement<FieldExtension>> =
             if rap_challenges.len() > LOGUP_CHALLENGE_ALPHA {
-                compute_alpha_powers(&rap_challenges[LOGUP_CHALLENGE_ALPHA], 32)
+                compute_alpha_powers(
+                    &rap_challenges[LOGUP_CHALLENGE_ALPHA],
+                    air.max_bus_elements(),
+                )
             } else {
                 Vec::new()
             };
@@ -105,6 +106,7 @@ where
                             periodic_buf,
                             rap_challenges,
                             &logup_alpha_powers,
+                            logup_table_offset,
                         );
                         air.compute_transition_into(&ctx, transition_buf);
 
@@ -155,6 +157,7 @@ where
                         &periodic_buf,
                         rap_challenges,
                         &logup_alpha_powers,
+                        logup_table_offset,
                     );
                     air.compute_transition_into(&ctx, &mut transition_buf);
 
@@ -191,8 +194,18 @@ where
         let boundary_constraints =
             air.boundary_constraints(pub_inputs, rap_challenges, bus_public_inputs, trace_length);
 
+        // Compute logup_table_offset = table_contribution / trace_length
+        let logup_table_offset = match bus_public_inputs {
+            Some(bpi) => {
+                let n = FieldElement::<FieldExtension>::from(trace_length as u64);
+                &bpi.table_contribution * n.inv().unwrap()
+            }
+            None => FieldElement::zero(),
+        };
+
         Self {
             boundary_constraints,
+            logup_table_offset,
             phantom: PhantomData::<(Field, PI)> {},
         }
     }
@@ -328,6 +341,7 @@ where
             num_transition,
             num_periodic,
             offsets,
+            &self.logup_table_offset,
         );
 
         #[cfg(feature = "instruments")]

--- a/crypto/stark/src/constraints/evaluator.rs
+++ b/crypto/stark/src/constraints/evaluator.rs
@@ -197,8 +197,10 @@ where
         // Compute logup_table_offset = table_contribution / trace_length
         let logup_table_offset = match bus_public_inputs {
             Some(bpi) => {
-                let n = FieldElement::<FieldExtension>::from(trace_length as u64);
-                &bpi.table_contribution * n.inv().unwrap()
+                let n_inv = FieldElement::<Field>::from(trace_length as u64)
+                    .inv()
+                    .unwrap();
+                &bpi.table_contribution * n_inv.to_extension::<FieldExtension>()
             }
             None => FieldElement::zero(),
         };

--- a/crypto/stark/src/constraints/evaluator.rs
+++ b/crypto/stark/src/constraints/evaluator.rs
@@ -200,7 +200,7 @@ where
                 let n_inv = FieldElement::<Field>::from(trace_length as u64)
                     .inv()
                     .unwrap();
-                &bpi.table_contribution * n_inv.to_extension::<FieldExtension>()
+                n_inv * &bpi.table_contribution
             }
             None => FieldElement::zero(),
         };

--- a/crypto/stark/src/debug.rs
+++ b/crypto/stark/src/debug.rs
@@ -111,7 +111,7 @@ pub fn validate_trace<
             let n_inv = FieldElement::<Field>::from(trace_length as u64)
                 .inv()
                 .unwrap();
-            &bpi.table_contribution * n_inv.to_extension::<FieldExtension>()
+            n_inv * &bpi.table_contribution
         }
         None => FieldElement::zero(),
     };

--- a/crypto/stark/src/debug.rs
+++ b/crypto/stark/src/debug.rs
@@ -108,8 +108,10 @@ pub fn validate_trace<
 
     let logup_table_offset = match bus_public_inputs {
         Some(bpi) => {
-            let n = FieldElement::<FieldExtension>::from(trace_length as u64);
-            &bpi.table_contribution * n.inv().unwrap()
+            let n_inv = FieldElement::<Field>::from(trace_length as u64)
+                .inv()
+                .unwrap();
+            &bpi.table_contribution * n_inv.to_extension::<FieldExtension>()
         }
         None => FieldElement::zero(),
     };

--- a/crypto/stark/src/debug.rs
+++ b/crypto/stark/src/debug.rs
@@ -1,4 +1,5 @@
 use super::domain::Domain;
+use super::lookup::BusPublicInputs;
 use super::trace::TraceTable;
 use super::traits::{AIR, TransitionEvaluationContext};
 use crate::lookup::{LOGUP_CHALLENGE_ALPHA, compute_alpha_powers};
@@ -27,6 +28,7 @@ pub fn validate_trace<
     trace: &TraceTable<Field, FieldExtension>,
     domain: &Domain<Field>,
     rap_challenges: &[FieldElement<FieldExtension>],
+    bus_public_inputs: Option<&BusPublicInputs<FieldExtension>>,
 ) -> bool {
     info!("Starting constraints validation over trace...");
     let mut ret = true;
@@ -65,9 +67,8 @@ pub fn validate_trace<
         .collect();
 
     // --------- VALIDATE BOUNDARY CONSTRAINTS ------------
-    // Note: We pass None for aux_hints because debug validation doesn't need the LogUp hints
     let trace_length = domain.interpolation_domain_size;
-    air.boundary_constraints(pub_inputs, rap_challenges, None, trace_length)
+    air.boundary_constraints(pub_inputs, rap_challenges, bus_public_inputs, trace_length)
         .constraints
         .iter()
         .for_each(|constraint| {
@@ -97,10 +98,21 @@ pub fn validate_trace<
 
     let logup_alpha_powers: Vec<FieldElement<FieldExtension>> =
         if rap_challenges.len() > LOGUP_CHALLENGE_ALPHA {
-            compute_alpha_powers(&rap_challenges[LOGUP_CHALLENGE_ALPHA], 32)
+            compute_alpha_powers(
+                &rap_challenges[LOGUP_CHALLENGE_ALPHA],
+                air.max_bus_elements(),
+            )
         } else {
             Vec::new()
         };
+
+    let logup_table_offset = match bus_public_inputs {
+        Some(bpi) => {
+            let n = FieldElement::<FieldExtension>::from(trace_length as u64);
+            &bpi.table_contribution * n.inv().unwrap()
+        }
+        None => FieldElement::zero(),
+    };
 
     // Iterate over trace and compute transitions
     for step in 0..lde_trace.num_steps() {
@@ -114,6 +126,7 @@ pub fn validate_trace<
             &periodic_values,
             rap_challenges,
             &logup_alpha_powers,
+            &logup_table_offset,
         );
         let evaluations = air.compute_transition(&transition_evaluation_context);
 

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -75,6 +75,21 @@ pub const LOGUP_CHALLENGE_ALPHA: usize = 1;
 /// Number of challenges required by the LogUp protocol.
 pub const LOGUP_NUM_CHALLENGES: usize = 2;
 
+/// Split N interactions into committed batched pairs and absorbed remainder.
+///
+/// Returns `(num_committed_pairs, absorbed_count)` where:
+/// - Committed pairs get dedicated auxiliary term columns (2 interactions per column)
+/// - Absorbed interactions (1 or 2) are folded into the accumulated constraint
+fn split_interactions(num_interactions: usize) -> (usize, usize) {
+    if num_interactions <= 2 {
+        (0, num_interactions)
+    } else if num_interactions % 2 == 1 {
+        ((num_interactions - 1) / 2, 1)
+    } else {
+        ((num_interactions - 2) / 2, 2)
+    }
+}
+
 // =============================================================================
 // Bus Types
 // =============================================================================
@@ -709,30 +724,9 @@ impl<
         let num_interactions = auxiliary_trace_build_data.interactions.len();
 
         // Split interactions: committed pairs get term columns, last 1-2 are absorbed
-        let (num_committed_pairs, absorbed) = if num_interactions == 0 {
-            (0, vec![])
-        } else if num_interactions <= 2 {
-            // All interactions absorbed, no committed term columns
-            (
-                0,
-                auxiliary_trace_build_data.interactions[..num_interactions].to_vec(),
-            )
-        } else if num_interactions % 2 == 1 {
-            // Odd: pairs from [0..N-1), absorb last 1
-            (
-                (num_interactions - 1) / 2,
-                vec![auxiliary_trace_build_data.interactions[num_interactions - 1].clone()],
-            )
-        } else {
-            // Even: pairs from [0..N-2), absorb last 2
-            (
-                (num_interactions - 2) / 2,
-                vec![
-                    auxiliary_trace_build_data.interactions[num_interactions - 2].clone(),
-                    auxiliary_trace_build_data.interactions[num_interactions - 1].clone(),
-                ],
-            )
-        };
+        let (num_committed_pairs, absorbed_count) = split_interactions(num_interactions);
+        let absorbed =
+            auxiliary_trace_build_data.interactions[num_interactions - absorbed_count..].to_vec();
 
         // Create batched term constraints for committed pairs only
         for pair_idx in 0..num_committed_pairs {
@@ -915,13 +909,7 @@ where
         let table_name = self.name.as_deref().unwrap_or("UNKNOWN");
 
         // Split interactions: committed pairs get term columns, last 1-2 are absorbed (virtual)
-        let (num_committed_pairs, absorbed_count) = if num_interactions <= 2 {
-            (0, num_interactions)
-        } else if num_interactions % 2 == 1 {
-            ((num_interactions - 1) / 2, 1usize)
-        } else {
-            ((num_interactions - 2) / 2, 2usize)
-        };
+        let (num_committed_pairs, absorbed_count) = split_interactions(num_interactions);
 
         // Compute committed term columns in parallel (batched pairs only)
         #[cfg(feature = "parallel")]

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1481,37 +1481,42 @@ where
     let multiplicities_a = compute_multiplicities(interaction_a);
     let multiplicities_b = compute_multiplicities(interaction_b);
 
+    // Compute fingerprints for both interactions using accumulate_fingerprint
+    // (zero-allocation inner loop: F×E multiplication instead of to_extension())
+    let bus_id_a = FieldElement::<F>::from(interaction_a.bus_id);
+    let bus_id_b = FieldElement::<F>::from(interaction_b.bus_id);
+
     // Concatenate both fingerprint vectors for a single batch inversion
     let mut all_fingerprints: Vec<FieldElement<E>> = Vec::with_capacity(2 * trace_len);
 
     for row in 0..trace_len {
-        let mut bus_elements_a: Vec<FieldElement<E>> =
-            vec![FieldElement::from(interaction_a.bus_id)];
-        bus_elements_a.extend(interaction_a.values.iter().flat_map(|bv| {
-            let combined: Vec<FieldElement<F>> =
-                bv.combine_from(|col| main_segment_cols[col][row].clone());
-            combined.into_iter().map(|v| v.to_extension())
-        }));
-        let lc_a: FieldElement<E> = bus_elements_a
-            .iter()
-            .zip(alpha_powers.iter())
-            .map(|(v, coeff)| v * coeff)
-            .sum();
+        let mut lc_a = &bus_id_a * &alpha_powers[0];
+        let mut alpha_offset = 1;
+        for bv in &interaction_a.values {
+            let consumed = bv.accumulate_fingerprint(
+                main_segment_cols,
+                row,
+                &alpha_powers,
+                alpha_offset,
+                &mut lc_a,
+            );
+            alpha_offset += consumed;
+        }
         all_fingerprints.push(z - &lc_a);
     }
     for row in 0..trace_len {
-        let mut bus_elements_b: Vec<FieldElement<E>> =
-            vec![FieldElement::from(interaction_b.bus_id)];
-        bus_elements_b.extend(interaction_b.values.iter().flat_map(|bv| {
-            let combined: Vec<FieldElement<F>> =
-                bv.combine_from(|col| main_segment_cols[col][row].clone());
-            combined.into_iter().map(|v| v.to_extension())
-        }));
-        let lc_b: FieldElement<E> = bus_elements_b
-            .iter()
-            .zip(alpha_powers.iter())
-            .map(|(v, coeff)| v * coeff)
-            .sum();
+        let mut lc_b = &bus_id_b * &alpha_powers[0];
+        let mut alpha_offset = 1;
+        for bv in &interaction_b.values {
+            let consumed = bv.accumulate_fingerprint(
+                main_segment_cols,
+                row,
+                &alpha_powers,
+                alpha_offset,
+                &mut lc_b,
+            );
+            alpha_offset += consumed;
+        }
         all_fingerprints.push(z - &lc_b);
     }
 

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1678,18 +1678,17 @@ fn compute_fingerprint_from_step<A: IsSubFieldOf<B>, B: IsField>(
     z: &FieldElement<B>,
     alpha_powers: &[FieldElement<B>],
 ) -> FieldElement<B> {
-    let mut bus_elements: Vec<FieldElement<B>> = vec![FieldElement::from(interaction.bus_id)];
-    bus_elements.extend(interaction.values.iter().flat_map(|bv| {
+    let bus_id_ext: FieldElement<B> = FieldElement::from(interaction.bus_id);
+    let mut linear_combination = &bus_id_ext * &alpha_powers[0];
+    let mut alpha_idx = 1;
+    for bv in &interaction.values {
         let combined: Vec<FieldElement<A>> =
             bv.combine_from(|col| step.get_main_evaluation_element(0, col).clone());
-        combined.into_iter().map(|v| v.to_extension())
-    }));
-
-    let linear_combination: FieldElement<B> = bus_elements
-        .iter()
-        .zip(alpha_powers.iter())
-        .map(|(v, coeff)| v * coeff)
-        .sum();
+        for v in combined {
+            linear_combination += v * &alpha_powers[alpha_idx];
+            alpha_idx += 1;
+        }
+    }
 
     z - &linear_combination
 }

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -676,6 +676,9 @@ pub struct AirWithBuses<
     num_precomputed_cols: Option<usize>,
     /// Optional name for debug output (per-table bus sum tracking)
     name: Option<String>,
+    /// Maximum number of bus elements across all interactions.
+    /// Used to compute the correct number of alpha powers.
+    max_bus_elements: usize,
 }
 
 impl<
@@ -688,11 +691,14 @@ impl<
     /// Creates an AirWithBuses with LogUp-specific transition constraints.
     /// If no boundary constraints are needed, use `NullBoundaryConstraintBuilder` as B and () as PI.
     ///
-    /// Auxiliary column layout:
-    /// - Columns 0..N-1: Term columns (one per interaction), each containing ±m[i]/fp[i]
-    /// - Column N: Accumulated column, containing the running sum of all terms
+    /// Auxiliary column layout (with interaction batching + absorption):
+    /// - Columns 0..num_committed_pairs-1: Committed term columns (batched pairs)
+    /// - Last column: Accumulated column (running sum + 1-2 absorbed interactions)
     ///
-    /// Total aux columns = N + 1 where N is the number of interactions.
+    /// The last 1-2 interactions are "absorbed" into the accumulated constraint
+    /// by clearing denominators, eliminating one committed term column per table.
+    ///
+    /// Total aux columns = ⌈N/2⌉ where N is the number of interactions.
     pub fn new(
         num_main_columns: usize,
         auxiliary_trace_build_data: AuxiliaryTraceBuildData,
@@ -702,30 +708,70 @@ impl<
     ) -> Self {
         let num_interactions = auxiliary_trace_build_data.interactions.len();
 
-        // Add a term constraint for each interaction
-        // Each term constraint verifies: term[i] = sign * multiplicity[i] / fingerprint[i]
-        // Rearranged as: term[i] * fingerprint[i] - sign * multiplicity[i] = 0
-        for (i, interaction) in auxiliary_trace_build_data.interactions.iter().enumerate() {
-            let constraint =
-                LookupTermConstraint::new(interaction.clone(), i, transition_constraints.len());
+        // Split interactions: committed pairs get term columns, last 1-2 are absorbed
+        let (num_committed_pairs, absorbed) = if num_interactions == 0 {
+            (0, vec![])
+        } else if num_interactions <= 2 {
+            // All interactions absorbed, no committed term columns
+            (
+                0,
+                auxiliary_trace_build_data.interactions[..num_interactions].to_vec(),
+            )
+        } else if num_interactions % 2 == 1 {
+            // Odd: pairs from [0..N-1), absorb last 1
+            (
+                (num_interactions - 1) / 2,
+                vec![auxiliary_trace_build_data.interactions[num_interactions - 1].clone()],
+            )
+        } else {
+            // Even: pairs from [0..N-2), absorb last 2
+            (
+                (num_interactions - 2) / 2,
+                vec![
+                    auxiliary_trace_build_data.interactions[num_interactions - 2].clone(),
+                    auxiliary_trace_build_data.interactions[num_interactions - 1].clone(),
+                ],
+            )
+        };
+
+        // Create batched term constraints for committed pairs only
+        for pair_idx in 0..num_committed_pairs {
+            let constraint = LookupBatchedTermConstraint::new(
+                auxiliary_trace_build_data.interactions[pair_idx * 2].clone(),
+                auxiliary_trace_build_data.interactions[pair_idx * 2 + 1].clone(),
+                pair_idx,
+                transition_constraints.len(),
+            );
             transition_constraints.push(Box::new(constraint));
         }
 
-        // Add the accumulated constraint (always, even for 1 interaction)
-        // This checks: acc[i+1] = acc[i] + sum of all terms at row i+1
+        let num_term_columns = num_committed_pairs;
+
+        // Add the accumulated constraint with absorbed interactions
         if num_interactions > 0 {
-            let accumulated_constraint =
-                LookupAccumulatedConstraint::new(transition_constraints.len(), num_interactions);
+            let accumulated_constraint = LookupAccumulatedConstraint::new(
+                transition_constraints.len(),
+                num_term_columns,
+                absorbed,
+            );
             transition_constraints.push(Box::new(accumulated_constraint));
         }
 
-        // Create Layout: N term columns + 1 accumulated column
+        // Layout: num_committed_pairs term columns + 1 accumulated = ⌈N/2⌉
         let num_aux_columns = if num_interactions > 0 {
-            num_interactions + 1
+            num_term_columns + 1
         } else {
             0
         };
         let trace_layout = (num_main_columns, num_aux_columns);
+
+        // Compute max bus elements across all interactions for alpha power count
+        let max_bus_elements = auxiliary_trace_build_data
+            .interactions
+            .iter()
+            .map(|i| i.num_bus_elements())
+            .max()
+            .unwrap_or(0);
 
         // Create context
         let context = AirContext {
@@ -745,6 +791,7 @@ impl<
             preprocessed_commitment: None,
             num_precomputed_cols: None,
             name: None,
+            max_bus_elements,
         }
     }
 
@@ -821,8 +868,18 @@ where
         !self.auxiliary_trace_build_data.interactions.is_empty()
     }
 
+    fn max_bus_elements(&self) -> usize {
+        self.max_bus_elements
+    }
+
     fn composition_poly_degree_bound(&self, trace_length: usize) -> usize {
-        trace_length * 2
+        let max_degree = self
+            .transition_constraints
+            .iter()
+            .map(|c| c.degree())
+            .max()
+            .unwrap_or(1);
+        trace_length * max_degree
     }
 
     fn context(&self) -> &AirContext {
@@ -857,22 +914,36 @@ where
         let trace_len = trace.num_rows();
         let table_name = self.name.as_deref().unwrap_or("UNKNOWN");
 
-        // Compute term columns in parallel — even with 1-3 interactions per table,
-        // each column computation is heavy enough to benefit from parallelism on
-        // high-core-count machines. Internal parallelism within each column is also used.
-        #[cfg(feature = "parallel")]
-        let interactions_iter = self
-            .auxiliary_trace_build_data
-            .interactions
-            .as_slice()
-            .into_par_iter();
-        #[cfg(not(feature = "parallel"))]
-        let interactions_iter = self.auxiliary_trace_build_data.interactions.iter();
+        // Split interactions: committed pairs get term columns, last 1-2 are absorbed (virtual)
+        let (num_committed_pairs, absorbed_count) = if num_interactions <= 2 {
+            (0, num_interactions)
+        } else if num_interactions % 2 == 1 {
+            ((num_interactions - 1) / 2, 1usize)
+        } else {
+            ((num_interactions - 2) / 2, 2usize)
+        };
 
-        let term_columns: Vec<Vec<FieldElement<E>>> = interactions_iter
-            .map(|interaction| {
-                compute_logup_term_column(
-                    interaction,
+        // Compute committed term columns in parallel (batched pairs only)
+        #[cfg(feature = "parallel")]
+        let committed_columns: Vec<Vec<FieldElement<E>>> = (0..num_committed_pairs)
+            .into_par_iter()
+            .map(|i| {
+                compute_logup_batched_term_column(
+                    &self.auxiliary_trace_build_data.interactions[i * 2],
+                    &self.auxiliary_trace_build_data.interactions[i * 2 + 1],
+                    &main_segment_cols,
+                    trace_len,
+                    challenges,
+                    table_name,
+                )
+            })
+            .collect();
+        #[cfg(not(feature = "parallel"))]
+        let committed_columns: Vec<Vec<FieldElement<E>>> = (0..num_committed_pairs)
+            .map(|i| {
+                compute_logup_batched_term_column(
+                    &self.auxiliary_trace_build_data.interactions[i * 2],
+                    &self.auxiliary_trace_build_data.interactions[i * 2 + 1],
                     &main_segment_cols,
                     trace_len,
                     challenges,
@@ -881,8 +952,28 @@ where
             })
             .collect();
 
-        // Write term columns to trace
-        for (col_idx, col_data) in term_columns.iter().enumerate() {
+        // Compute virtual column for absorbed interactions (NOT written to trace)
+        let virtual_column = if absorbed_count == 2 {
+            compute_logup_batched_term_column(
+                &self.auxiliary_trace_build_data.interactions[num_interactions - 2],
+                &self.auxiliary_trace_build_data.interactions[num_interactions - 1],
+                &main_segment_cols,
+                trace_len,
+                challenges,
+                table_name,
+            )
+        } else {
+            compute_logup_term_column(
+                &self.auxiliary_trace_build_data.interactions[num_interactions - 1],
+                &main_segment_cols,
+                trace_len,
+                challenges,
+                table_name,
+            )
+        };
+
+        // Write only committed columns to trace
+        for (col_idx, col_data) in committed_columns.iter().enumerate() {
             for (row, value) in col_data.iter().enumerate() {
                 trace.set_aux(row, col_idx, value.clone());
             }
@@ -890,22 +981,24 @@ where
 
         #[cfg(feature = "debug-checks")]
         let (per_bus_sums, per_bus_sender_sums, per_bus_receiver_sums) =
-            compute_debug_bus_sums(&self.auxiliary_trace_build_data.interactions, trace);
+            compute_debug_bus_sums_batched(
+                &self.auxiliary_trace_build_data.interactions,
+                &committed_columns,
+                &main_segment_cols,
+                trace_len,
+                challenges,
+                table_name,
+            );
 
-        // Build accumulated column from pre-computed term columns
-        let acc_col_idx = num_interactions;
-        build_accumulated_column_from_terms(acc_col_idx, &term_columns, trace);
+        // Build accumulated from all columns (committed + virtual)
+        let mut all_columns = committed_columns;
+        all_columns.push(virtual_column);
+        let acc_col_idx = num_committed_pairs; // accumulated column in trace follows committed columns
+        let table_contribution =
+            build_accumulated_column_from_terms(acc_col_idx, &all_columns, trace);
 
-        // Collect term column values at row 0 (public inputs for row-0 boundary constraints)
-        let initial_terms: Vec<FieldElement<E>> = (0..num_interactions)
-            .map(|i| trace.get_aux(0, i).clone())
-            .collect();
-
-        // Return BusPublicInputs with initial terms and accumulated column endpoints
-        let last_row = trace.num_rows() - 1;
         Some(BusPublicInputs {
-            initial_terms,
-            final_accumulated: trace.get_aux(last_row, acc_col_idx).clone(),
+            table_contribution,
             #[cfg(feature = "debug-checks")]
             per_bus_sums,
             #[cfg(feature = "debug-checks")]
@@ -930,36 +1023,21 @@ where
         &self,
         pub_inputs: &Self::PublicInputs,
         rap_challenges: &[FieldElement<E>],
-        bus_public_inputs: Option<&BusPublicInputs<E>>,
+        _bus_public_inputs: Option<&BusPublicInputs<E>>,
         trace_length: usize,
     ) -> BoundaryConstraints<E> {
-        let mut boundary_constraints = vec![];
+        let mut boundary_constraints = B::boundary_constraints(pub_inputs, rap_challenges);
 
-        if let Some(bus_inputs) = bus_public_inputs {
-            let acc_col_idx = self.auxiliary_trace_build_data.interactions.len();
-
-            // One boundary constraint per term column at row 0: term_i(0) = initial_terms[i].
-            // This makes each term's initial value a verifier-enforced public input.
-            // The verifier rejects proofs where initial_terms.len() != num_interactions
-            // before reaching constraint evaluation, so the length of initial_terms is guaranteed to be correct.
-            for (i, expected) in bus_inputs.initial_terms.iter().enumerate() {
-                boundary_constraints.push(BoundaryConstraint::new_aux(i, 0, expected.clone()));
-            }
-
-            // Boundary constraint for the accumulated column at row 0: acc(0) = Σ initial_terms.
-            let initial_acc: FieldElement<E> = bus_inputs.initial_terms.iter().cloned().sum();
-            boundary_constraints.push(BoundaryConstraint::new_aux(acc_col_idx, 0, initial_acc));
-
-            // Boundary constraint for the accumulated column at last row.
+        // Pin acc[N-1] = 0 to remove the constant-shift degree of freedom
+        // in the circular transition constraint.
+        if !self.auxiliary_trace_build_data.interactions.is_empty() {
+            let acc_col_idx = self.trace_layout.1 - 1; // last aux column = accumulated
             boundary_constraints.push(BoundaryConstraint::new_aux(
                 acc_col_idx,
                 trace_length - 1,
-                bus_inputs.final_accumulated.clone(),
+                FieldElement::zero(),
             ));
         }
-
-        // User-defined boundary constraints
-        boundary_constraints.extend(B::boundary_constraints(pub_inputs, rap_challenges));
 
         BoundaryConstraints::from_constraints(boundary_constraints)
     }
@@ -1116,24 +1194,24 @@ impl BusInteraction {
     }
 }
 
-/// Public inputs for a table's accumulated LogUp column.
-/// Contains the initial and final values needed for boundary constraints
-/// and bus balance verification.
+/// Public inputs for a table's LogUp accumulated column.
 ///
-/// Each table has exactly one BusPublicInputs, representing its accumulated column.
-/// The sign (sender vs receiver) is already baked into the accumulated values,
-/// so the bus balance check is simply: Σ final_accumulated across all tables = 0
+/// Each table has exactly one BusPublicInputs, representing the total
+/// contribution of all its LogUp terms (L = Σ all terms across all rows).
+/// The sign (sender vs receiver) is already baked into the values,
+/// so the bus balance check is: Σ table_contribution across all tables = 0.
+///
+/// For the circular constraint, `table_contribution / N` is the per-row offset
+/// that makes the accumulated column wrap to zero at row N-1.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(bound = "")]
 pub struct BusPublicInputs<E>
 where
     E: IsField,
 {
-    /// Term column values at row 0 (one per interaction).
-    /// Used for boundary constraints that enforce term_i(0) = initial_terms[i].
-    pub initial_terms: Vec<FieldElement<E>>,
-    /// Accumulated column value at last row (total sum of all terms)
-    pub final_accumulated: FieldElement<E>,
+    /// Total sum of all LogUp terms across all rows (L).
+    /// Used for bus balance check and to derive the per-row offset L/N.
+    pub table_contribution: FieldElement<E>,
     /// Per-bus sums for this table (bus_id → sum) - for debug aggregation
     #[cfg(feature = "debug-checks")]
     pub per_bus_sums: HashMap<u64, FieldElement<E>>,
@@ -1319,60 +1397,226 @@ where
         .collect()
 }
 
-/// Builds the accumulated column from pre-computed term columns.
+/// Computes a batched term column for two interactions sharing one aux column.
 ///
-/// acc[0] = sum of all term columns at row 0
-/// acc[i] = acc[i-1] + sum of all term columns at row i
+/// Each row contains: `term[i] = sign_a * m_a[i] / fp_a[i] + sign_b * m_b[i] / fp_b[i]`
 ///
-/// Takes term columns directly to avoid row-major trace access.
+/// Uses a single batch inversion for both fingerprint vectors (2*N elements).
+#[allow(clippy::needless_range_loop)]
+fn compute_logup_batched_term_column<F, E>(
+    interaction_a: &BusInteraction,
+    interaction_b: &BusInteraction,
+    main_segment_cols: &[Vec<FieldElement<F>>],
+    trace_len: usize,
+    challenges: &[FieldElement<E>],
+    #[cfg_attr(not(feature = "debug-checks"), allow(unused))] _table_name: &str,
+) -> Vec<FieldElement<E>>
+where
+    F: IsFFTField + IsSubFieldOf<E> + IsPrimeField + Send + Sync,
+    E: IsField + Send + Sync,
+{
+    let z = &challenges[LOGUP_CHALLENGE_Z];
+    let alpha = &challenges[LOGUP_CHALLENGE_ALPHA];
+
+    let max_bus_elements = interaction_a
+        .num_bus_elements()
+        .max(interaction_b.num_bus_elements());
+    let alpha_powers = compute_alpha_powers(alpha, max_bus_elements);
+
+    let sign_a = if interaction_a.is_sender {
+        FieldElement::<E>::one()
+    } else {
+        -FieldElement::<E>::one()
+    };
+    let sign_b = if interaction_b.is_sender {
+        FieldElement::<E>::one()
+    } else {
+        -FieldElement::<E>::one()
+    };
+
+    // Helper to compute multiplicities for an interaction
+    let compute_multiplicities = |interaction: &BusInteraction| -> Vec<FieldElement<F>> {
+        match &interaction.multiplicity {
+            Multiplicity::One => vec![FieldElement::one(); trace_len],
+            Multiplicity::Column(col) => main_segment_cols[*col].clone(),
+            Multiplicity::Sum(col_a, col_b) => main_segment_cols[*col_a]
+                .iter()
+                .zip(main_segment_cols[*col_b].iter())
+                .map(|(a, b)| a + b)
+                .collect(),
+            Multiplicity::Negated(col) => main_segment_cols[*col]
+                .iter()
+                .map(|elem| FieldElement::<F>::one() - elem)
+                .collect(),
+            Multiplicity::Linear(terms) => (0..trace_len)
+                .map(|row| {
+                    let mut result = FieldElement::<F>::zero();
+                    for term in terms {
+                        match *term {
+                            LinearTerm::Column {
+                                coefficient,
+                                column,
+                            } => {
+                                let coeff = FieldElement::<F>::from(coefficient);
+                                result += &main_segment_cols[column][row] * coeff;
+                            }
+                            LinearTerm::ColumnUnsigned {
+                                coefficient,
+                                column,
+                            } => {
+                                let coeff = FieldElement::<F>::from(coefficient);
+                                result += &main_segment_cols[column][row] * coeff;
+                            }
+                            LinearTerm::Constant(value) => {
+                                result += FieldElement::<F>::from(value);
+                            }
+                        }
+                    }
+                    result
+                })
+                .collect(),
+        }
+    };
+
+    let multiplicities_a = compute_multiplicities(interaction_a);
+    let multiplicities_b = compute_multiplicities(interaction_b);
+
+    // Concatenate both fingerprint vectors for a single batch inversion
+    let mut all_fingerprints: Vec<FieldElement<E>> = Vec::with_capacity(2 * trace_len);
+
+    for row in 0..trace_len {
+        let mut bus_elements_a: Vec<FieldElement<E>> =
+            vec![FieldElement::from(interaction_a.bus_id)];
+        bus_elements_a.extend(interaction_a.values.iter().flat_map(|bv| {
+            let combined: Vec<FieldElement<F>> =
+                bv.combine_from(|col| main_segment_cols[col][row].clone());
+            combined.into_iter().map(|v| v.to_extension())
+        }));
+        let lc_a: FieldElement<E> = bus_elements_a
+            .iter()
+            .zip(alpha_powers.iter())
+            .map(|(v, coeff)| v * coeff)
+            .sum();
+        all_fingerprints.push(z - &lc_a);
+    }
+    for row in 0..trace_len {
+        let mut bus_elements_b: Vec<FieldElement<E>> =
+            vec![FieldElement::from(interaction_b.bus_id)];
+        bus_elements_b.extend(interaction_b.values.iter().flat_map(|bv| {
+            let combined: Vec<FieldElement<F>> =
+                bv.combine_from(|col| main_segment_cols[col][row].clone());
+            combined.into_iter().map(|v| v.to_extension())
+        }));
+        let lc_b: FieldElement<E> = bus_elements_b
+            .iter()
+            .zip(alpha_powers.iter())
+            .map(|(v, coeff)| v * coeff)
+            .sum();
+        all_fingerprints.push(z - &lc_b);
+    }
+
+    // Single batch inversion for all 2*N fingerprints
+    FieldElement::inplace_batch_inverse(&mut all_fingerprints)
+        .expect("fingerprint is zero - probability of sampling zero is negligible");
+
+    // Compute batched terms: term[i] = sign_a * m_a[i] * fp_a_inv[i] + sign_b * m_b[i] * fp_b_inv[i]
+    (0..trace_len)
+        .map(|row| {
+            let fp_a_inv = &all_fingerprints[row];
+            let fp_b_inv = &all_fingerprints[trace_len + row];
+            &multiplicities_a[row] * &sign_a * fp_a_inv
+                + &multiplicities_b[row] * &sign_b * fp_b_inv
+        })
+        .collect()
+}
+
+/// Builds the circular accumulated column from pre-computed term columns.
+///
+/// For the circular constraint: acc[(i+1) mod N] - acc[i] - terms[(i+1) mod N] + L/N = 0
+/// We build: acc[0] = terms[0] - L/N, acc[i] = acc[i-1] + terms[i] - L/N
+/// Result: acc[N-1] = L - N*(L/N) = 0
+///
+/// Returns L (table_contribution = sum of all terms across all rows).
 fn build_accumulated_column_from_terms<F, E>(
     acc_column_idx: usize,
     term_columns: &[Vec<FieldElement<E>>],
     trace: &mut TraceTable<F, E>,
-) where
+) -> FieldElement<E>
+where
     F: IsFFTField + IsSubFieldOf<E> + Send + Sync,
     E: IsField + Send + Sync,
 {
     if term_columns.is_empty() {
-        return;
+        return FieldElement::zero();
     }
     let trace_len = term_columns[0].len();
-    let mut accumulated = FieldElement::<E>::zero();
 
+    // Compute L = sum of all terms across all rows
+    let mut table_contribution = FieldElement::<E>::zero();
+    for row in 0..trace_len {
+        for col in term_columns {
+            table_contribution = &table_contribution + &col[row];
+        }
+    }
+
+    // offset_per_row = L / N
+    let n = FieldElement::<E>::from(trace_len as u64);
+    let offset_per_row = &table_contribution * n.inv().unwrap();
+
+    // Build circular accumulated column
+    let mut accumulated = FieldElement::<E>::zero();
     for row in 0..trace_len {
         let mut row_sum = FieldElement::<E>::zero();
         for col in term_columns {
             row_sum = row_sum + &col[row];
         }
-        accumulated += row_sum;
+        accumulated = &accumulated + &row_sum - &offset_per_row;
         trace.set_aux(row, acc_column_idx, accumulated.clone());
     }
+
+    table_contribution
 }
 
-/// Sum aux term columns by bus_id to produce per-bus totals for the debug report.
+/// Sum per-interaction contributions by bus_id for debug reporting.
+///
+/// With batched term columns, we can't read individual interaction sums from
+/// the trace anymore (each column holds the sum of two interactions). Instead,
+/// we compute each interaction's sum from its raw term column.
 #[cfg(feature = "debug-checks")]
 #[allow(clippy::type_complexity)]
-fn compute_debug_bus_sums<F, E>(
+fn compute_debug_bus_sums_batched<F, E>(
     interactions: &[BusInteraction],
-    trace: &TraceTable<F, E>,
+    _batched_term_columns: &[Vec<FieldElement<E>>],
+    main_segment_cols: &[Vec<FieldElement<F>>],
+    trace_len: usize,
+    challenges: &[FieldElement<E>],
+    table_name: &str,
 ) -> (
     HashMap<u64, FieldElement<E>>,
     HashMap<u64, FieldElement<E>>,
     HashMap<u64, FieldElement<E>>,
 )
 where
-    F: IsFFTField + IsSubFieldOf<E> + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + IsPrimeField + Send + Sync,
     E: IsField + Send + Sync,
 {
     let mut bus_sums: HashMap<u64, FieldElement<E>> = HashMap::new();
     let mut sender_sums: HashMap<u64, FieldElement<E>> = HashMap::new();
     let mut receiver_sums: HashMap<u64, FieldElement<E>> = HashMap::new();
 
-    for (i, interaction) in interactions.iter().enumerate() {
-        let mut col_sum = FieldElement::<E>::zero();
-        for row in 0..trace.num_rows() {
-            col_sum = col_sum + trace.get_aux(row, i);
-        }
+    // Compute each interaction's individual term column for summing
+    for interaction in interactions.iter() {
+        let individual_terms = compute_logup_term_column(
+            interaction,
+            main_segment_cols,
+            trace_len,
+            challenges,
+            table_name,
+        );
+        let col_sum: FieldElement<E> = individual_terms
+            .iter()
+            .fold(FieldElement::zero(), |acc, x| acc + x);
+
         *bus_sums
             .entry(interaction.bus_id)
             .or_insert(FieldElement::zero()) += col_sum.clone();
@@ -1391,41 +1635,111 @@ where
     (bus_sums, sender_sums, receiver_sums)
 }
 
-/// Constraint for each term column.
+/// Computes multiplicity for an interaction from a `TableView`.
+fn compute_multiplicity_from_step<A: IsSubFieldOf<B>, B: IsField>(
+    step: &TableView<A, B>,
+    multiplicity: &Multiplicity,
+) -> FieldElement<A> {
+    match multiplicity {
+        Multiplicity::One => FieldElement::<A>::one(),
+        Multiplicity::Column(col) => step.get_main_evaluation_element(0, *col).clone(),
+        Multiplicity::Sum(col_a, col_b) => {
+            step.get_main_evaluation_element(0, *col_a)
+                + step.get_main_evaluation_element(0, *col_b)
+        }
+        Multiplicity::Negated(col) => {
+            FieldElement::<A>::one() - step.get_main_evaluation_element(0, *col)
+        }
+        Multiplicity::Linear(terms) => {
+            let mut result = FieldElement::<A>::zero();
+            for term in terms {
+                match term {
+                    LinearTerm::Column {
+                        coefficient,
+                        column,
+                    } => {
+                        let coeff = FieldElement::<A>::from(*coefficient);
+                        result += step.get_main_evaluation_element(0, *column) * coeff;
+                    }
+                    LinearTerm::ColumnUnsigned {
+                        coefficient,
+                        column,
+                    } => {
+                        let coeff = FieldElement::<A>::from(*coefficient);
+                        result += step.get_main_evaluation_element(0, *column) * coeff;
+                    }
+                    LinearTerm::Constant(value) => {
+                        result += FieldElement::<A>::from(*value);
+                    }
+                }
+            }
+            result
+        }
+    }
+}
+
+/// Computes the fingerprint for an interaction from a `TableView`.
 ///
-/// Verifies: `term[i] = sign * multiplicity[i] / fingerprint[i]`
+/// Returns `z - (bus_id*α^0 + v[0]*α^1 + v[1]*α^2 + ...)`
+fn compute_fingerprint_from_step<A: IsSubFieldOf<B>, B: IsField>(
+    step: &TableView<A, B>,
+    interaction: &BusInteraction,
+    z: &FieldElement<B>,
+    alpha_powers: &[FieldElement<B>],
+) -> FieldElement<B> {
+    let mut bus_elements: Vec<FieldElement<B>> = vec![FieldElement::from(interaction.bus_id)];
+    bus_elements.extend(interaction.values.iter().flat_map(|bv| {
+        let combined: Vec<FieldElement<A>> =
+            bv.combine_from(|col| step.get_main_evaluation_element(0, col).clone());
+        combined.into_iter().map(|v| v.to_extension())
+    }));
+
+    let linear_combination: FieldElement<B> = bus_elements
+        .iter()
+        .zip(alpha_powers.iter())
+        .map(|(v, coeff)| v * coeff)
+        .sum();
+
+    z - &linear_combination
+}
+
+/// Constraint for a batched pair of interactions sharing one aux column.
 ///
-/// Rearranged to avoid division: `term[i] * fingerprint[i] - sign * multiplicity[i] = 0`
+/// Verifies: `c = m_a/fp_a + m_b/fp_b` where signs are baked into m_a, m_b.
 ///
-/// where:
-/// - `fingerprint[i] = z - (v0 + v1*α + v2*α² + ...)` (bus elements after type combining)
-/// - `sign = +1` for senders, `-1` for receivers
-struct LookupTermConstraint {
-    // Indicates columns with multiplicity and values used to compute the term
-    interaction: BusInteraction,
-    // Index of the term column (aux column)
+/// Clearing denominators: `c * fp_a * fp_b - sign_a * m_a * fp_b - sign_b * m_b * fp_a = 0`
+///
+/// Degree 3: c (aux) × fp_a (linear in main) × fp_b (linear in main).
+struct LookupBatchedTermConstraint {
+    interaction_a: BusInteraction,
+    interaction_b: BusInteraction,
     term_column_idx: usize,
-    // Index of the constraint
     constraint_idx: usize,
 }
 
-impl LookupTermConstraint {
-    pub fn new(interaction: BusInteraction, term_column_idx: usize, constraint_idx: usize) -> Self {
+impl LookupBatchedTermConstraint {
+    pub fn new(
+        interaction_a: BusInteraction,
+        interaction_b: BusInteraction,
+        term_column_idx: usize,
+        constraint_idx: usize,
+    ) -> Self {
         Self {
-            interaction,
+            interaction_a,
+            interaction_b,
             term_column_idx,
             constraint_idx,
         }
     }
 }
 
-impl<F, E> TransitionConstraint<F, E> for LookupTermConstraint
+impl<F, E> TransitionConstraint<F, E> for LookupBatchedTermConstraint
 where
     F: IsFFTField + IsSubFieldOf<E> + Send + Sync,
     E: IsField + Send + Sync,
 {
     fn degree(&self) -> usize {
-        2 // aux * fingerprint (fingerprint is linear in main trace values)
+        3 // c * fp_a * fp_b
     }
 
     fn constraint_idx(&self) -> usize {
@@ -1433,7 +1747,7 @@ where
     }
 
     fn end_exemptions(&self) -> usize {
-        0 // Check all rows including the last
+        0
     }
 
     fn evaluate(
@@ -1441,230 +1755,36 @@ where
         evaluation_context: &TransitionEvaluationContext<F, E>,
         transition_evaluations: &mut [FieldElement<E>],
     ) {
-        fn evaluate_term_constraint<A: IsSubFieldOf<B>, B: IsField>(
+        fn evaluate_batched_term_constraint<A: IsSubFieldOf<B>, B: IsField>(
             step: &TableView<A, B>,
             term_column_idx: usize,
-            interaction: &BusInteraction,
+            interaction_a: &BusInteraction,
+            interaction_b: &BusInteraction,
             rap_challenges: &&[FieldElement<B>],
             alpha_powers: &[FieldElement<B>],
         ) -> FieldElement<B> {
-            // Term column value
-            let term = step.get_aux_evaluation_element(0, term_column_idx);
-
+            let c = step.get_aux_evaluation_element(0, term_column_idx);
             let z = &rap_challenges[LOGUP_CHALLENGE_Z];
 
-            // Compute multiplicity based on the Multiplicity variant
-            let multiplicity: FieldElement<A> = match &interaction.multiplicity {
-                Multiplicity::One => FieldElement::<A>::one(),
-                Multiplicity::Column(col) => step.get_main_evaluation_element(0, *col).clone(),
-                Multiplicity::Sum(col_a, col_b) => {
-                    step.get_main_evaluation_element(0, *col_a)
-                        + step.get_main_evaluation_element(0, *col_b)
-                }
-                Multiplicity::Negated(col) => {
-                    FieldElement::<A>::one() - step.get_main_evaluation_element(0, *col)
-                }
-                Multiplicity::Linear(terms) => {
-                    let mut result = FieldElement::<A>::zero();
-                    for term in terms {
-                        match term {
-                            LinearTerm::Column {
-                                coefficient,
-                                column,
-                            } => {
-                                let coeff = FieldElement::<A>::from(*coefficient);
-                                result += step.get_main_evaluation_element(0, *column) * coeff;
-                            }
-                            LinearTerm::ColumnUnsigned {
-                                coefficient,
-                                column,
-                            } => {
-                                let coeff = FieldElement::<A>::from(*coefficient);
-                                result += step.get_main_evaluation_element(0, *column) * coeff;
-                            }
-                            LinearTerm::Constant(value) => {
-                                result += FieldElement::<A>::from(*value);
-                            }
-                        }
-                    }
-                    result
-                }
-            };
+            let m_a = compute_multiplicity_from_step(step, &interaction_a.multiplicity);
+            let m_b = compute_multiplicity_from_step(step, &interaction_b.multiplicity);
 
-            // Compute fingerprint using pre-computed alpha powers (indexed access).
-            // fingerprint = z - (bus_id*α^0 + v[0]*α^1 + v[1]*α^2 + ...)
-            // alpha_powers[0] = 1, alpha_powers[1] = α, alpha_powers[2] = α², ...
-            let bus_id_f = FieldElement::<A>::from(interaction.bus_id);
-            let mut linear_combination = &bus_id_f * &alpha_powers[0];
-            #[allow(unused_assignments)]
-            let mut alpha_idx: usize = 1;
-            for bv in &interaction.values {
-                match bv {
-                    BusValue::Packed {
-                        start_column,
-                        packing,
-                    } => {
-                        match packing {
-                            Packing::Direct => {
-                                linear_combination += step
-                                    .get_main_evaluation_element(0, *start_column)
-                                    * &alpha_powers[alpha_idx];
-                                alpha_idx += 1;
-                            }
-                            Packing::Word2L => {
-                                let shift_16 = FieldElement::<A>::from(SHIFT_16);
-                                let combined = step.get_main_evaluation_element(0, *start_column)
-                                    + step.get_main_evaluation_element(0, *start_column + 1)
-                                        * &shift_16;
-                                linear_combination += &combined * &alpha_powers[alpha_idx];
-                                alpha_idx += 1;
-                            }
-                            Packing::Word4L => {
-                                let shift_8 = FieldElement::<A>::from(SHIFT_8);
-                                let shift_16 = FieldElement::<A>::from(SHIFT_16);
-                                let shift_24 = &shift_8 * &shift_16;
-                                let combined = step.get_main_evaluation_element(0, *start_column)
-                                    + step.get_main_evaluation_element(0, *start_column + 1)
-                                        * &shift_8
-                                    + step.get_main_evaluation_element(0, *start_column + 2)
-                                        * &shift_16
-                                    + step.get_main_evaluation_element(0, *start_column + 3)
-                                        * &shift_24;
-                                linear_combination += &combined * &alpha_powers[alpha_idx];
-                                alpha_idx += 1;
-                            }
-                            Packing::DWordWL => {
-                                // 2× Direct
-                                linear_combination += step
-                                    .get_main_evaluation_element(0, *start_column)
-                                    * &alpha_powers[alpha_idx];
-                                linear_combination += step
-                                    .get_main_evaluation_element(0, *start_column + 1)
-                                    * &alpha_powers[alpha_idx + 1];
-                                alpha_idx += 2;
-                            }
-                            Packing::DWordHL => {
-                                // 2× Word2L
-                                let shift_16 = FieldElement::<A>::from(SHIFT_16);
-                                let w0 = step.get_main_evaluation_element(0, *start_column)
-                                    + step.get_main_evaluation_element(0, *start_column + 1)
-                                        * &shift_16;
-                                linear_combination += &w0 * &alpha_powers[alpha_idx];
-                                let w1 = step.get_main_evaluation_element(0, *start_column + 2)
-                                    + step.get_main_evaluation_element(0, *start_column + 3)
-                                        * &shift_16;
-                                linear_combination += &w1 * &alpha_powers[alpha_idx + 1];
-                                alpha_idx += 2;
-                            }
-                            Packing::DWordBL => {
-                                // 2× Word4L
-                                let shift_8 = FieldElement::<A>::from(SHIFT_8);
-                                let shift_16 = FieldElement::<A>::from(SHIFT_16);
-                                let shift_24 = &shift_8 * &shift_16;
-                                let w0 = step.get_main_evaluation_element(0, *start_column)
-                                    + step.get_main_evaluation_element(0, *start_column + 1)
-                                        * &shift_8
-                                    + step.get_main_evaluation_element(0, *start_column + 2)
-                                        * &shift_16
-                                    + step.get_main_evaluation_element(0, *start_column + 3)
-                                        * &shift_24;
-                                linear_combination += &w0 * &alpha_powers[alpha_idx];
-                                let w1 = step.get_main_evaluation_element(0, *start_column + 4)
-                                    + step.get_main_evaluation_element(0, *start_column + 5)
-                                        * &shift_8
-                                    + step.get_main_evaluation_element(0, *start_column + 6)
-                                        * &shift_16
-                                    + step.get_main_evaluation_element(0, *start_column + 7)
-                                        * &shift_24;
-                                linear_combination += &w1 * &alpha_powers[alpha_idx + 1];
-                                alpha_idx += 2;
-                            }
-                            Packing::DWordHHW => {
-                                // Direct + Word2L
-                                linear_combination += step
-                                    .get_main_evaluation_element(0, *start_column)
-                                    * &alpha_powers[alpha_idx];
-                                let shift_16 = FieldElement::<A>::from(SHIFT_16);
-                                let w = step.get_main_evaluation_element(0, *start_column + 1)
-                                    + step.get_main_evaluation_element(0, *start_column + 2)
-                                        * &shift_16;
-                                linear_combination += &w * &alpha_powers[alpha_idx + 1];
-                                alpha_idx += 2;
-                            }
-                            Packing::DWordWHH => {
-                                // Word2L + Direct
-                                let shift_16 = FieldElement::<A>::from(SHIFT_16);
-                                let w = step.get_main_evaluation_element(0, *start_column)
-                                    + step.get_main_evaluation_element(0, *start_column + 1)
-                                        * &shift_16;
-                                linear_combination += &w * &alpha_powers[alpha_idx];
-                                linear_combination += step
-                                    .get_main_evaluation_element(0, *start_column + 2)
-                                    * &alpha_powers[alpha_idx + 1];
-                                alpha_idx += 2;
-                            }
-                            Packing::QuadHL => {
-                                // 4× Word2L
-                                let shift_16 = FieldElement::<A>::from(SHIFT_16);
-                                for i in 0..4 {
-                                    let c = *start_column + i * 2;
-                                    let w = step.get_main_evaluation_element(0, c)
-                                        + step.get_main_evaluation_element(0, c + 1) * &shift_16;
-                                    linear_combination += &w * &alpha_powers[alpha_idx + i];
-                                }
-                                alpha_idx += 4;
-                            }
-                            Packing::QuadWL => {
-                                // 4× Direct
-                                for i in 0..4 {
-                                    linear_combination += step
-                                        .get_main_evaluation_element(0, *start_column + i)
-                                        * &alpha_powers[alpha_idx + i];
-                                }
-                                alpha_idx += 4;
-                            }
-                        }
-                    }
-                    BusValue::Linear(terms) => {
-                        let mut result = FieldElement::<A>::zero();
-                        for term in terms {
-                            match term {
-                                LinearTerm::Column {
-                                    coefficient,
-                                    column,
-                                } => {
-                                    let coeff = FieldElement::<A>::from(*coefficient);
-                                    result += step.get_main_evaluation_element(0, *column) * coeff;
-                                }
-                                LinearTerm::ColumnUnsigned {
-                                    coefficient,
-                                    column,
-                                } => {
-                                    let coeff = FieldElement::<A>::from(*coefficient);
-                                    result += step.get_main_evaluation_element(0, *column) * coeff;
-                                }
-                                LinearTerm::Constant(value) => {
-                                    result += FieldElement::<A>::from(*value);
-                                }
-                            }
-                        }
-                        linear_combination += &result * &alpha_powers[alpha_idx];
-                        alpha_idx += 1;
-                    }
-                }
-            }
-            let fingerprint = z - &linear_combination;
+            let fp_a = compute_fingerprint_from_step(step, interaction_a, z, alpha_powers);
+            let fp_b = compute_fingerprint_from_step(step, interaction_b, z, alpha_powers);
 
-            // Sign: +1 for senders, -1 for receivers
-            let sign = if interaction.is_sender {
-                FieldElement::<B>::one()
+            let sign_a: FieldElement<B> = if interaction_a.is_sender {
+                FieldElement::one()
             } else {
-                -FieldElement::<B>::one()
+                -FieldElement::one()
+            };
+            let sign_b: FieldElement<B> = if interaction_b.is_sender {
+                FieldElement::one()
+            } else {
+                -FieldElement::one()
             };
 
-            // Constraint: term * fingerprint = sign * multiplicity
-            // Rearranged: term * fingerprint - sign * multiplicity = 0
-            term * &fingerprint - multiplicity * sign
+            // c * fp_a * fp_b - sign_a * m_a * fp_b - sign_b * m_b * fp_a = 0
+            c * &fp_a * &fp_b - m_a * sign_a * &fp_b - m_b * sign_b * &fp_a
         }
 
         let res = match evaluation_context {
@@ -1673,10 +1793,11 @@ where
                 rap_challenges,
                 logup_alpha_powers,
                 ..
-            } => evaluate_term_constraint(
+            } => evaluate_batched_term_constraint(
                 frame.get_evaluation_step(0),
                 self.term_column_idx,
-                &self.interaction,
+                &self.interaction_a,
+                &self.interaction_b,
                 rap_challenges,
                 logup_alpha_powers,
             ),
@@ -1685,10 +1806,11 @@ where
                 rap_challenges,
                 logup_alpha_powers,
                 ..
-            } => evaluate_term_constraint(
+            } => evaluate_batched_term_constraint(
                 frame.get_evaluation_step(0),
                 self.term_column_idx,
-                &self.interaction,
+                &self.interaction_a,
+                &self.interaction_b,
                 rap_challenges,
                 logup_alpha_powers,
             ),
@@ -1700,28 +1822,37 @@ where
     }
 }
 
-/// Constraint for the accumulated column.
+/// Constraint for the accumulated column with absorbed interactions.
 ///
-/// Verifies: `acc[i+1] = acc[i] + sum_k(term_k[i+1])`
+/// The accumulated column tracks the running sum of all committed term columns
+/// plus 1-2 "absorbed" interactions whose terms are verified inline (not committed).
 ///
-/// Rearranged: `acc[i+1] - acc[i] - sum_k(term_k[i+1]) = 0`
+/// For 1 absorbed interaction:
+///   `(acc_next - acc_curr - Σ terms + L/N) · f - sign · m = 0` (degree 2)
 ///
-/// where `term_k[i] = sign * multiplicity[i] / fingerprint[i]` for the k-th interaction.
+/// For 2 absorbed interactions:
+///   `(acc_next - acc_curr - Σ terms + L/N) · f₁·f₂ - sign₁·m₁·f₂ - sign₂·m₂·f₁ = 0` (degree 3)
 struct LookupAccumulatedConstraint {
-    // Index of the constraint
     constraint_idx: usize,
-    // Number of term columns (one per interaction)
+    /// Number of committed term columns (excludes absorbed interactions)
     num_term_columns: usize,
-    // Index of the accumulated column (= num_term_columns)
+    /// Index of the accumulated column (= num_term_columns)
     acc_column_idx: usize,
+    /// 1 or 2 interactions absorbed into this constraint (not committed as columns)
+    absorbed: Vec<BusInteraction>,
 }
 
 impl LookupAccumulatedConstraint {
-    pub fn new(constraint_idx: usize, num_term_columns: usize) -> Self {
+    pub fn new(
+        constraint_idx: usize,
+        num_term_columns: usize,
+        absorbed: Vec<BusInteraction>,
+    ) -> Self {
         Self {
             constraint_idx,
             num_term_columns,
             acc_column_idx: num_term_columns,
+            absorbed,
         }
     }
 }
@@ -1732,7 +1863,7 @@ where
     E: IsField + Send + Sync,
 {
     fn degree(&self) -> usize {
-        1 // Just additions, no multiplications with main trace
+        1 + self.absorbed.len() // 2 for 1 absorbed, 3 for 2 absorbed
     }
 
     fn constraint_idx(&self) -> usize {
@@ -1740,7 +1871,7 @@ where
     }
 
     fn end_exemptions(&self) -> usize {
-        1 // Last row doesn't have a "next row"
+        0 // Circular constraint applies to all rows including last→first wrap
     }
 
     fn evaluate(
@@ -1748,38 +1879,101 @@ where
         evaluation_context: &TransitionEvaluationContext<F, E>,
         transition_evaluations: &mut [FieldElement<E>],
     ) {
+        #[allow(clippy::too_many_arguments)]
         fn evaluate_accumulated_constraint<A: IsSubFieldOf<B>, B: IsField>(
             first_step: &TableView<A, B>,
             second_step: &TableView<A, B>,
             acc_column_idx: usize,
             num_term_columns: usize,
+            logup_table_offset: &FieldElement<B>,
+            absorbed: &[BusInteraction],
+            rap_challenges: &&[FieldElement<B>],
+            alpha_powers: &[FieldElement<B>],
         ) -> FieldElement<B> {
             // Accumulated column values
             let acc_curr = first_step.get_aux_evaluation_element(0, acc_column_idx);
             let acc_next = second_step.get_aux_evaluation_element(0, acc_column_idx);
 
-            // Sum of all term columns at the next step
+            // Sum of all committed term columns at the next step
             let terms_sum: FieldElement<B> = (0..num_term_columns)
                 .map(|i| second_step.get_aux_evaluation_element(0, i).clone())
                 .sum();
 
-            // Constraint: acc[i+1] = acc[i] + sum of terms at row i+1
-            // Rearranged: acc[i+1] - acc[i] - terms_sum = 0
-            acc_next - acc_curr - terms_sum
+            // delta = acc_next - acc_curr - terms_sum + L/N
+            let delta = acc_next - acc_curr - terms_sum + logup_table_offset;
+
+            let z = &rap_challenges[LOGUP_CHALLENGE_Z];
+
+            // Clear denominators of absorbed interactions
+            match absorbed.len() {
+                1 => {
+                    // (delta) · f - sign · m = 0
+                    let m = compute_multiplicity_from_step(second_step, &absorbed[0].multiplicity);
+                    let f =
+                        compute_fingerprint_from_step(second_step, &absorbed[0], z, alpha_powers);
+                    let sign: FieldElement<B> = if absorbed[0].is_sender {
+                        FieldElement::one()
+                    } else {
+                        -FieldElement::one()
+                    };
+                    delta * &f - m * sign
+                }
+                2 => {
+                    // (delta) · f₁ · f₂ - sign₁·m₁·f₂ - sign₂·m₂·f₁ = 0
+                    let m1 = compute_multiplicity_from_step(second_step, &absorbed[0].multiplicity);
+                    let m2 = compute_multiplicity_from_step(second_step, &absorbed[1].multiplicity);
+                    let f1 =
+                        compute_fingerprint_from_step(second_step, &absorbed[0], z, alpha_powers);
+                    let f2 =
+                        compute_fingerprint_from_step(second_step, &absorbed[1], z, alpha_powers);
+                    let sign1: FieldElement<B> = if absorbed[0].is_sender {
+                        FieldElement::one()
+                    } else {
+                        -FieldElement::one()
+                    };
+                    let sign2: FieldElement<B> = if absorbed[1].is_sender {
+                        FieldElement::one()
+                    } else {
+                        -FieldElement::one()
+                    };
+                    delta * &f1 * &f2 - m1 * sign1 * &f2 - m2 * sign2 * &f1
+                }
+                _ => unreachable!("absorbed must contain 1 or 2 interactions"),
+            }
         }
 
         let res = match evaluation_context {
-            TransitionEvaluationContext::Prover { frame, .. } => evaluate_accumulated_constraint(
+            TransitionEvaluationContext::Prover {
+                frame,
+                logup_table_offset,
+                rap_challenges,
+                logup_alpha_powers,
+                ..
+            } => evaluate_accumulated_constraint(
                 frame.get_evaluation_step(0),
                 frame.get_evaluation_step(1),
                 self.acc_column_idx,
                 self.num_term_columns,
+                logup_table_offset,
+                &self.absorbed,
+                rap_challenges,
+                logup_alpha_powers,
             ),
-            TransitionEvaluationContext::Verifier { frame, .. } => evaluate_accumulated_constraint(
+            TransitionEvaluationContext::Verifier {
+                frame,
+                logup_table_offset,
+                rap_challenges,
+                logup_alpha_powers,
+                ..
+            } => evaluate_accumulated_constraint(
                 frame.get_evaluation_step(0),
                 frame.get_evaluation_step(1),
                 self.acc_column_idx,
                 self.num_term_columns,
+                logup_table_offset,
+                &self.absorbed,
+                rap_challenges,
+                logup_alpha_powers,
             ),
         };
 

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -983,7 +983,6 @@ where
         let (per_bus_sums, per_bus_sender_sums, per_bus_receiver_sums) =
             compute_debug_bus_sums_batched(
                 &self.auxiliary_trace_build_data.interactions,
-                &committed_columns,
                 &main_segment_cols,
                 trace_len,
                 challenges,
@@ -1591,7 +1590,6 @@ where
 #[allow(clippy::type_complexity)]
 fn compute_debug_bus_sums_batched<F, E>(
     interactions: &[BusInteraction],
-    _batched_term_columns: &[Vec<FieldElement<E>>],
     main_segment_cols: &[Vec<FieldElement<F>>],
     trace_len: usize,
     challenges: &[FieldElement<E>],
@@ -1910,6 +1908,7 @@ where
             let z = &rap_challenges[LOGUP_CHALLENGE_Z];
 
             // Clear denominators of absorbed interactions
+            debug_assert!(matches!(absorbed.len(), 1 | 2));
             match absorbed.len() {
                 1 => {
                     // (delta) · f - sign · m = 0

--- a/crypto/stark/src/proof/stark.rs
+++ b/crypto/stark/src/proof/stark.rs
@@ -62,9 +62,9 @@ pub struct StarkProof<F: IsSubFieldOf<E>, E: IsField, PI> {
     // nonce obtained from grinding
     pub nonce: Option<u64>,
     // Bus interaction public inputs for the accumulated column.
-    // Contains initial and final aux column values, used for:
-    // 1. Boundary constraints on aux columns (row 0 and last row)
-    // 2. Bus balance check: Σ final_accumulated across all tables = 0
+    // Contains the table contribution (L), used for:
+    // 1. Circular constraint offset: L/N per row
+    // 2. Bus balance check: Σ table_contribution across all tables = 0
     pub bus_public_inputs: Option<BusPublicInputs<E>>,
     // Public inputs used for boundary constraints
     pub public_inputs: PI,

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1603,6 +1603,11 @@ pub trait IsStarkProver<
                 &mut aux_pool,
             )?;
 
+            // Bind table_contribution (L) to transcript for defense-in-depth.
+            if let Some(ref bpi) = round_1_result.bus_public_inputs {
+                table_transcript.append_field_element(&bpi.table_contribution);
+            }
+
             let proof = Self::prove_rounds_2_to_4(
                 *air,
                 *pub_inputs,

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -636,6 +636,7 @@ pub trait IsStarkProver<
                 *trace,
                 domain,
                 &round_1_result.rap_challenges,
+                round_1_result.bus_public_inputs.as_ref(),
             );
         }
     }

--- a/crypto/stark/src/tests/bus_tests/packing_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/packing_tests.rs
@@ -326,8 +326,8 @@ fn test_air_layout_single_interaction() {
         vec![],
     );
 
-    // 4 main, 2 aux (1 term + 1 accumulated)
-    assert_eq!(air.trace_layout(), (4, 2));
+    // 4 main, 1 aux (0 committed pairs + 1 accumulated with 1 absorbed)
+    assert_eq!(air.trace_layout(), (4, 1));
 }
 
 #[test]
@@ -358,6 +358,6 @@ fn test_air_layout_multiple_interactions() {
         vec![],
     );
 
-    // 5 main, 3 aux (2 term + 1 accumulated)
-    assert_eq!(air.trace_layout(), (5, 3));
+    // 5 main, 1 aux (0 committed pairs + 1 accumulated with 2 absorbed)
+    assert_eq!(air.trace_layout(), (5, 1));
 }

--- a/crypto/stark/src/tests/bus_tests/soundness_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/soundness_tests.rs
@@ -599,15 +599,14 @@ fn test_missing_receiver() {
 // First-row boundary constraints
 // =============================================================================
 
-/// A proof where initial_terms[0] has been tampered with is rejected.
+/// A proof where table_contribution has been tampered with is rejected.
 ///
-/// The ADD table exposes its term column value at row 0 as a public input
-/// (initial_terms[0]). The verifier enforces term_col_0(ω^0) = initial_terms[0]
-/// as a boundary constraint. We simulate a dishonest prover by corrupting
-/// initial_terms[0] in the proof after generation. The composition polynomial
-/// check then fails because the committed trace disagrees with the claimed value.
+/// The table_contribution (L) is used both for the bus balance check
+/// (Σ L = 0 across all tables) and for the per-row circular constraint
+/// offset (L/N). Corrupting it causes the circular transition constraint
+/// to fail, since the committed trace was built with the honest L.
 #[test_log::test]
-fn test_tampered_accumulator_first_row() {
+fn test_tampered_table_contribution() {
     // Simple valid trace: CPU sends (5, 3, 8) to the ADD table.
     let mut cpu_trace = TraceTable::from_columns_main(
         vec![
@@ -656,35 +655,33 @@ fn test_tampered_accumulator_first_row() {
     let mut multi_proof =
         Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
 
-    // Corrupt initial_terms[0] in the ADD table's bus public inputs.
-    // ADD has 1 interaction (receiver), so initial_terms has 1 element.
-    // Changing this breaks the boundary constraint for term_col_0 at row 0:
-    // the verifier will enforce term_col_0(ω^0) = corrupted value, but the
-    // committed trace has the honest value, causing the composition poly check to fail.
+    // Corrupt table_contribution in the ADD table's bus public inputs.
+    // This changes the per-row offset L/N used in the circular constraint,
+    // so the verifier's transition constraint evaluation will disagree with the
+    // committed trace (which was built with the honest L).
     let add_proof = &mut multi_proof.proofs[1]; // proofs: [cpu=0, add=1, mul=2]
     let bus_inputs = add_proof
         .bus_public_inputs
         .as_mut()
         .expect("ADD table must have bus public inputs");
-    bus_inputs.initial_terms[0] += FieldElement::<E>::one();
+    bus_inputs.table_contribution += FieldElement::<E>::one();
 
     let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
         vec![&cpu_air, &add_air, &mul_air];
 
     assert!(
         !Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[])),
-        "Proof with corrupted initial_terms[0] must be rejected"
+        "Proof with corrupted table_contribution must be rejected"
     );
 }
 
-/// A proof where the acc column OOD evaluation at row 0 is tampered with is rejected.
+/// A proof where the acc column OOD evaluation is tampered with is rejected.
 ///
-/// The verifier enforces acc(ω^0) = Σ initial_terms as a boundary constraint.
-/// We keep initial_terms honest but corrupt the acc column's OOD evaluation directly.
-/// The composition polynomial check then fails because the committed acc(z) no longer
-/// matches the expected value Σ initial_terms.
+/// The circular transition constraint enforces the relationship between
+/// consecutive acc column values at every step. Corrupting the acc column's
+/// OOD evaluation breaks this constraint at the OOD point.
 #[test_log::test]
-fn test_tampered_acc_ood_first_row() {
+fn test_tampered_acc_ood_evaluation() {
     // Simple valid trace: CPU sends (5, 3, 8) to the ADD table.
     let mut cpu_trace = TraceTable::from_columns_main(
         vec![
@@ -734,13 +731,11 @@ fn test_tampered_acc_ood_first_row() {
         Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
 
     // Corrupt the acc column OOD evaluation in the ADD table proof.
-    // ADD has 4 main columns + 1 interaction column + 1 acc column, so the aux layout is:
-    //   column 4 (OOD) = term column,  column 5 (OOD) = acc column
-    // initial_terms is kept honest, so the verifier's expected value Σ initial_terms
-    // is correct. But acc(z) no longer matches it → composition poly check fails.
+    // With batching + absorption, ADD has 4 main columns and 1 aux column
+    // (the accumulated column — all interactions are absorbed).
+    // The acc column is the last aux column.
     let num_main = 4usize;
-    let num_interactions = 1usize;
-    let acc_col_ood_idx = num_main + num_interactions;
+    let acc_col_ood_idx = num_main; // first (and only) aux column
     let add_proof = &mut multi_proof.proofs[1]; // proofs: [cpu=0, add=1, mul=2]
     let corrupted = *add_proof.trace_ood_evaluations.get(0, acc_col_ood_idx) + FieldElement::one();
     add_proof
@@ -752,7 +747,7 @@ fn test_tampered_acc_ood_first_row() {
 
     assert!(
         !Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[])),
-        "Proof with corrupted acc[0] OOD evaluation must be rejected"
+        "Proof with corrupted acc OOD evaluation must be rejected"
     );
 }
 
@@ -827,13 +822,63 @@ fn test_missing_bus_public_inputs_rejected() {
     );
 }
 
-/// A proof where initial_terms has fewer elements than expected is rejected.
+/// A proof where a non-LogUp AIR has bus_public_inputs injected is rejected.
 ///
-/// The verifier checks that initial_terms.len() == num_interactions before
-/// evaluating boundary constraints. A shorter vector would otherwise cause
-/// some term boundary constraints to be silently skipped.
+/// A dishonest prover could inject a compensating table_contribution into a
+/// table that has no LogUp constraints, making the bus balance ΣL = 0 while
+/// the actual lookup interactions don't balance. The verifier must reject
+/// any proof that contains bus_public_inputs for an AIR without trace interaction.
 #[test_log::test]
-fn test_initial_terms_length_mismatch_rejected() {
+fn test_injected_bus_public_inputs_on_non_logup_air_rejected() {
+    use crate::examples::dummy_air::{self, DummyAIR};
+    use crate::lookup::BusPublicInputs;
+
+    type DummyF = F; // GoldilocksField (same base and extension for DummyAIR)
+
+    let trace_length = 16;
+    let mut trace = dummy_air::dummy_trace::<DummyF>(trace_length);
+    let proof_options = ProofOptions::default_test_options();
+    let air = DummyAIR::new(&proof_options);
+
+    let mut proof = Prover::<DummyF, DummyF, ()>::prove(
+        &air,
+        &mut trace,
+        &(),
+        &mut DefaultTranscript::<DummyF>::new(&[]),
+    )
+    .unwrap();
+
+    // Inject fake bus_public_inputs into a non-LogUp proof.
+    // DummyAIR has has_trace_interaction() = false, so this must be rejected.
+    proof.bus_public_inputs = Some(BusPublicInputs {
+        table_contribution: FieldElement::<DummyF>::from(42u64),
+        #[cfg(feature = "debug-checks")]
+        per_bus_sums: Default::default(),
+        #[cfg(feature = "debug-checks")]
+        per_bus_sender_sums: Default::default(),
+        #[cfg(feature = "debug-checks")]
+        per_bus_receiver_sums: Default::default(),
+        #[cfg(feature = "debug-checks")]
+        table_name: "FAKE".to_string(),
+    });
+
+    assert!(
+        !Verifier::<DummyF, DummyF, ()>::verify(
+            &proof,
+            &air,
+            &mut DefaultTranscript::<DummyF>::new(&[])
+        ),
+        "Proof with injected bus_public_inputs on non-LogUp AIR must be rejected"
+    );
+}
+
+/// A proof where table_contribution is zeroed out is rejected.
+///
+/// Setting table_contribution to zero changes the per-row offset L/N to zero,
+/// which breaks the circular transition constraint since the committed trace
+/// was built with the honest (non-zero) L.
+#[test_log::test]
+fn test_zeroed_table_contribution_rejected() {
     let mut cpu_trace = TraceTable::from_columns_main(
         vec![
             vec![FE::one(), FE::zero(), FE::zero(), FE::zero()],
@@ -881,20 +926,20 @@ fn test_initial_terms_length_mismatch_rejected() {
     let mut multi_proof =
         Prover::multi_prove(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
 
-    // Truncate initial_terms to empty — ADD has 1 interaction so expected length is 1.
+    // Zero out table_contribution for the ADD table.
     let add_proof = &mut multi_proof.proofs[1];
     let bus_inputs = add_proof
         .bus_public_inputs
         .as_mut()
         .expect("ADD table must have bus public inputs");
-    bus_inputs.initial_terms.clear();
+    bus_inputs.table_contribution = FieldElement::<E>::zero();
 
     let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
         vec![&cpu_air, &add_air, &mul_air];
 
     assert!(
         !Verifier::multi_verify(&airs, &multi_proof, &mut DefaultTranscript::<E>::new(&[])),
-        "Proof with initial_terms length mismatch must be rejected"
+        "Proof with zeroed table_contribution must be rejected"
     );
 }
 

--- a/crypto/stark/src/traits.rs
+++ b/crypto/stark/src/traits.rs
@@ -77,12 +77,14 @@ where
         periodic_values: &'a [FieldElement<F>],
         rap_challenges: &'a [FieldElement<E>],
         logup_alpha_powers: &'a [FieldElement<E>],
+        logup_table_offset: &'a FieldElement<E>,
     },
     Verifier {
         frame: &'a Frame<E, E>,
         periodic_values: &'a [FieldElement<E>],
         rap_challenges: &'a [FieldElement<E>],
         logup_alpha_powers: &'a [FieldElement<E>],
+        logup_table_offset: &'a FieldElement<E>,
     },
 }
 
@@ -96,12 +98,14 @@ where
         periodic_values: &'a [FieldElement<F>],
         rap_challenges: &'a [FieldElement<E>],
         logup_alpha_powers: &'a [FieldElement<E>],
+        logup_table_offset: &'a FieldElement<E>,
     ) -> Self {
         Self::Prover {
             frame,
             periodic_values,
             rap_challenges,
             logup_alpha_powers,
+            logup_table_offset,
         }
     }
 
@@ -110,12 +114,14 @@ where
         periodic_values: &'a [FieldElement<E>],
         rap_challenges: &'a [FieldElement<E>],
         logup_alpha_powers: &'a [FieldElement<E>],
+        logup_table_offset: &'a FieldElement<E>,
     ) -> Self {
         Self::Verifier {
             frame,
             periodic_values,
             rap_challenges,
             logup_alpha_powers,
+            logup_table_offset,
         }
     }
 }
@@ -165,6 +171,12 @@ pub trait AIR: Send + Sync {
     /// Generic RAP AIRs with auxiliary columns but no bus interactions must return false.
     fn has_trace_interaction(&self) -> bool {
         false
+    }
+
+    /// Returns the maximum number of bus elements across all interactions.
+    /// Used to compute the correct number of alpha powers for LogUp fingerprints.
+    fn max_bus_elements(&self) -> usize {
+        0
     }
 
     /// Returns true if this AIR has preprocessed (precomputed) columns.

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -321,7 +321,10 @@ pub trait IsStarkVerifier<
         let logup_table_offset = match &proof.bus_public_inputs {
             Some(bpi) => {
                 let n = FieldElement::<FieldExtension>::from(trace_length as u64);
-                &bpi.table_contribution * n.inv().unwrap()
+                match n.inv() {
+                    Ok(n_inv) => &bpi.table_contribution * n_inv,
+                    Err(_) => return false, // trace_length == 0 is invalid
+                }
             }
             None => FieldElement::zero(),
         };

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -320,9 +320,9 @@ pub trait IsStarkVerifier<
 
         let logup_table_offset = match &proof.bus_public_inputs {
             Some(bpi) => {
-                let n = FieldElement::<FieldExtension>::from(trace_length as u64);
+                let n = FieldElement::<Field>::from(trace_length as u64);
                 match n.inv() {
-                    Ok(n_inv) => &bpi.table_contribution * n_inv,
+                    Ok(n_inv) => n_inv * &bpi.table_contribution,
                     Err(_) => return false, // trace_length == 0 is invalid
                 }
             }

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -310,10 +310,22 @@ pub trait IsStarkVerifier<
 
         let logup_alpha_powers: Vec<FieldElement<FieldExtension>> =
             if challenges.rap_challenges.len() > LOGUP_CHALLENGE_ALPHA {
-                compute_alpha_powers(&challenges.rap_challenges[LOGUP_CHALLENGE_ALPHA], 32)
+                compute_alpha_powers(
+                    &challenges.rap_challenges[LOGUP_CHALLENGE_ALPHA],
+                    air.max_bus_elements(),
+                )
             } else {
                 Vec::new()
             };
+
+        let logup_table_offset = match &proof.bus_public_inputs {
+            Some(bpi) => {
+                let n = FieldElement::<FieldExtension>::from(trace_length as u64);
+                &bpi.table_contribution * n.inv().unwrap()
+            }
+            None => FieldElement::zero(),
+        };
+
         let ood_frame =
             (proof.trace_ood_evaluations).into_frame(num_main_trace_columns, air.step_size());
         let transition_evaluation_context = TransitionEvaluationContext::new_verifier(
@@ -321,6 +333,7 @@ pub trait IsStarkVerifier<
             &periodic_values,
             &challenges.rap_challenges,
             &logup_alpha_powers,
+            &logup_table_offset,
         );
         let transition_ood_frame_evaluations =
             air.compute_transition(&transition_evaluation_context);
@@ -905,11 +918,12 @@ pub trait IsStarkVerifier<
         };
 
         // =====================================================================
-        // Validate bus_public_inputs presence and length against AIR layout
+        // Validate bus_public_inputs presence against AIR layout
         // =====================================================================
         // A dishonest prover could omit bus_public_inputs entirely (None) to
-        // bypass the bus balance check and boundary constraints, or submit fewer
-        // initial_terms than expected to skip term boundary constraints.
+        // bypass the bus balance check. With circular constraints, there are no
+        // boundary constraints on LogUp columns, so the bus balance check is
+        // the only cross-table validation.
 
         for (idx, (air, proof)) in airs.iter().zip(&multi_proof.proofs).enumerate() {
             if air.has_trace_interaction() && proof.bus_public_inputs.is_none() {
@@ -918,23 +932,11 @@ pub trait IsStarkVerifier<
                 );
                 return false;
             }
-            if let Some(bus_inputs) = &proof.bus_public_inputs {
-                let num_aux = air.num_auxiliary_rap_columns();
-                if num_aux == 0 {
-                    error!(
-                        "Table {idx}: proof has bus_public_inputs but AIR has no auxiliary columns"
-                    );
-                    return false;
-                }
-                let expected_interactions = num_aux - 1;
-                if bus_inputs.initial_terms.len() != expected_interactions {
-                    error!(
-                        "Table {idx}: initial_terms length mismatch: got {}, expected {}",
-                        bus_inputs.initial_terms.len(),
-                        expected_interactions
-                    );
-                    return false;
-                }
+            if !air.has_trace_interaction() && proof.bus_public_inputs.is_some() {
+                error!(
+                    "Table {idx}: AIR has no LogUp interactions but proof contains bus_public_inputs"
+                );
+                return false;
             }
         }
 
@@ -959,6 +961,11 @@ pub trait IsStarkVerifier<
                 table_transcript.append_bytes(&root);
             }
 
+            // Bind table_contribution (L) to transcript, matching prover.
+            if let Some(ref bpi) = proof.bus_public_inputs {
+                table_transcript.append_field_element(&bpi.table_contribution);
+            }
+
             // Rounds 2-4: verify
             if !Self::verify_rounds_2_to_4(
                 *air,
@@ -977,17 +984,19 @@ pub trait IsStarkVerifier<
         }
 
         // =====================================================================
-        // Bus Balance Check: Σ accumulated_values = 0
+        // Bus Balance Check: Σ table_contribution = 0
         // =====================================================================
-        // For LogUp, each table has one accumulated column that sums all its terms.
-        // The sign (sender vs receiver) is already baked into the accumulated values,
-        // so the bus balances when the sum of all accumulated values equals zero.
+        // For LogUp with circular constraints, each table's total contribution L
+        // (sum of all per-row terms) is exposed as a public input. The bus balances
+        // when the sum of all table contributions equals zero.
 
         if needs_lookup_challenges {
             let mut total = FieldElement::<FieldExtension>::zero();
-            for proof in &multi_proof.proofs {
-                if let Some(interaction) = &proof.bus_public_inputs {
-                    total = total + &interaction.final_accumulated;
+            for (air, proof) in airs.iter().zip(&multi_proof.proofs) {
+                if air.has_trace_interaction()
+                    && let Some(interaction) = &proof.bus_public_inputs
+                {
+                    total = total + &interaction.table_contribution;
                 }
             }
 

--- a/prover/src/constraints/cpu.rs
+++ b/prover/src/constraints/cpu.rs
@@ -701,9 +701,7 @@ impl NextPcAddConstraint {
         let instr_size = four - two * c_type;
 
         // carry_0 = (pc_lo + instr_size - next_pc_lo) * 2^(-32)
-        let inv_2_32: FieldElement<F> = FieldElement::from(super::templates::SHIFT_32)
-            .inv()
-            .unwrap();
+        let inv_2_32 = FieldElement::<F>::from(super::templates::INV_SHIFT_32);
         (pc_lo + instr_size - next_pc_lo) * inv_2_32
     }
 
@@ -719,9 +717,7 @@ impl NextPcAddConstraint {
 
         // rhs_hi = 0 (instruction size fits in low word)
         // carry_1 = (pc_hi + 0 + carry_0 - next_pc_hi) * 2^(-32)
-        let inv_2_32: FieldElement<F> = FieldElement::from(super::templates::SHIFT_32)
-            .inv()
-            .unwrap();
+        let inv_2_32 = FieldElement::<F>::from(super::templates::INV_SHIFT_32);
         (pc_hi + carry_0 - next_pc_hi) * inv_2_32
     }
 

--- a/prover/src/constraints/templates.rs
+++ b/prover/src/constraints/templates.rs
@@ -27,10 +27,15 @@ use crate::tables::types::{GoldilocksExtension, GoldilocksField};
 /// 2^32 for word combining and carry extraction
 pub const SHIFT_32: u64 = 1u64 << 32;
 
+/// Precomputed: (2^32)^(-1) mod p where p = 2^64 - 2^32 + 1.
+/// Avoids ~72 multiplications per inv() call in constraint hot loops.
+/// Verify: INV_SHIFT_32 * SHIFT_32 ≡ 1 (mod p)
+pub const INV_SHIFT_32: u64 = 18446744065119617026;
+
 /// 2^(-32) in the field, used for carry extraction.
 #[inline]
 fn inv_2_32<F: IsField>() -> FieldElement<F> {
-    FieldElement::from(SHIFT_32).inv().unwrap()
+    FieldElement::from(INV_SHIFT_32)
 }
 
 // =========================================================================
@@ -566,4 +571,17 @@ pub fn new_is_bit_constraints(
         .collect();
 
     (constraints, constraint_idx_start + value_cols.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tables::types::GoldilocksField;
+
+    #[test]
+    fn test_inv_shift_32_is_correct() {
+        let inv = FieldElement::<GoldilocksField>::from(INV_SHIFT_32);
+        let shift = FieldElement::<GoldilocksField>::from(SHIFT_32);
+        assert_eq!(inv * shift, FieldElement::one());
+    }
 }

--- a/prover/src/tables/branch.rs
+++ b/prover/src/tables/branch.rs
@@ -34,7 +34,7 @@ use stark::table::TableView;
 use stark::trace::TraceTable;
 use stark::traits::TransitionEvaluationContext;
 
-use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16, SHIFT_32};
+use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16};
 
 // =========================================================================
 // Column indices for BRANCH table
@@ -490,9 +490,7 @@ impl BranchConstraint {
         // Compute carry_0 as (base + offset - result) / 2^32 in the field.
         // This works because: base + offset = result + carry_0 * 2^32 (mod field)
         // Rearranging: carry_0 = (base + offset - result) * (2^32)^-1 (mod field)
-        let inv_2_32 = FieldElement::<F>::from(SHIFT_32)
-            .inv()
-            .expect("2^32 must be invertible in field");
+        let inv_2_32 = FieldElement::<F>::from(crate::constraints::templates::INV_SHIFT_32);
         (&base_0 + &offset_0 - &unmasked_0) * &inv_2_32
     }
 
@@ -517,9 +515,7 @@ impl BranchConstraint {
         let offset_1 = step.get_main_evaluation_element(0, cols::OFFSET_1).clone();
 
         // carry[1] = (base[1] + offset[1] + carry[0] - unmasked[1]) / 2^32
-        let inv_2_32 = FieldElement::<F>::from(SHIFT_32)
-            .inv()
-            .expect("2^32 must be invertible in field");
+        let inv_2_32 = FieldElement::<F>::from(crate::constraints::templates::INV_SHIFT_32);
         (&base_1 + &offset_1 + &carry_0 - &unmasked_1) * &inv_2_32
     }
 

--- a/prover/src/tables/dvrm.rs
+++ b/prover/src/tables/dvrm.rs
@@ -41,7 +41,7 @@ use stark::traits::TransitionEvaluationContext;
 
 use super::types::{
     BusId, FE, GoldilocksExtension, GoldilocksField, NEG_INV_2_16, NEG_INV_2_32, NEG_INV_2_48,
-    NEG_INV_2_64, SHIFT_16, SHIFT_32,
+    NEG_INV_2_64, SHIFT_16,
 };
 
 // =========================================================================
@@ -1163,7 +1163,7 @@ impl DvrmConstraint {
         E: IsField,
     {
         let shift_16 = FieldElement::<F>::from(SHIFT_16);
-        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().unwrap();
+        let inv_2_32 = FieldElement::<F>::from(crate::constraints::templates::INV_SHIFT_32);
         let sign_fill = FieldElement::<F>::from(SIGN_FILL);
 
         // Get n, n_sub_r, r halfwords

--- a/prover/src/tables/lt.rs
+++ b/prover/src/tables/lt.rs
@@ -33,7 +33,7 @@ use stark::table::TableView;
 use stark::trace::TraceTable;
 use stark::traits::TransitionEvaluationContext;
 
-use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16, SHIFT_32};
+use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField, SHIFT_16};
 
 // =========================================================================
 // Column indices for LT table
@@ -428,7 +428,7 @@ impl LtConstraint {
         let sub_lo = &sub_0 + &sub_1 * &shift_16;
 
         // carry[0] = (rhs[0] + sub_lo - lhs[0]) / 2^32
-        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().unwrap();
+        let inv_2_32 = FieldElement::<F>::from(crate::constraints::templates::INV_SHIFT_32);
         (&rhs_0 + &sub_lo - &lhs_0) * &inv_2_32
     }
 
@@ -471,7 +471,7 @@ impl LtConstraint {
         let carry_0 = self.compute_carry_0(step);
 
         // carry[1] = (rhs_hi + sub_hi + carry_0 - lhs_hi) / 2^32
-        let inv_2_32 = FieldElement::<F>::from(SHIFT_32).inv().unwrap();
+        let inv_2_32 = FieldElement::<F>::from(crate::constraints::templates::INV_SHIFT_32);
         (&rhs_hi + &sub_hi + &carry_0 - &lhs_hi) * &inv_2_32
     }
 


### PR DESCRIPTION
This PR introduces column batching for LogUp tables, pairing two bus interactions per auxiliary column to reduce auxiliary trace width.

Each LogUp table currently uses N+1 auxiliary columns (one per interaction plus an accumulated column), which increases memory usage and commitment cost. Reducing auxiliary trace width lowers peak memory usage and Merkle tree size.

The batching uses the cleared-denominator constraint
`c * fp_a * fp_b - sign_a * m_a * fp_b - sign_b * m_b * fp_a = 0` (degree 3),
and absorbs the final 1–2 interactions into the accumulated constraint instead of requiring dedicated columns.
As a result, auxiliary columns are reduced from N+1` to ⌈N/2⌉ per table.