### PR TITLE
SIMD Goldilocks FFT butterflies (NEON + AVX2)

### DIFF
--- a/crypto/math/src/fft/cpu/bowers_fft.rs
+++ b/crypto/math/src/fft/cpu/bowers_fft.rs
@@ -320,20 +320,18 @@ fn process_fused_block<F, E>(
     #[cfg(target_arch = "x86_64")]
     if core::any::TypeId::of::<F>() == core::any::TypeId::of::<GoldilocksField>()
         && core::any::TypeId::of::<E>() == core::any::TypeId::of::<GoldilocksField>()
+        && is_x86_feature_detected!("avx2")
     {
-        if is_x86_feature_detected!("avx2") {
-            let data = unsafe {
-                core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len())
-            };
-            let tw0 = unsafe {
-                core::slice::from_raw_parts(twiddles_l0.as_ptr() as *const u64, twiddles_l0.len())
-            };
-            let tw1 = unsafe {
-                core::slice::from_raw_parts(twiddles_l1.as_ptr() as *const u64, twiddles_l1.len())
-            };
-            unsafe { super::simd_butterflies::dif_fused_butterfly_avx2(data, tw0, tw1) };
-            return;
-        }
+        let data =
+            unsafe { core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len()) };
+        let tw0 = unsafe {
+            core::slice::from_raw_parts(twiddles_l0.as_ptr() as *const u64, twiddles_l0.len())
+        };
+        let tw1 = unsafe {
+            core::slice::from_raw_parts(twiddles_l1.as_ptr() as *const u64, twiddles_l1.len())
+        };
+        unsafe { super::simd_butterflies::dif_fused_butterfly_avx2(data, tw0, tw1) };
+        return;
     }
 
     let block_size = block.len();
@@ -418,17 +416,14 @@ fn process_single_layer_block<F, E>(
     if core::any::TypeId::of::<F>() == core::any::TypeId::of::<GoldilocksField>()
         && core::any::TypeId::of::<E>() == core::any::TypeId::of::<GoldilocksField>()
         && half_block >= super::simd_butterflies::AVX2_MIN_HALF_BLOCK
+        && is_x86_feature_detected!("avx2")
     {
-        if is_x86_feature_detected!("avx2") {
-            let data = unsafe {
-                core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len())
-            };
-            let tw = unsafe {
-                core::slice::from_raw_parts(twiddles.as_ptr() as *const u64, twiddles.len())
-            };
-            unsafe { super::simd_butterflies::dif_butterfly_avx2(data, tw, half_block) };
-            return;
-        }
+        let data =
+            unsafe { core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len()) };
+        let tw =
+            unsafe { core::slice::from_raw_parts(twiddles.as_ptr() as *const u64, twiddles.len()) };
+        unsafe { super::simd_butterflies::dif_butterfly_avx2(data, tw, half_block) };
+        return;
     }
 
     debug_assert!(
@@ -767,17 +762,14 @@ fn process_ifft_single_layer_block<F, E>(
     if core::any::TypeId::of::<F>() == core::any::TypeId::of::<GoldilocksField>()
         && core::any::TypeId::of::<E>() == core::any::TypeId::of::<GoldilocksField>()
         && half_block >= super::simd_butterflies::AVX2_MIN_HALF_BLOCK
+        && is_x86_feature_detected!("avx2")
     {
-        if is_x86_feature_detected!("avx2") {
-            let data = unsafe {
-                core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len())
-            };
-            let tw = unsafe {
-                core::slice::from_raw_parts(twiddles.as_ptr() as *const u64, twiddles.len())
-            };
-            unsafe { super::simd_butterflies::dit_butterfly_avx2(data, tw, half_block) };
-            return;
-        }
+        let data =
+            unsafe { core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len()) };
+        let tw =
+            unsafe { core::slice::from_raw_parts(twiddles.as_ptr() as *const u64, twiddles.len()) };
+        unsafe { super::simd_butterflies::dit_butterfly_avx2(data, tw, half_block) };
+        return;
     }
 
     debug_assert!(

--- a/crypto/math/src/fft/cpu/bowers_fft.rs
+++ b/crypto/math/src/fft/cpu/bowers_fft.rs
@@ -41,6 +41,9 @@ use crate::field::{
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+#[cfg(feature = "alloc")]
+use crate::field::fields::fft_friendly::u64_goldilocks::GoldilocksField;
+
 /// Maximum supported FFT order to prevent integer overflow.
 /// With order 63, n = 2^63 which is the largest power of 2 that fits in usize on 64-bit.
 /// For 32-bit systems, max order is 31.
@@ -207,8 +210,8 @@ pub fn bowers_fft_opt_fused_parallel<F, E>(
     layer_twiddles: &LayerTwiddles<F>,
 ) -> Result<(), FFTError>
 where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + Send + Sync + 'static,
     FieldElement<F>: Send + Sync,
     FieldElement<E>: Send + Sync,
 {
@@ -276,18 +279,8 @@ where
             });
         } else {
             for block_start in (0..n).step_by(block_size) {
-                for j in 0..half_block {
-                    let i0 = block_start + j;
-                    let i1 = i0 + half_block;
-                    let w = &twiddles[j];
-
-                    let sum = &input[i0] + &input[i1];
-                    let diff = &input[i0] - &input[i1];
-                    let diff_w = w * &diff;
-
-                    input[i0] = sum;
-                    input[i1] = diff_w;
-                }
+                let block = &mut input[block_start..block_start + block_size];
+                process_single_layer_block(block, twiddles, half_block);
             }
         }
         layer += 1;
@@ -304,9 +297,45 @@ fn process_fused_block<F, E>(
     twiddles_l0: &[FieldElement<F>],
     twiddles_l1: &[FieldElement<F>],
 ) where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + 'static,
 {
+    // SIMD dispatch for GoldilocksField
+    #[cfg(target_arch = "aarch64")]
+    if core::any::TypeId::of::<F>() == core::any::TypeId::of::<GoldilocksField>()
+        && core::any::TypeId::of::<E>() == core::any::TypeId::of::<GoldilocksField>()
+    {
+        let data =
+            unsafe { core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len()) };
+        let tw0 = unsafe {
+            core::slice::from_raw_parts(twiddles_l0.as_ptr() as *const u64, twiddles_l0.len())
+        };
+        let tw1 = unsafe {
+            core::slice::from_raw_parts(twiddles_l1.as_ptr() as *const u64, twiddles_l1.len())
+        };
+        super::simd_butterflies::dif_fused_butterfly_neon(data, tw0, tw1);
+        return;
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    if core::any::TypeId::of::<F>() == core::any::TypeId::of::<GoldilocksField>()
+        && core::any::TypeId::of::<E>() == core::any::TypeId::of::<GoldilocksField>()
+    {
+        if is_x86_feature_detected!("avx2") {
+            let data = unsafe {
+                core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len())
+            };
+            let tw0 = unsafe {
+                core::slice::from_raw_parts(twiddles_l0.as_ptr() as *const u64, twiddles_l0.len())
+            };
+            let tw1 = unsafe {
+                core::slice::from_raw_parts(twiddles_l1.as_ptr() as *const u64, twiddles_l1.len())
+            };
+            unsafe { super::simd_butterflies::dif_fused_butterfly_avx2(data, tw0, tw1) };
+            return;
+        }
+    }
+
     let block_size = block.len();
     let quarter = block_size >> 2;
 
@@ -368,9 +397,40 @@ fn process_single_layer_block<F, E>(
     twiddles: &[FieldElement<F>],
     half_block: usize,
 ) where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + 'static,
 {
+    // SIMD dispatch for GoldilocksField
+    #[cfg(target_arch = "aarch64")]
+    if core::any::TypeId::of::<F>() == core::any::TypeId::of::<GoldilocksField>()
+        && core::any::TypeId::of::<E>() == core::any::TypeId::of::<GoldilocksField>()
+        && half_block >= super::simd_butterflies::NEON_MIN_HALF_BLOCK
+    {
+        let data =
+            unsafe { core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len()) };
+        let tw =
+            unsafe { core::slice::from_raw_parts(twiddles.as_ptr() as *const u64, twiddles.len()) };
+        super::simd_butterflies::dif_butterfly_neon(data, tw, half_block);
+        return;
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    if core::any::TypeId::of::<F>() == core::any::TypeId::of::<GoldilocksField>()
+        && core::any::TypeId::of::<E>() == core::any::TypeId::of::<GoldilocksField>()
+        && half_block >= super::simd_butterflies::AVX2_MIN_HALF_BLOCK
+    {
+        if is_x86_feature_detected!("avx2") {
+            let data = unsafe {
+                core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len())
+            };
+            let tw = unsafe {
+                core::slice::from_raw_parts(twiddles.as_ptr() as *const u64, twiddles.len())
+            };
+            unsafe { super::simd_butterflies::dif_butterfly_avx2(data, tw, half_block) };
+            return;
+        }
+    }
+
     debug_assert!(
         twiddles.len() >= half_block,
         "twiddles too short: {} < {}",
@@ -567,8 +627,8 @@ pub fn bowers_ifft_opt<F, E>(
     layer_twiddles: &LayerTwiddles<F>,
 ) -> Result<(), FFTError>
 where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + 'static,
 {
     let n = input.len();
     if !n.is_power_of_two() {
@@ -629,8 +689,8 @@ pub fn bowers_ifft_opt_parallel<F, E>(
     layer_twiddles: &LayerTwiddles<F>,
 ) -> Result<(), FFTError>
 where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + Send + Sync + 'static,
     FieldElement<F>: Send + Sync,
     FieldElement<E>: Send + Sync,
 {
@@ -669,18 +729,8 @@ where
             });
         } else {
             for block_start in (0..n).step_by(block_size) {
-                for j in 0..half_block {
-                    let i0 = block_start + j;
-                    let i1 = i0 + half_block;
-                    let w = &twiddles[j];
-
-                    let bw = w * &input[i1];
-                    let sum = &input[i0] + &bw;
-                    let diff = &input[i0] - &bw;
-
-                    input[i0] = sum;
-                    input[i1] = diff;
-                }
+                let block = &mut input[block_start..block_start + block_size];
+                process_ifft_single_layer_block(block, twiddles, half_block);
             }
         }
     }
@@ -696,9 +746,40 @@ fn process_ifft_single_layer_block<F, E>(
     twiddles: &[FieldElement<F>],
     half_block: usize,
 ) where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + 'static,
 {
+    // SIMD dispatch for GoldilocksField
+    #[cfg(target_arch = "aarch64")]
+    if core::any::TypeId::of::<F>() == core::any::TypeId::of::<GoldilocksField>()
+        && core::any::TypeId::of::<E>() == core::any::TypeId::of::<GoldilocksField>()
+        && half_block >= super::simd_butterflies::NEON_MIN_HALF_BLOCK
+    {
+        let data =
+            unsafe { core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len()) };
+        let tw =
+            unsafe { core::slice::from_raw_parts(twiddles.as_ptr() as *const u64, twiddles.len()) };
+        super::simd_butterflies::dit_butterfly_neon(data, tw, half_block);
+        return;
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    if core::any::TypeId::of::<F>() == core::any::TypeId::of::<GoldilocksField>()
+        && core::any::TypeId::of::<E>() == core::any::TypeId::of::<GoldilocksField>()
+        && half_block >= super::simd_butterflies::AVX2_MIN_HALF_BLOCK
+    {
+        if is_x86_feature_detected!("avx2") {
+            let data = unsafe {
+                core::slice::from_raw_parts_mut(block.as_mut_ptr() as *mut u64, block.len())
+            };
+            let tw = unsafe {
+                core::slice::from_raw_parts(twiddles.as_ptr() as *const u64, twiddles.len())
+            };
+            unsafe { super::simd_butterflies::dit_butterfly_avx2(data, tw, half_block) };
+            return;
+        }
+    }
+
     debug_assert!(
         twiddles.len() >= half_block,
         "twiddles too short: {} < {}",
@@ -740,8 +821,8 @@ pub fn bowers_fft_opt_fused<F, E>(
     layer_twiddles: &LayerTwiddles<F>,
 ) -> Result<(), FFTError>
 where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + 'static,
 {
     let n = input.len();
     if !n.is_power_of_two() {
@@ -889,8 +970,8 @@ pub fn bowers_batch_fft_opt<F, E>(
     layer_twiddles: &LayerTwiddles<F>,
 ) -> Result<(), FFTError>
 where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + 'static,
 {
     if matrix.height == 0 || matrix.width <= 1 {
         return Ok(());

--- a/crypto/math/src/fft/cpu/mod.rs
+++ b/crypto/math/src/fft/cpu/mod.rs
@@ -8,3 +8,5 @@ pub mod fft;
 pub mod ops;
 #[cfg(feature = "alloc")]
 pub mod roots_of_unity;
+#[cfg(feature = "alloc")]
+pub(crate) mod simd_butterflies;

--- a/crypto/math/src/fft/cpu/simd_butterflies.rs
+++ b/crypto/math/src/fft/cpu/simd_butterflies.rs
@@ -1,0 +1,350 @@
+//! SIMD butterfly kernels for Goldilocks FFT.
+//!
+//! These operate on `&mut [u64]` slices (reinterpreted from `&mut [FieldElement<GoldilocksField>]`
+//! via `#[repr(transparent)]`). Called from the TypeId dispatch in `bowers_fft.rs`.
+
+use crate::field::fields::fft_friendly::u64_goldilocks::GoldilocksField;
+use crate::field::traits::IsField;
+
+// ==================== Scalar helpers ====================
+
+#[inline(always)]
+fn scalar_dif_butterfly(data: &mut [u64], j: usize, half_block: usize, tw: u64) {
+    let a = data[j];
+    let b = data[j + half_block];
+    let sum = GoldilocksField::add(&a, &b);
+    let diff = GoldilocksField::sub(&a, &b);
+    data[j] = sum;
+    data[j + half_block] = GoldilocksField::mul(&tw, &diff);
+}
+
+#[inline(always)]
+fn scalar_dit_butterfly(data: &mut [u64], j: usize, half_block: usize, tw: u64) {
+    let a = data[j];
+    let b = data[j + half_block];
+    let bw = GoldilocksField::mul(&tw, &b);
+    data[j] = GoldilocksField::add(&a, &bw);
+    data[j + half_block] = GoldilocksField::sub(&a, &bw);
+}
+
+// ==================== NEON (aarch64) ====================
+
+#[cfg(target_arch = "aarch64")]
+mod neon {
+    use super::*;
+    use crate::field::fields::fft_friendly::goldilocks_neon::PackedGoldilocks2;
+
+    /// DIF single-layer butterfly on a block. `data` has length `2 * half_block`.
+    /// `twiddles` has length `>= half_block`.
+    pub fn dif_butterfly(data: &mut [u64], twiddles: &[u64], half_block: usize) {
+        let simd_count = half_block / 2;
+        let scalar_start = simd_count * 2;
+
+        for i in 0..simd_count {
+            let j = i * 2;
+            let a = PackedGoldilocks2::load(&data[j..]);
+            let b = PackedGoldilocks2::load(&data[j + half_block..]);
+            let w = PackedGoldilocks2::load(&twiddles[j..]);
+
+            let sum = a + b;
+            let diff = a - b;
+            let diff_w = w * diff;
+
+            sum.store(&mut data[j..]);
+            diff_w.store(&mut data[j + half_block..]);
+        }
+
+        for (j, &tw) in (scalar_start..).zip(&twiddles[scalar_start..half_block]) {
+            scalar_dif_butterfly(data, j, half_block, tw);
+        }
+    }
+
+    /// DIF fused 2-layer butterfly on a block of size `4 * quarter`.
+    pub fn dif_fused_butterfly(block: &mut [u64], tw0: &[u64], tw1: &[u64]) {
+        let block_size = block.len();
+        let quarter = block_size / 4;
+        let simd_count = quarter / 2;
+        let scalar_start = simd_count * 2;
+
+        for i in 0..simd_count {
+            let j = i * 2;
+            let i0 = j;
+            let i1 = j + quarter;
+            let i2 = j + 2 * quarter;
+            let i3 = j + 3 * quarter;
+
+            let a0 = PackedGoldilocks2::load(&block[i0..]);
+            let a1 = PackedGoldilocks2::load(&block[i1..]);
+            let a2 = PackedGoldilocks2::load(&block[i2..]);
+            let a3 = PackedGoldilocks2::load(&block[i3..]);
+
+            let w0 = PackedGoldilocks2::load(&tw0[j..]);
+            let w1 = PackedGoldilocks2::load(&tw0[j + quarter..]);
+            let w2 = PackedGoldilocks2::load(&tw1[j..]);
+
+            // First layer
+            let sum_02 = a0 + a2;
+            let diff_02 = a0 - a2;
+            let diff_02_w = w0 * diff_02;
+
+            let sum_13 = a1 + a3;
+            let diff_13 = a1 - a3;
+            let diff_13_w = w1 * diff_13;
+
+            // Second layer
+            let final_0 = sum_02 + sum_13;
+            let diff_sums = sum_02 - sum_13;
+            let final_1 = w2 * diff_sums;
+
+            let final_2 = diff_02_w + diff_13_w;
+            let diff_diffs = diff_02_w - diff_13_w;
+            let final_3 = w2 * diff_diffs;
+
+            final_0.store(&mut block[i0..]);
+            final_1.store(&mut block[i1..]);
+            final_2.store(&mut block[i2..]);
+            final_3.store(&mut block[i3..]);
+        }
+
+        // Scalar tail
+        for j in scalar_start..quarter {
+            let i0 = j;
+            let i1 = j + quarter;
+            let i2 = j + 2 * quarter;
+            let i3 = j + 3 * quarter;
+
+            let (w0, w1, w2) = (tw0[j], tw0[j + quarter], tw1[j]);
+
+            let sum_02 = GoldilocksField::add(&block[i0], &block[i2]);
+            let diff_02 = GoldilocksField::sub(&block[i0], &block[i2]);
+            let diff_02_w = GoldilocksField::mul(&w0, &diff_02);
+
+            let sum_13 = GoldilocksField::add(&block[i1], &block[i3]);
+            let diff_13 = GoldilocksField::sub(&block[i1], &block[i3]);
+            let diff_13_w = GoldilocksField::mul(&w1, &diff_13);
+
+            let final_0 = GoldilocksField::add(&sum_02, &sum_13);
+            let diff_sums = GoldilocksField::sub(&sum_02, &sum_13);
+            let final_1 = GoldilocksField::mul(&w2, &diff_sums);
+
+            let final_2 = GoldilocksField::add(&diff_02_w, &diff_13_w);
+            let diff_diffs = GoldilocksField::sub(&diff_02_w, &diff_13_w);
+            let final_3 = GoldilocksField::mul(&w2, &diff_diffs);
+
+            block[i0] = final_0;
+            block[i1] = final_1;
+            block[i2] = final_2;
+            block[i3] = final_3;
+        }
+    }
+
+    /// DIT single-layer butterfly (inverse FFT).
+    pub fn dit_butterfly(data: &mut [u64], twiddles: &[u64], half_block: usize) {
+        let simd_count = half_block / 2;
+        let scalar_start = simd_count * 2;
+
+        for i in 0..simd_count {
+            let j = i * 2;
+            let a = PackedGoldilocks2::load(&data[j..]);
+            let b = PackedGoldilocks2::load(&data[j + half_block..]);
+            let w = PackedGoldilocks2::load(&twiddles[j..]);
+
+            let bw = w * b;
+            let sum = a + bw;
+            let diff = a - bw;
+
+            sum.store(&mut data[j..]);
+            diff.store(&mut data[j + half_block..]);
+        }
+
+        for (j, &tw) in (scalar_start..).zip(&twiddles[scalar_start..half_block]) {
+            scalar_dit_butterfly(data, j, half_block, tw);
+        }
+    }
+}
+
+// ==================== AVX2 (x86_64) ====================
+
+#[cfg(target_arch = "x86_64")]
+mod avx2 {
+    use super::*;
+    use crate::field::fields::fft_friendly::goldilocks_avx2::PackedGoldilocks4;
+
+    /// DIF single-layer butterfly (AVX2).
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn dif_butterfly(data: &mut [u64], twiddles: &[u64], half_block: usize) {
+        let simd_count = half_block / 4;
+        let scalar_start = simd_count * 4;
+
+        for i in 0..simd_count {
+            let j = i * 4;
+            let a = PackedGoldilocks4::load(&data[j..]);
+            let b = PackedGoldilocks4::load(&data[j + half_block..]);
+            let w = PackedGoldilocks4::load(&twiddles[j..]);
+
+            let sum = a + b;
+            let diff = a - b;
+            let diff_w = w * diff;
+
+            sum.store(&mut data[j..]);
+            diff_w.store(&mut data[j + half_block..]);
+        }
+
+        for (j, &tw) in (scalar_start..).zip(&twiddles[scalar_start..half_block]) {
+            scalar_dif_butterfly(data, j, half_block, tw);
+        }
+    }
+
+    /// DIF fused 2-layer butterfly (AVX2).
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn dif_fused_butterfly(block: &mut [u64], tw0: &[u64], tw1: &[u64]) {
+        let block_size = block.len();
+        let quarter = block_size / 4;
+        let simd_count = quarter / 4;
+        let scalar_start = simd_count * 4;
+
+        for i in 0..simd_count {
+            let j = i * 4;
+            let i0 = j;
+            let i1 = j + quarter;
+            let i2 = j + 2 * quarter;
+            let i3 = j + 3 * quarter;
+
+            let a0 = PackedGoldilocks4::load(&block[i0..]);
+            let a1 = PackedGoldilocks4::load(&block[i1..]);
+            let a2 = PackedGoldilocks4::load(&block[i2..]);
+            let a3 = PackedGoldilocks4::load(&block[i3..]);
+
+            let w0 = PackedGoldilocks4::load(&tw0[j..]);
+            let w1 = PackedGoldilocks4::load(&tw0[j + quarter..]);
+            let w2 = PackedGoldilocks4::load(&tw1[j..]);
+
+            let sum_02 = a0 + a2;
+            let diff_02 = a0 - a2;
+            let diff_02_w = w0 * diff_02;
+
+            let sum_13 = a1 + a3;
+            let diff_13 = a1 - a3;
+            let diff_13_w = w1 * diff_13;
+
+            let final_0 = sum_02 + sum_13;
+            let diff_sums = sum_02 - sum_13;
+            let final_1 = w2 * diff_sums;
+
+            let final_2 = diff_02_w + diff_13_w;
+            let diff_diffs = diff_02_w - diff_13_w;
+            let final_3 = w2 * diff_diffs;
+
+            final_0.store(&mut block[i0..]);
+            final_1.store(&mut block[i1..]);
+            final_2.store(&mut block[i2..]);
+            final_3.store(&mut block[i3..]);
+        }
+
+        // Scalar tail
+        for j in scalar_start..quarter {
+            let i0 = j;
+            let i1 = j + quarter;
+            let i2 = j + 2 * quarter;
+            let i3 = j + 3 * quarter;
+
+            let (w0, w1, w2) = (tw0[j], tw0[j + quarter], tw1[j]);
+
+            let sum_02 = GoldilocksField::add(&block[i0], &block[i2]);
+            let diff_02 = GoldilocksField::sub(&block[i0], &block[i2]);
+            let diff_02_w = GoldilocksField::mul(&w0, &diff_02);
+
+            let sum_13 = GoldilocksField::add(&block[i1], &block[i3]);
+            let diff_13 = GoldilocksField::sub(&block[i1], &block[i3]);
+            let diff_13_w = GoldilocksField::mul(&w1, &diff_13);
+
+            let final_0 = GoldilocksField::add(&sum_02, &sum_13);
+            let diff_sums = GoldilocksField::sub(&sum_02, &sum_13);
+            let final_1 = GoldilocksField::mul(&w2, &diff_sums);
+
+            let final_2 = GoldilocksField::add(&diff_02_w, &diff_13_w);
+            let diff_diffs = GoldilocksField::sub(&diff_02_w, &diff_13_w);
+            let final_3 = GoldilocksField::mul(&w2, &diff_diffs);
+
+            block[i0] = final_0;
+            block[i1] = final_1;
+            block[i2] = final_2;
+            block[i3] = final_3;
+        }
+    }
+
+    /// DIT single-layer butterfly (inverse FFT, AVX2).
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn dit_butterfly(data: &mut [u64], twiddles: &[u64], half_block: usize) {
+        let simd_count = half_block / 4;
+        let scalar_start = simd_count * 4;
+
+        for i in 0..simd_count {
+            let j = i * 4;
+            let a = PackedGoldilocks4::load(&data[j..]);
+            let b = PackedGoldilocks4::load(&data[j + half_block..]);
+            let w = PackedGoldilocks4::load(&twiddles[j..]);
+
+            let bw = w * b;
+            let sum = a + bw;
+            let diff = a - bw;
+
+            sum.store(&mut data[j..]);
+            diff.store(&mut data[j + half_block..]);
+        }
+
+        for (j, &tw) in (scalar_start..).zip(&twiddles[scalar_start..half_block]) {
+            scalar_dit_butterfly(data, j, half_block, tw);
+        }
+    }
+}
+
+// ==================== Public dispatch ====================
+
+/// Minimum `half_block` size for NEON dispatch (2 elements = 1 SIMD iteration).
+#[cfg(target_arch = "aarch64")]
+pub const NEON_MIN_HALF_BLOCK: usize = 2;
+
+/// Minimum `half_block` size for AVX2 dispatch (4 elements = 1 SIMD iteration).
+#[cfg(target_arch = "x86_64")]
+pub const AVX2_MIN_HALF_BLOCK: usize = 4;
+
+// --- NEON public API ---
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+pub fn dif_butterfly_neon(data: &mut [u64], twiddles: &[u64], half_block: usize) {
+    neon::dif_butterfly(data, twiddles, half_block);
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+pub fn dif_fused_butterfly_neon(block: &mut [u64], tw0: &[u64], tw1: &[u64]) {
+    neon::dif_fused_butterfly(block, tw0, tw1);
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+pub fn dit_butterfly_neon(data: &mut [u64], twiddles: &[u64], half_block: usize) {
+    neon::dit_butterfly(data, twiddles, half_block);
+}
+
+// --- AVX2 public API ---
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+pub unsafe fn dif_butterfly_avx2(data: &mut [u64], twiddles: &[u64], half_block: usize) {
+    avx2::dif_butterfly(data, twiddles, half_block);
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+pub unsafe fn dif_fused_butterfly_avx2(block: &mut [u64], tw0: &[u64], tw1: &[u64]) {
+    avx2::dif_fused_butterfly(block, tw0, tw1);
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+pub unsafe fn dit_butterfly_avx2(data: &mut [u64], twiddles: &[u64], half_block: usize) {
+    avx2::dit_butterfly(data, twiddles, half_block);
+}

--- a/crypto/math/src/fft/cpu/simd_butterflies.rs
+++ b/crypto/math/src/fft/cpu/simd_butterflies.rs
@@ -178,16 +178,18 @@ mod avx2 {
 
         for i in 0..simd_count {
             let j = i * 4;
-            let a = PackedGoldilocks4::load(&data[j..]);
-            let b = PackedGoldilocks4::load(&data[j + half_block..]);
-            let w = PackedGoldilocks4::load(&twiddles[j..]);
+            unsafe {
+                let a = PackedGoldilocks4::load(&data[j..]);
+                let b = PackedGoldilocks4::load(&data[j + half_block..]);
+                let w = PackedGoldilocks4::load(&twiddles[j..]);
 
-            let sum = a + b;
-            let diff = a - b;
-            let diff_w = w * diff;
+                let sum = a + b;
+                let diff = a - b;
+                let diff_w = w * diff;
 
-            sum.store(&mut data[j..]);
-            diff_w.store(&mut data[j + half_block..]);
+                sum.store(&mut data[j..]);
+                diff_w.store(&mut data[j + half_block..]);
+            }
         }
 
         for (j, &tw) in (scalar_start..).zip(&twiddles[scalar_start..half_block]) {
@@ -210,35 +212,37 @@ mod avx2 {
             let i2 = j + 2 * quarter;
             let i3 = j + 3 * quarter;
 
-            let a0 = PackedGoldilocks4::load(&block[i0..]);
-            let a1 = PackedGoldilocks4::load(&block[i1..]);
-            let a2 = PackedGoldilocks4::load(&block[i2..]);
-            let a3 = PackedGoldilocks4::load(&block[i3..]);
+            unsafe {
+                let a0 = PackedGoldilocks4::load(&block[i0..]);
+                let a1 = PackedGoldilocks4::load(&block[i1..]);
+                let a2 = PackedGoldilocks4::load(&block[i2..]);
+                let a3 = PackedGoldilocks4::load(&block[i3..]);
 
-            let w0 = PackedGoldilocks4::load(&tw0[j..]);
-            let w1 = PackedGoldilocks4::load(&tw0[j + quarter..]);
-            let w2 = PackedGoldilocks4::load(&tw1[j..]);
+                let w0 = PackedGoldilocks4::load(&tw0[j..]);
+                let w1 = PackedGoldilocks4::load(&tw0[j + quarter..]);
+                let w2 = PackedGoldilocks4::load(&tw1[j..]);
 
-            let sum_02 = a0 + a2;
-            let diff_02 = a0 - a2;
-            let diff_02_w = w0 * diff_02;
+                let sum_02 = a0 + a2;
+                let diff_02 = a0 - a2;
+                let diff_02_w = w0 * diff_02;
 
-            let sum_13 = a1 + a3;
-            let diff_13 = a1 - a3;
-            let diff_13_w = w1 * diff_13;
+                let sum_13 = a1 + a3;
+                let diff_13 = a1 - a3;
+                let diff_13_w = w1 * diff_13;
 
-            let final_0 = sum_02 + sum_13;
-            let diff_sums = sum_02 - sum_13;
-            let final_1 = w2 * diff_sums;
+                let final_0 = sum_02 + sum_13;
+                let diff_sums = sum_02 - sum_13;
+                let final_1 = w2 * diff_sums;
 
-            let final_2 = diff_02_w + diff_13_w;
-            let diff_diffs = diff_02_w - diff_13_w;
-            let final_3 = w2 * diff_diffs;
+                let final_2 = diff_02_w + diff_13_w;
+                let diff_diffs = diff_02_w - diff_13_w;
+                let final_3 = w2 * diff_diffs;
 
-            final_0.store(&mut block[i0..]);
-            final_1.store(&mut block[i1..]);
-            final_2.store(&mut block[i2..]);
-            final_3.store(&mut block[i3..]);
+                final_0.store(&mut block[i0..]);
+                final_1.store(&mut block[i1..]);
+                final_2.store(&mut block[i2..]);
+                final_3.store(&mut block[i3..]);
+            }
         }
 
         // Scalar tail
@@ -281,16 +285,18 @@ mod avx2 {
 
         for i in 0..simd_count {
             let j = i * 4;
-            let a = PackedGoldilocks4::load(&data[j..]);
-            let b = PackedGoldilocks4::load(&data[j + half_block..]);
-            let w = PackedGoldilocks4::load(&twiddles[j..]);
+            unsafe {
+                let a = PackedGoldilocks4::load(&data[j..]);
+                let b = PackedGoldilocks4::load(&data[j + half_block..]);
+                let w = PackedGoldilocks4::load(&twiddles[j..]);
 
-            let bw = w * b;
-            let sum = a + bw;
-            let diff = a - bw;
+                let bw = w * b;
+                let sum = a + bw;
+                let diff = a - bw;
 
-            sum.store(&mut data[j..]);
-            diff.store(&mut data[j + half_block..]);
+                sum.store(&mut data[j..]);
+                diff.store(&mut data[j + half_block..]);
+            }
         }
 
         for (j, &tw) in (scalar_start..).zip(&twiddles[scalar_start..half_block]) {
@@ -334,17 +340,17 @@ pub fn dit_butterfly_neon(data: &mut [u64], twiddles: &[u64], half_block: usize)
 #[cfg(target_arch = "x86_64")]
 #[inline]
 pub unsafe fn dif_butterfly_avx2(data: &mut [u64], twiddles: &[u64], half_block: usize) {
-    avx2::dif_butterfly(data, twiddles, half_block);
+    unsafe { avx2::dif_butterfly(data, twiddles, half_block) };
 }
 
 #[cfg(target_arch = "x86_64")]
 #[inline]
 pub unsafe fn dif_fused_butterfly_avx2(block: &mut [u64], tw0: &[u64], tw1: &[u64]) {
-    avx2::dif_fused_butterfly(block, tw0, tw1);
+    unsafe { avx2::dif_fused_butterfly(block, tw0, tw1) };
 }
 
 #[cfg(target_arch = "x86_64")]
 #[inline]
 pub unsafe fn dit_butterfly_avx2(data: &mut [u64], twiddles: &[u64], half_block: usize) {
-    avx2::dit_butterfly(data, twiddles, half_block);
+    unsafe { avx2::dit_butterfly(data, twiddles, half_block) };
 }

--- a/crypto/math/src/fft/cpu/simd_butterflies.rs
+++ b/crypto/math/src/fft/cpu/simd_butterflies.rs
@@ -178,18 +178,16 @@ mod avx2 {
 
         for i in 0..simd_count {
             let j = i * 4;
-            unsafe {
-                let a = PackedGoldilocks4::load(&data[j..]);
-                let b = PackedGoldilocks4::load(&data[j + half_block..]);
-                let w = PackedGoldilocks4::load(&twiddles[j..]);
+            let a = PackedGoldilocks4::load(&data[j..]);
+            let b = PackedGoldilocks4::load(&data[j + half_block..]);
+            let w = PackedGoldilocks4::load(&twiddles[j..]);
 
-                let sum = a + b;
-                let diff = a - b;
-                let diff_w = w * diff;
+            let sum = a + b;
+            let diff = a - b;
+            let diff_w = w * diff;
 
-                sum.store(&mut data[j..]);
-                diff_w.store(&mut data[j + half_block..]);
-            }
+            sum.store(&mut data[j..]);
+            diff_w.store(&mut data[j + half_block..]);
         }
 
         for (j, &tw) in (scalar_start..).zip(&twiddles[scalar_start..half_block]) {
@@ -212,37 +210,35 @@ mod avx2 {
             let i2 = j + 2 * quarter;
             let i3 = j + 3 * quarter;
 
-            unsafe {
-                let a0 = PackedGoldilocks4::load(&block[i0..]);
-                let a1 = PackedGoldilocks4::load(&block[i1..]);
-                let a2 = PackedGoldilocks4::load(&block[i2..]);
-                let a3 = PackedGoldilocks4::load(&block[i3..]);
+            let a0 = PackedGoldilocks4::load(&block[i0..]);
+            let a1 = PackedGoldilocks4::load(&block[i1..]);
+            let a2 = PackedGoldilocks4::load(&block[i2..]);
+            let a3 = PackedGoldilocks4::load(&block[i3..]);
 
-                let w0 = PackedGoldilocks4::load(&tw0[j..]);
-                let w1 = PackedGoldilocks4::load(&tw0[j + quarter..]);
-                let w2 = PackedGoldilocks4::load(&tw1[j..]);
+            let w0 = PackedGoldilocks4::load(&tw0[j..]);
+            let w1 = PackedGoldilocks4::load(&tw0[j + quarter..]);
+            let w2 = PackedGoldilocks4::load(&tw1[j..]);
 
-                let sum_02 = a0 + a2;
-                let diff_02 = a0 - a2;
-                let diff_02_w = w0 * diff_02;
+            let sum_02 = a0 + a2;
+            let diff_02 = a0 - a2;
+            let diff_02_w = w0 * diff_02;
 
-                let sum_13 = a1 + a3;
-                let diff_13 = a1 - a3;
-                let diff_13_w = w1 * diff_13;
+            let sum_13 = a1 + a3;
+            let diff_13 = a1 - a3;
+            let diff_13_w = w1 * diff_13;
 
-                let final_0 = sum_02 + sum_13;
-                let diff_sums = sum_02 - sum_13;
-                let final_1 = w2 * diff_sums;
+            let final_0 = sum_02 + sum_13;
+            let diff_sums = sum_02 - sum_13;
+            let final_1 = w2 * diff_sums;
 
-                let final_2 = diff_02_w + diff_13_w;
-                let diff_diffs = diff_02_w - diff_13_w;
-                let final_3 = w2 * diff_diffs;
+            let final_2 = diff_02_w + diff_13_w;
+            let diff_diffs = diff_02_w - diff_13_w;
+            let final_3 = w2 * diff_diffs;
 
-                final_0.store(&mut block[i0..]);
-                final_1.store(&mut block[i1..]);
-                final_2.store(&mut block[i2..]);
-                final_3.store(&mut block[i3..]);
-            }
+            final_0.store(&mut block[i0..]);
+            final_1.store(&mut block[i1..]);
+            final_2.store(&mut block[i2..]);
+            final_3.store(&mut block[i3..]);
         }
 
         // Scalar tail
@@ -285,18 +281,16 @@ mod avx2 {
 
         for i in 0..simd_count {
             let j = i * 4;
-            unsafe {
-                let a = PackedGoldilocks4::load(&data[j..]);
-                let b = PackedGoldilocks4::load(&data[j + half_block..]);
-                let w = PackedGoldilocks4::load(&twiddles[j..]);
+            let a = PackedGoldilocks4::load(&data[j..]);
+            let b = PackedGoldilocks4::load(&data[j + half_block..]);
+            let w = PackedGoldilocks4::load(&twiddles[j..]);
 
-                let bw = w * b;
-                let sum = a + bw;
-                let diff = a - bw;
+            let bw = w * b;
+            let sum = a + bw;
+            let diff = a - bw;
 
-                sum.store(&mut data[j..]);
-                diff.store(&mut data[j + half_block..]);
-            }
+            sum.store(&mut data[j..]);
+            diff.store(&mut data[j + half_block..]);
         }
 
         for (j, &tw) in (scalar_start..).zip(&twiddles[scalar_start..half_block]) {

--- a/crypto/math/src/fft/cpu/simd_butterflies.rs
+++ b/crypto/math/src/fft/cpu/simd_butterflies.rs
@@ -178,16 +178,18 @@ mod avx2 {
 
         for i in 0..simd_count {
             let j = i * 4;
-            let a = PackedGoldilocks4::load(&data[j..]);
-            let b = PackedGoldilocks4::load(&data[j + half_block..]);
-            let w = PackedGoldilocks4::load(&twiddles[j..]);
+            unsafe {
+                let a = PackedGoldilocks4::load(&data[j..]);
+                let b = PackedGoldilocks4::load(&data[j + half_block..]);
+                let w = PackedGoldilocks4::load(&twiddles[j..]);
 
-            let sum = a + b;
-            let diff = a - b;
-            let diff_w = w * diff;
+                let sum = a + b;
+                let diff = a - b;
+                let diff_w = w * diff;
 
-            sum.store(&mut data[j..]);
-            diff_w.store(&mut data[j + half_block..]);
+                sum.store(&mut data[j..]);
+                diff_w.store(&mut data[j + half_block..]);
+            }
         }
 
         for (j, &tw) in (scalar_start..).zip(&twiddles[scalar_start..half_block]) {
@@ -210,35 +212,37 @@ mod avx2 {
             let i2 = j + 2 * quarter;
             let i3 = j + 3 * quarter;
 
-            let a0 = PackedGoldilocks4::load(&block[i0..]);
-            let a1 = PackedGoldilocks4::load(&block[i1..]);
-            let a2 = PackedGoldilocks4::load(&block[i2..]);
-            let a3 = PackedGoldilocks4::load(&block[i3..]);
+            unsafe {
+                let a0 = PackedGoldilocks4::load(&block[i0..]);
+                let a1 = PackedGoldilocks4::load(&block[i1..]);
+                let a2 = PackedGoldilocks4::load(&block[i2..]);
+                let a3 = PackedGoldilocks4::load(&block[i3..]);
 
-            let w0 = PackedGoldilocks4::load(&tw0[j..]);
-            let w1 = PackedGoldilocks4::load(&tw0[j + quarter..]);
-            let w2 = PackedGoldilocks4::load(&tw1[j..]);
+                let w0 = PackedGoldilocks4::load(&tw0[j..]);
+                let w1 = PackedGoldilocks4::load(&tw0[j + quarter..]);
+                let w2 = PackedGoldilocks4::load(&tw1[j..]);
 
-            let sum_02 = a0 + a2;
-            let diff_02 = a0 - a2;
-            let diff_02_w = w0 * diff_02;
+                let sum_02 = a0 + a2;
+                let diff_02 = a0 - a2;
+                let diff_02_w = w0 * diff_02;
 
-            let sum_13 = a1 + a3;
-            let diff_13 = a1 - a3;
-            let diff_13_w = w1 * diff_13;
+                let sum_13 = a1 + a3;
+                let diff_13 = a1 - a3;
+                let diff_13_w = w1 * diff_13;
 
-            let final_0 = sum_02 + sum_13;
-            let diff_sums = sum_02 - sum_13;
-            let final_1 = w2 * diff_sums;
+                let final_0 = sum_02 + sum_13;
+                let diff_sums = sum_02 - sum_13;
+                let final_1 = w2 * diff_sums;
 
-            let final_2 = diff_02_w + diff_13_w;
-            let diff_diffs = diff_02_w - diff_13_w;
-            let final_3 = w2 * diff_diffs;
+                let final_2 = diff_02_w + diff_13_w;
+                let diff_diffs = diff_02_w - diff_13_w;
+                let final_3 = w2 * diff_diffs;
 
-            final_0.store(&mut block[i0..]);
-            final_1.store(&mut block[i1..]);
-            final_2.store(&mut block[i2..]);
-            final_3.store(&mut block[i3..]);
+                final_0.store(&mut block[i0..]);
+                final_1.store(&mut block[i1..]);
+                final_2.store(&mut block[i2..]);
+                final_3.store(&mut block[i3..]);
+            }
         }
 
         // Scalar tail
@@ -281,16 +285,18 @@ mod avx2 {
 
         for i in 0..simd_count {
             let j = i * 4;
-            let a = PackedGoldilocks4::load(&data[j..]);
-            let b = PackedGoldilocks4::load(&data[j + half_block..]);
-            let w = PackedGoldilocks4::load(&twiddles[j..]);
+            unsafe {
+                let a = PackedGoldilocks4::load(&data[j..]);
+                let b = PackedGoldilocks4::load(&data[j + half_block..]);
+                let w = PackedGoldilocks4::load(&twiddles[j..]);
 
-            let bw = w * b;
-            let sum = a + bw;
-            let diff = a - bw;
+                let bw = w * b;
+                let sum = a + bw;
+                let diff = a - bw;
 
-            sum.store(&mut data[j..]);
-            diff.store(&mut data[j + half_block..]);
+                sum.store(&mut data[j..]);
+                diff.store(&mut data[j + half_block..]);
+            }
         }
 
         for (j, &tw) in (scalar_start..).zip(&twiddles[scalar_start..half_block]) {

--- a/crypto/math/src/fft/polynomial.rs
+++ b/crypto/math/src/fft/polynomial.rs
@@ -28,7 +28,7 @@ const PARALLEL_FFT_THRESHOLD: usize = 1 << 14;
 
 /// Dispatch forward FFT (DIF) to parallel or sequential implementation based on buffer size.
 #[inline]
-fn dispatch_fft<F: IsFFTField + IsSubFieldOf<E>, E: IsField + Send + Sync>(
+fn dispatch_fft<F: IsFFTField + IsSubFieldOf<E> + 'static, E: IsField + Send + Sync + 'static>(
     buffer: &mut [FieldElement<E>],
     twiddles: &LayerTwiddles<F>,
 ) -> Result<(), FFTError> {
@@ -43,7 +43,7 @@ fn dispatch_fft<F: IsFFTField + IsSubFieldOf<E>, E: IsField + Send + Sync>(
 
 /// Dispatch inverse FFT (DIT) to parallel or sequential implementation based on buffer size.
 #[inline]
-fn dispatch_ifft<F: IsFFTField + IsSubFieldOf<E>, E: IsField + Send + Sync>(
+fn dispatch_ifft<F: IsFFTField + IsSubFieldOf<E> + 'static, E: IsField + Send + Sync + 'static>(
     buffer: &mut [FieldElement<E>],
     twiddles: &LayerTwiddles<F>,
 ) -> Result<(), FFTError> {
@@ -56,12 +56,12 @@ fn dispatch_ifft<F: IsFFTField + IsSubFieldOf<E>, E: IsField + Send + Sync>(
     bowers_ifft_opt(buffer, twiddles)
 }
 
-impl<E: IsField> Polynomial<FieldElement<E>> {
+impl<E: IsField + 'static> Polynomial<FieldElement<E>> {
     /// Returns `N` evaluations of this polynomial using FFT over a domain in a subfield F of E (so the results
     /// are P(w^i), with w being a primitive root of unity).
     /// `N = max(self.coeff_len(), domain_size).next_power_of_two() * blowup_factor`.
     /// If `domain_size` is `None`, it defaults to 0.
-    pub fn evaluate_fft<F: IsFFTField + IsSubFieldOf<E>>(
+    pub fn evaluate_fft<F: IsFFTField + IsSubFieldOf<E> + 'static>(
         poly: &Polynomial<FieldElement<E>>,
         blowup_factor: usize,
         domain_size: Option<usize>,
@@ -102,7 +102,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     /// (so the results are P(w^i), with w being a primitive root of unity).
     /// `N = max(self.coeff_len(), domain_size).next_power_of_two() * blowup_factor`.
     /// If `domain_size` is `None`, it defaults to 0.
-    pub fn evaluate_offset_fft<F: IsFFTField + IsSubFieldOf<E>>(
+    pub fn evaluate_offset_fft<F: IsFFTField + IsSubFieldOf<E> + 'static>(
         poly: &Polynomial<FieldElement<E>>,
         blowup_factor: usize,
         domain_size: Option<usize>,
@@ -118,7 +118,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     /// Returns a new polynomial that interpolates `(w^i, fft_evals[i])`, with `w` being a
     /// Nth primitive root of unity in a subfield F of E, and `i in 0..N`, with `N = fft_evals.len()`.
     /// This is considered to be the inverse operation of [Self::evaluate_fft()].
-    pub fn interpolate_fft<F: IsFFTField + IsSubFieldOf<E>>(
+    pub fn interpolate_fft<F: IsFFTField + IsSubFieldOf<E> + 'static>(
         fft_evals: &[FieldElement<E>],
     ) -> Result<Self, FFTError>
     where
@@ -142,7 +142,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     /// Returns a new polynomial that interpolates offset `(w^i, fft_evals[i])`, with `w` being a
     /// Nth primitive root of unity in a subfield F of E, and `i in 0..N`, with `N = fft_evals.len()`.
     /// This is considered to be the inverse operation of [Self::evaluate_offset_fft()].
-    pub fn interpolate_offset_fft<F: IsFFTField + IsSubFieldOf<E>>(
+    pub fn interpolate_offset_fft<F: IsFFTField + IsSubFieldOf<E> + 'static>(
         fft_evals: &[FieldElement<E>],
         offset: &FieldElement<F>,
     ) -> Result<Polynomial<FieldElement<E>>, FFTError>
@@ -164,7 +164,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     ///
     /// Uses Bowers FFT internally. To share pre-computed twiddles across multiple
     /// columns, use [`coset_lde_with_twiddles`] instead.
-    pub fn coset_lde<F: IsFFTField + IsSubFieldOf<E>>(
+    pub fn coset_lde<F: IsFFTField + IsSubFieldOf<E> + 'static>(
         evals: &[FieldElement<E>],
         blowup_factor: usize,
         offset: &FieldElement<F>,
@@ -192,7 +192,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     ///
     /// - `inv_twiddles`: inverse twiddles for iFFT on the trace-size domain (order = log2(n))
     /// - `fwd_twiddles`: forward twiddles for FFT on the LDE-size domain (order = log2(n * blowup_factor))
-    pub fn coset_lde_with_twiddles<F: IsFFTField + IsSubFieldOf<E>>(
+    pub fn coset_lde_with_twiddles<F: IsFFTField + IsSubFieldOf<E> + 'static>(
         evals: &[FieldElement<E>],
         blowup_factor: usize,
         offset: &FieldElement<F>,
@@ -246,7 +246,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     /// Same as [`coset_lde_with_twiddles`], but also accepts pre-computed `weights[i] = offset^i / n`
     /// so that the scaling step avoids the running product across columns.
     /// Weights are in the base field F — the scaling `w * coeff` uses mixed F×E multiplication.
-    pub fn coset_lde_full<F: IsFFTField + IsSubFieldOf<E> + Send + Sync>(
+    pub fn coset_lde_full<F: IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static>(
         evals: &[FieldElement<E>],
         blowup_factor: usize,
         weights: &[FieldElement<F>],
@@ -280,7 +280,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     /// The buffer is cleared and reused: `buffer.clear(); buffer.extend_from_slice(evals);
     /// buffer.resize(lde_size, zero)`. When the capacity is sufficient, no heap allocation occurs.
     /// Weights are in the base field F — the scaling `w * coeff` uses mixed F×E multiplication.
-    pub fn coset_lde_full_into<F: IsFFTField + IsSubFieldOf<E> + Send + Sync>(
+    pub fn coset_lde_full_into<F: IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static>(
         evals: &[FieldElement<E>],
         blowup_factor: usize,
         weights: &[FieldElement<F>],
@@ -334,7 +334,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     /// Unlike [`coset_lde_full_into`], this skips the `clear + extend_from_slice` step
     /// since data is already in the buffer. Used for transpose elimination: columns are
     /// extracted directly into pool buffers, then expanded in-place.
-    pub fn coset_lde_full_expand<F: IsFFTField + IsSubFieldOf<E> + Send + Sync>(
+    pub fn coset_lde_full_expand<F: IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static>(
         buffer: &mut Vec<FieldElement<E>>,
         blowup_factor: usize,
         weights: &[FieldElement<F>],
@@ -384,7 +384,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     /// This is an implementation of the fast division algorithm from
     /// [Gathen's book](https://www.cambridge.org/core/books/modern-computer-algebra/DB3563D4013401734851CF683D2F03F0)
     /// chapter 9
-    pub fn fast_fft_multiplication<F: IsFFTField + IsSubFieldOf<E>>(
+    pub fn fast_fft_multiplication<F: IsFFTField + IsSubFieldOf<E> + 'static>(
         &self,
         other: &Self,
     ) -> Result<Self, FFTError>
@@ -402,7 +402,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     /// Divides two polynomials with remainder.
     /// This is faster than the naive division if the degree of the divisor
     /// is greater than the degree of the dividend and both degrees are large enough.
-    pub fn fast_division<F: IsSubFieldOf<E> + IsFFTField>(
+    pub fn fast_division<F: IsSubFieldOf<E> + IsFFTField + 'static>(
         &self,
         divisor: &Self,
     ) -> Result<(Self, Self), FFTError>
@@ -437,7 +437,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
 
     /// Computes the inverse of polynomial P modulo x^k using Newton iteration.
     /// P must have an invertible constant term.
-    pub fn invert_polynomial_mod<F: IsSubFieldOf<E> + IsFFTField>(
+    pub fn invert_polynomial_mod<F: IsSubFieldOf<E> + IsFFTField + 'static>(
         &self,
         k: usize,
     ) -> Result<Self, FFTError>
@@ -474,8 +474,8 @@ pub fn compose_fft<F, E>(
     poly_2: &Polynomial<FieldElement<E>>,
 ) -> Polynomial<FieldElement<E>>
 where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + Send + Sync + 'static,
 {
     let poly_2_evaluations = Polynomial::evaluate_fft::<F>(poly_2, 1, None).unwrap();
 
@@ -489,8 +489,8 @@ where
 
 pub fn evaluate_fft_cpu<F, E>(coeffs: &[FieldElement<E>]) -> Result<Vec<FieldElement<E>>, FFTError>
 where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + Send + Sync + 'static,
 {
     let n = coeffs.len();
     if !n.is_power_of_two() {
@@ -510,8 +510,8 @@ pub fn interpolate_fft_cpu<F, E>(
     fft_evals: &[FieldElement<E>],
 ) -> Result<Polynomial<FieldElement<E>>, FFTError>
 where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + Send + Sync + 'static,
 {
     let n = fft_evals.len();
     if !n.is_power_of_two() {

--- a/crypto/math/src/field/element.rs
+++ b/crypto/math/src/field/element.rs
@@ -41,6 +41,7 @@ use super::traits::{IsPrimeField, IsSubFieldOf, LegendreSymbol};
 /// A field element with operations algorithms defined in `F`
 #[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Debug, Clone, Hash, Copy)]
+#[repr(transparent)]
 pub struct FieldElement<F: IsField> {
     value: F::BaseType,
 }

--- a/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
+++ b/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
@@ -3,9 +3,9 @@
 //! Provides `PackedGoldilocks4`, holding 4 Goldilocks field elements with
 //! parallel AVX2 operations. Used by the FFT butterfly kernels.
 //!
-//! **Important**: `_mm256_cmpgt_epi64` is signed. For unsigned overflow
-//! detection we compare `(a_signed > sum_signed)` which works because
-//! wrapping addition flips the sign bit on overflow.
+//! AVX2 only has signed 64-bit comparison (`_mm256_cmpgt_epi64`). For unsigned
+//! overflow/underflow detection, we XOR both operands with `0x8000_0000_0000_0000`
+//! to flip the sign bit, converting unsigned order to signed order.
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
@@ -16,8 +16,15 @@ use core::ops::{Add, Mul, Sub};
 
 use super::u64_goldilocks::GOLDILOCKS_PRIME;
 
-const P: u64 = GOLDILOCKS_PRIME;
 const EPSILON: u64 = 0xFFFF_FFFF;
+
+/// Unsigned `a > b` via signed comparison with sign-bit flip.
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn unsigned_cmpgt(a: __m256i, b: __m256i) -> __m256i {
+    let sign = _mm256_set1_epi64x(i64::MIN);
+    _mm256_cmpgt_epi64(_mm256_xor_si256(a, sign), _mm256_xor_si256(b, sign))
+}
 
 /// 4-wide packed Goldilocks field elements using AVX2 `__m256i`.
 #[derive(Clone, Copy)]
@@ -25,6 +32,8 @@ const EPSILON: u64 = 0xFFFF_FFFF;
 pub struct PackedGoldilocks4(__m256i);
 
 impl PackedGoldilocks4 {
+    /// # Safety
+    /// Requires AVX2. `slice` must have at least 4 elements.
     #[inline]
     #[target_feature(enable = "avx2")]
     pub unsafe fn load(slice: &[u64]) -> Self {
@@ -32,6 +41,8 @@ impl PackedGoldilocks4 {
         unsafe { Self(_mm256_loadu_si256(slice.as_ptr() as *const __m256i)) }
     }
 
+    /// # Safety
+    /// Requires AVX2. `slice` must have at least 4 elements.
     #[inline]
     #[target_feature(enable = "avx2")]
     pub unsafe fn store(self, slice: &mut [u64]) {
@@ -39,12 +50,16 @@ impl PackedGoldilocks4 {
         unsafe { _mm256_storeu_si256(slice.as_mut_ptr() as *mut __m256i, self.0) }
     }
 
+    /// # Safety
+    /// Requires AVX2.
     #[inline]
     #[target_feature(enable = "avx2")]
     pub unsafe fn broadcast(val: u64) -> Self {
-        unsafe { Self(_mm256_set1_epi64x(val as i64)) }
+        Self(_mm256_set1_epi64x(val as i64))
     }
 
+    /// # Safety
+    /// Requires AVX2.
     #[inline]
     #[target_feature(enable = "avx2")]
     pub unsafe fn square(self) -> Self {
@@ -82,106 +97,97 @@ impl Mul for PackedGoldilocks4 {
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn add_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    unsafe {
-        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-        let sum = _mm256_add_epi64(a.0, b.0);
-        // Unsigned overflow: sum < a (signed cmpgt detects wrapping)
-        let overflow = _mm256_cmpgt_epi64(a.0, sum);
-        let correction = _mm256_and_si256(overflow, epsilon);
-        let result = _mm256_add_epi64(sum, correction);
-        // Second overflow from adding epsilon
-        let overflow2 = _mm256_cmpgt_epi64(sum, result);
-        let correction2 = _mm256_and_si256(overflow2, epsilon);
-        PackedGoldilocks4(_mm256_add_epi64(result, correction2))
-    }
+    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+    let sum = _mm256_add_epi64(a.0, b.0);
+    // Unsigned overflow: a > sum means wrapping occurred
+    let overflow = unsafe { unsigned_cmpgt(a.0, sum) };
+    let correction = _mm256_and_si256(overflow, epsilon);
+    let result = _mm256_add_epi64(sum, correction);
+    // Second overflow from adding epsilon
+    let overflow2 = unsafe { unsigned_cmpgt(sum, result) };
+    let correction2 = _mm256_and_si256(overflow2, epsilon);
+    PackedGoldilocks4(_mm256_add_epi64(result, correction2))
 }
 
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn sub_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    unsafe {
-        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-        let diff = _mm256_sub_epi64(a.0, b.0);
-        // Unsigned underflow: b > a (signed cmpgt)
-        let underflow = _mm256_cmpgt_epi64(b.0, a.0);
-        let correction = _mm256_and_si256(underflow, epsilon);
-        let result = _mm256_sub_epi64(diff, correction);
-        // Second underflow from subtracting epsilon
-        let underflow2 = _mm256_cmpgt_epi64(diff, result);
-        let correction2 = _mm256_and_si256(underflow2, epsilon);
-        PackedGoldilocks4(_mm256_sub_epi64(result, correction2))
-    }
+    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+    let diff = _mm256_sub_epi64(a.0, b.0);
+    // Unsigned underflow: b > a
+    let underflow = unsafe { unsigned_cmpgt(b.0, a.0) };
+    let correction = _mm256_and_si256(underflow, epsilon);
+    let result = _mm256_sub_epi64(diff, correction);
+    // Second underflow from subtracting epsilon
+    let underflow2 = unsafe { unsigned_cmpgt(diff, result) };
+    let correction2 = _mm256_and_si256(underflow2, epsilon);
+    PackedGoldilocks4(_mm256_sub_epi64(result, correction2))
 }
 
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn mul_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    unsafe {
-        let low_mask = _mm256_set1_epi64x(0xFFFF_FFFF_i64);
+    let low_mask = _mm256_set1_epi64x(0xFFFF_FFFF_i64);
 
-        let a_lo = _mm256_and_si256(a.0, low_mask);
-        let a_hi = _mm256_srli_epi64(a.0, 32);
-        let b_lo = _mm256_and_si256(b.0, low_mask);
-        let b_hi = _mm256_srli_epi64(b.0, 32);
+    let a_lo = _mm256_and_si256(a.0, low_mask);
+    let a_hi = _mm256_srli_epi64(a.0, 32);
+    let b_lo = _mm256_and_si256(b.0, low_mask);
+    let b_hi = _mm256_srli_epi64(b.0, 32);
 
-        let p_ll = _mm256_mul_epu32(a_lo, b_lo);
-        let p_lh = _mm256_mul_epu32(a_lo, b_hi);
-        let p_hl = _mm256_mul_epu32(a_hi, b_lo);
-        let p_hh = _mm256_mul_epu32(a_hi, b_hi);
+    let p_ll = _mm256_mul_epu32(a_lo, b_lo);
+    let p_lh = _mm256_mul_epu32(a_lo, b_hi);
+    let p_hl = _mm256_mul_epu32(a_hi, b_lo);
+    let p_hh = _mm256_mul_epu32(a_hi, b_hi);
 
-        // Middle term
-        let p_mid = _mm256_add_epi64(p_lh, p_hl);
-        let p_mid_lo = _mm256_and_si256(p_mid, low_mask);
-        let p_mid_hi = _mm256_srli_epi64(p_mid, 32);
+    // Middle term
+    let p_mid = _mm256_add_epi64(p_lh, p_hl);
+    let p_mid_lo = _mm256_and_si256(p_mid, low_mask);
+    let p_mid_hi = _mm256_srli_epi64(p_mid, 32);
 
-        // Detect carry from p_lh + p_hl overflow (at bit 64 of mid, i.e. bit 96 total)
-        // When p_mid < p_lh, overflow happened
-        let mid_overflow = _mm256_cmpgt_epi64(p_lh, p_mid);
-        let mid_carry = _mm256_srli_epi64(mid_overflow, 63); // -1 >> 63 = 1 on overflow lanes
+    // Detect carry from p_lh + p_hl overflow (at bit 64 of mid, i.e. bit 96 total)
+    let mid_overflow = unsafe { unsigned_cmpgt(p_lh, p_mid) };
+    let mid_carry = _mm256_srli_epi64(mid_overflow, 63); // -1 >> 63 = 1 on overflow lanes
 
-        // lo = p_ll + (p_mid_lo << 32)
-        let mid_lo_shifted = _mm256_slli_epi64(p_mid_lo, 32);
-        let lo = _mm256_add_epi64(p_ll, mid_lo_shifted);
-        let lo_overflow = _mm256_cmpgt_epi64(p_ll, lo);
-        let lo_carry = _mm256_srli_epi64(lo_overflow, 63);
+    // lo = p_ll + (p_mid_lo << 32)
+    let mid_lo_shifted = _mm256_slli_epi64(p_mid_lo, 32);
+    let lo = _mm256_add_epi64(p_ll, mid_lo_shifted);
+    let lo_overflow = unsafe { unsigned_cmpgt(p_ll, lo) };
+    let lo_carry = _mm256_srli_epi64(lo_overflow, 63);
 
-        // hi = p_hh + p_mid_hi + mid_carry_shifted + lo_carry
-        let mid_carry_shifted = _mm256_slli_epi64(mid_carry, 32);
-        let hi = _mm256_add_epi64(
-            _mm256_add_epi64(p_hh, p_mid_hi),
-            _mm256_add_epi64(mid_carry_shifted, lo_carry),
-        );
+    // hi = p_hh + p_mid_hi + mid_carry_shifted + lo_carry
+    let mid_carry_shifted = _mm256_slli_epi64(mid_carry, 32);
+    let hi = _mm256_add_epi64(
+        _mm256_add_epi64(p_hh, p_mid_hi),
+        _mm256_add_epi64(mid_carry_shifted, lo_carry),
+    );
 
-        reduce_128_avx2(lo, hi)
-    }
+    unsafe { reduce_128_avx2(lo, hi) }
 }
 
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn reduce_128_avx2(lo: __m256i, hi: __m256i) -> PackedGoldilocks4 {
-    unsafe {
-        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-        let low_mask = epsilon; // same bit pattern
+    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+    let low_mask = epsilon; // same bit pattern
 
-        let hi_lo = _mm256_and_si256(hi, low_mask);
-        let hi_hi = _mm256_srli_epi64(hi, 32);
+    let hi_lo = _mm256_and_si256(hi, low_mask);
+    let hi_hi = _mm256_srli_epi64(hi, 32);
 
-        // t0 = lo - hi_hi
-        let borrow = _mm256_cmpgt_epi64(hi_hi, lo);
-        let t0 = _mm256_sub_epi64(lo, hi_hi);
-        let borrow_correction = _mm256_and_si256(borrow, epsilon);
-        let t0 = _mm256_sub_epi64(t0, borrow_correction);
+    // t0 = lo - hi_hi
+    let borrow = unsafe { unsigned_cmpgt(hi_hi, lo) };
+    let t0 = _mm256_sub_epi64(lo, hi_hi);
+    let borrow_correction = _mm256_and_si256(borrow, epsilon);
+    let t0 = _mm256_sub_epi64(t0, borrow_correction);
 
-        // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
-        let hi_lo_shifted = _mm256_slli_epi64(hi_lo, 32);
-        let t1 = _mm256_sub_epi64(hi_lo_shifted, hi_lo);
+    // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
+    let hi_lo_shifted = _mm256_slli_epi64(hi_lo, 32);
+    let t1 = _mm256_sub_epi64(hi_lo_shifted, hi_lo);
 
-        // result = t0 + t1
-        let sum = _mm256_add_epi64(t0, t1);
-        let carry = _mm256_cmpgt_epi64(t0, sum);
-        let carry_correction = _mm256_and_si256(carry, epsilon);
-        PackedGoldilocks4(_mm256_add_epi64(sum, carry_correction))
-    }
+    // result = t0 + t1
+    let sum = _mm256_add_epi64(t0, t1);
+    let carry = unsafe { unsigned_cmpgt(t0, sum) };
+    let carry_correction = _mm256_and_si256(carry, epsilon);
+    PackedGoldilocks4(_mm256_add_epi64(sum, carry_correction))
 }
 
 #[cfg(test)]
@@ -201,7 +207,13 @@ mod tests {
         if !is_x86_feature_detected!("avx2") {
             return;
         }
-        let cases: [(u64, u64); 4] = [(1, 3), (P - 1, 2), (P - 1, P - 1), (0, 0)];
+        let cases: [(u64, u64); 5] = [
+            (1, 3),
+            (GOLDILOCKS_PRIME - 1, 2),
+            (GOLDILOCKS_PRIME - 1, GOLDILOCKS_PRIME - 1),
+            (0, 0),
+            (0, GOLDILOCKS_PRIME - 1), // catches signed-comparison bug
+        ];
         for (a, b) in cases {
             unsafe {
                 let pa = PackedGoldilocks4::broadcast(a);
@@ -218,7 +230,12 @@ mod tests {
         if !is_x86_feature_detected!("avx2") {
             return;
         }
-        let cases: [(u64, u64); 4] = [(5, 3), (3, 5), (0, P - 1), (P - 1, P - 1)];
+        let cases: [(u64, u64); 4] = [
+            (5, 3),
+            (3, 5),
+            (0, GOLDILOCKS_PRIME - 1),
+            (GOLDILOCKS_PRIME - 1, GOLDILOCKS_PRIME - 1),
+        ];
         for (a, b) in cases {
             unsafe {
                 let pa = PackedGoldilocks4::broadcast(a);
@@ -239,8 +256,8 @@ mod tests {
             (1, 1),
             (2, 3),
             (EPSILON, EPSILON),
-            (P - 1, 2),
-            (P - 1, P - 1),
+            (GOLDILOCKS_PRIME - 1, 2),
+            (GOLDILOCKS_PRIME - 1, GOLDILOCKS_PRIME - 1),
         ];
         for (a, b) in cases {
             unsafe {
@@ -274,7 +291,7 @@ mod proptests {
     use proptest::prelude::*;
 
     fn arb_fe() -> impl Strategy<Value = u64> {
-        0..P
+        0..GOLDILOCKS_PRIME
     }
 
     proptest! {

--- a/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
+++ b/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
@@ -25,27 +25,27 @@ const EPSILON: u64 = 0xFFFF_FFFF;
 pub struct PackedGoldilocks4(__m256i);
 
 impl PackedGoldilocks4 {
-    #[inline(always)]
+    #[inline]
     #[target_feature(enable = "avx2")]
     pub unsafe fn load(slice: &[u64]) -> Self {
         debug_assert!(slice.len() >= 4);
-        unsafe { Self(_mm256_loadu_si256(slice.as_ptr() as *const __m256i)) }
+        Self(_mm256_loadu_si256(slice.as_ptr() as *const __m256i))
     }
 
-    #[inline(always)]
+    #[inline]
     #[target_feature(enable = "avx2")]
     pub unsafe fn store(self, slice: &mut [u64]) {
         debug_assert!(slice.len() >= 4);
-        unsafe { _mm256_storeu_si256(slice.as_mut_ptr() as *mut __m256i, self.0) }
+        _mm256_storeu_si256(slice.as_mut_ptr() as *mut __m256i, self.0)
     }
 
-    #[inline(always)]
+    #[inline]
     #[target_feature(enable = "avx2")]
     pub unsafe fn broadcast(val: u64) -> Self {
-        unsafe { Self(_mm256_set1_epi64x(val as i64)) }
+        Self(_mm256_set1_epi64x(val as i64))
     }
 
-    #[inline(always)]
+    #[inline]
     #[target_feature(enable = "avx2")]
     pub unsafe fn square(self) -> Self {
         self * self
@@ -79,109 +79,101 @@ impl Mul for PackedGoldilocks4 {
     }
 }
 
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn add_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    unsafe {
-        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-        let sum = _mm256_add_epi64(a.0, b.0);
-        // Unsigned overflow: sum < a (signed cmpgt detects wrapping)
-        let overflow = _mm256_cmpgt_epi64(a.0, sum);
-        let correction = _mm256_and_si256(overflow, epsilon);
-        let result = _mm256_add_epi64(sum, correction);
-        // Second overflow from adding epsilon
-        let overflow2 = _mm256_cmpgt_epi64(sum, result);
-        let correction2 = _mm256_and_si256(overflow2, epsilon);
-        PackedGoldilocks4(_mm256_add_epi64(result, correction2))
-    }
+    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+    let sum = _mm256_add_epi64(a.0, b.0);
+    // Unsigned overflow: sum < a (signed cmpgt detects wrapping)
+    let overflow = _mm256_cmpgt_epi64(a.0, sum);
+    let correction = _mm256_and_si256(overflow, epsilon);
+    let result = _mm256_add_epi64(sum, correction);
+    // Second overflow from adding epsilon
+    let overflow2 = _mm256_cmpgt_epi64(sum, result);
+    let correction2 = _mm256_and_si256(overflow2, epsilon);
+    PackedGoldilocks4(_mm256_add_epi64(result, correction2))
 }
 
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn sub_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    unsafe {
-        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-        let diff = _mm256_sub_epi64(a.0, b.0);
-        // Unsigned underflow: b > a (signed cmpgt)
-        let underflow = _mm256_cmpgt_epi64(b.0, a.0);
-        let correction = _mm256_and_si256(underflow, epsilon);
-        let result = _mm256_sub_epi64(diff, correction);
-        // Second underflow from subtracting epsilon
-        let underflow2 = _mm256_cmpgt_epi64(diff, result);
-        let correction2 = _mm256_and_si256(underflow2, epsilon);
-        PackedGoldilocks4(_mm256_sub_epi64(result, correction2))
-    }
+    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+    let diff = _mm256_sub_epi64(a.0, b.0);
+    // Unsigned underflow: b > a (signed cmpgt)
+    let underflow = _mm256_cmpgt_epi64(b.0, a.0);
+    let correction = _mm256_and_si256(underflow, epsilon);
+    let result = _mm256_sub_epi64(diff, correction);
+    // Second underflow from subtracting epsilon
+    let underflow2 = _mm256_cmpgt_epi64(diff, result);
+    let correction2 = _mm256_and_si256(underflow2, epsilon);
+    PackedGoldilocks4(_mm256_sub_epi64(result, correction2))
 }
 
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn mul_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    unsafe {
-        let low_mask = _mm256_set1_epi64x(0xFFFF_FFFF_i64);
+    let low_mask = _mm256_set1_epi64x(0xFFFF_FFFF_i64);
 
-        let a_lo = _mm256_and_si256(a.0, low_mask);
-        let a_hi = _mm256_srli_epi64(a.0, 32);
-        let b_lo = _mm256_and_si256(b.0, low_mask);
-        let b_hi = _mm256_srli_epi64(b.0, 32);
+    let a_lo = _mm256_and_si256(a.0, low_mask);
+    let a_hi = _mm256_srli_epi64(a.0, 32);
+    let b_lo = _mm256_and_si256(b.0, low_mask);
+    let b_hi = _mm256_srli_epi64(b.0, 32);
 
-        let p_ll = _mm256_mul_epu32(a_lo, b_lo);
-        let p_lh = _mm256_mul_epu32(a_lo, b_hi);
-        let p_hl = _mm256_mul_epu32(a_hi, b_lo);
-        let p_hh = _mm256_mul_epu32(a_hi, b_hi);
+    let p_ll = _mm256_mul_epu32(a_lo, b_lo);
+    let p_lh = _mm256_mul_epu32(a_lo, b_hi);
+    let p_hl = _mm256_mul_epu32(a_hi, b_lo);
+    let p_hh = _mm256_mul_epu32(a_hi, b_hi);
 
-        // Middle term
-        let p_mid = _mm256_add_epi64(p_lh, p_hl);
-        let p_mid_lo = _mm256_and_si256(p_mid, low_mask);
-        let p_mid_hi = _mm256_srli_epi64(p_mid, 32);
+    // Middle term
+    let p_mid = _mm256_add_epi64(p_lh, p_hl);
+    let p_mid_lo = _mm256_and_si256(p_mid, low_mask);
+    let p_mid_hi = _mm256_srli_epi64(p_mid, 32);
 
-        // Detect carry from p_lh + p_hl overflow (at bit 64 of mid, i.e. bit 96 total)
-        // When p_mid < p_lh, overflow happened
-        let mid_overflow = _mm256_cmpgt_epi64(p_lh, p_mid);
-        let mid_carry = _mm256_srli_epi64(mid_overflow, 63); // -1 >> 63 = 1 on overflow lanes
+    // Detect carry from p_lh + p_hl overflow (at bit 64 of mid, i.e. bit 96 total)
+    // When p_mid < p_lh, overflow happened
+    let mid_overflow = _mm256_cmpgt_epi64(p_lh, p_mid);
+    let mid_carry = _mm256_srli_epi64(mid_overflow, 63); // -1 >> 63 = 1 on overflow lanes
 
-        // lo = p_ll + (p_mid_lo << 32)
-        let mid_lo_shifted = _mm256_slli_epi64(p_mid_lo, 32);
-        let lo = _mm256_add_epi64(p_ll, mid_lo_shifted);
-        let lo_overflow = _mm256_cmpgt_epi64(p_ll, lo);
-        let lo_carry = _mm256_srli_epi64(lo_overflow, 63);
+    // lo = p_ll + (p_mid_lo << 32)
+    let mid_lo_shifted = _mm256_slli_epi64(p_mid_lo, 32);
+    let lo = _mm256_add_epi64(p_ll, mid_lo_shifted);
+    let lo_overflow = _mm256_cmpgt_epi64(p_ll, lo);
+    let lo_carry = _mm256_srli_epi64(lo_overflow, 63);
 
-        // hi = p_hh + p_mid_hi + mid_carry_shifted + lo_carry
-        let mid_carry_shifted = _mm256_slli_epi64(mid_carry, 32);
-        let hi = _mm256_add_epi64(
-            _mm256_add_epi64(p_hh, p_mid_hi),
-            _mm256_add_epi64(mid_carry_shifted, lo_carry),
-        );
+    // hi = p_hh + p_mid_hi + mid_carry_shifted + lo_carry
+    let mid_carry_shifted = _mm256_slli_epi64(mid_carry, 32);
+    let hi = _mm256_add_epi64(
+        _mm256_add_epi64(p_hh, p_mid_hi),
+        _mm256_add_epi64(mid_carry_shifted, lo_carry),
+    );
 
-        reduce_128_avx2(lo, hi)
-    }
+    reduce_128_avx2(lo, hi)
 }
 
-#[inline(always)]
+#[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn reduce_128_avx2(lo: __m256i, hi: __m256i) -> PackedGoldilocks4 {
-    unsafe {
-        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-        let low_mask = epsilon; // same bit pattern
+    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+    let low_mask = epsilon; // same bit pattern
 
-        let hi_lo = _mm256_and_si256(hi, low_mask);
-        let hi_hi = _mm256_srli_epi64(hi, 32);
+    let hi_lo = _mm256_and_si256(hi, low_mask);
+    let hi_hi = _mm256_srli_epi64(hi, 32);
 
-        // t0 = lo - hi_hi
-        let borrow = _mm256_cmpgt_epi64(hi_hi, lo);
-        let t0 = _mm256_sub_epi64(lo, hi_hi);
-        let borrow_correction = _mm256_and_si256(borrow, epsilon);
-        let t0 = _mm256_sub_epi64(t0, borrow_correction);
+    // t0 = lo - hi_hi
+    let borrow = _mm256_cmpgt_epi64(hi_hi, lo);
+    let t0 = _mm256_sub_epi64(lo, hi_hi);
+    let borrow_correction = _mm256_and_si256(borrow, epsilon);
+    let t0 = _mm256_sub_epi64(t0, borrow_correction);
 
-        // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
-        let hi_lo_shifted = _mm256_slli_epi64(hi_lo, 32);
-        let t1 = _mm256_sub_epi64(hi_lo_shifted, hi_lo);
+    // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
+    let hi_lo_shifted = _mm256_slli_epi64(hi_lo, 32);
+    let t1 = _mm256_sub_epi64(hi_lo_shifted, hi_lo);
 
-        // result = t0 + t1
-        let sum = _mm256_add_epi64(t0, t1);
-        let carry = _mm256_cmpgt_epi64(t0, sum);
-        let carry_correction = _mm256_and_si256(carry, epsilon);
-        PackedGoldilocks4(_mm256_add_epi64(sum, carry_correction))
-    }
+    // result = t0 + t1
+    let sum = _mm256_add_epi64(t0, t1);
+    let carry = _mm256_cmpgt_epi64(t0, sum);
+    let carry_correction = _mm256_and_si256(carry, epsilon);
+    PackedGoldilocks4(_mm256_add_epi64(sum, carry_correction))
 }
 
 #[cfg(test)]

--- a/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
+++ b/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
@@ -29,20 +29,20 @@ impl PackedGoldilocks4 {
     #[target_feature(enable = "avx2")]
     pub unsafe fn load(slice: &[u64]) -> Self {
         debug_assert!(slice.len() >= 4);
-        Self(_mm256_loadu_si256(slice.as_ptr() as *const __m256i))
+        unsafe { Self(_mm256_loadu_si256(slice.as_ptr() as *const __m256i)) }
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     pub unsafe fn store(self, slice: &mut [u64]) {
         debug_assert!(slice.len() >= 4);
-        _mm256_storeu_si256(slice.as_mut_ptr() as *mut __m256i, self.0)
+        unsafe { _mm256_storeu_si256(slice.as_mut_ptr() as *mut __m256i, self.0) }
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     pub unsafe fn broadcast(val: u64) -> Self {
-        Self(_mm256_set1_epi64x(val as i64))
+        unsafe { Self(_mm256_set1_epi64x(val as i64)) }
     }
 
     #[inline]
@@ -82,98 +82,106 @@ impl Mul for PackedGoldilocks4 {
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn add_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-    let sum = _mm256_add_epi64(a.0, b.0);
-    // Unsigned overflow: sum < a (signed cmpgt detects wrapping)
-    let overflow = _mm256_cmpgt_epi64(a.0, sum);
-    let correction = _mm256_and_si256(overflow, epsilon);
-    let result = _mm256_add_epi64(sum, correction);
-    // Second overflow from adding epsilon
-    let overflow2 = _mm256_cmpgt_epi64(sum, result);
-    let correction2 = _mm256_and_si256(overflow2, epsilon);
-    PackedGoldilocks4(_mm256_add_epi64(result, correction2))
+    unsafe {
+        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+        let sum = _mm256_add_epi64(a.0, b.0);
+        // Unsigned overflow: sum < a (signed cmpgt detects wrapping)
+        let overflow = _mm256_cmpgt_epi64(a.0, sum);
+        let correction = _mm256_and_si256(overflow, epsilon);
+        let result = _mm256_add_epi64(sum, correction);
+        // Second overflow from adding epsilon
+        let overflow2 = _mm256_cmpgt_epi64(sum, result);
+        let correction2 = _mm256_and_si256(overflow2, epsilon);
+        PackedGoldilocks4(_mm256_add_epi64(result, correction2))
+    }
 }
 
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn sub_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-    let diff = _mm256_sub_epi64(a.0, b.0);
-    // Unsigned underflow: b > a (signed cmpgt)
-    let underflow = _mm256_cmpgt_epi64(b.0, a.0);
-    let correction = _mm256_and_si256(underflow, epsilon);
-    let result = _mm256_sub_epi64(diff, correction);
-    // Second underflow from subtracting epsilon
-    let underflow2 = _mm256_cmpgt_epi64(diff, result);
-    let correction2 = _mm256_and_si256(underflow2, epsilon);
-    PackedGoldilocks4(_mm256_sub_epi64(result, correction2))
+    unsafe {
+        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+        let diff = _mm256_sub_epi64(a.0, b.0);
+        // Unsigned underflow: b > a (signed cmpgt)
+        let underflow = _mm256_cmpgt_epi64(b.0, a.0);
+        let correction = _mm256_and_si256(underflow, epsilon);
+        let result = _mm256_sub_epi64(diff, correction);
+        // Second underflow from subtracting epsilon
+        let underflow2 = _mm256_cmpgt_epi64(diff, result);
+        let correction2 = _mm256_and_si256(underflow2, epsilon);
+        PackedGoldilocks4(_mm256_sub_epi64(result, correction2))
+    }
 }
 
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn mul_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    let low_mask = _mm256_set1_epi64x(0xFFFF_FFFF_i64);
+    unsafe {
+        let low_mask = _mm256_set1_epi64x(0xFFFF_FFFF_i64);
 
-    let a_lo = _mm256_and_si256(a.0, low_mask);
-    let a_hi = _mm256_srli_epi64(a.0, 32);
-    let b_lo = _mm256_and_si256(b.0, low_mask);
-    let b_hi = _mm256_srli_epi64(b.0, 32);
+        let a_lo = _mm256_and_si256(a.0, low_mask);
+        let a_hi = _mm256_srli_epi64(a.0, 32);
+        let b_lo = _mm256_and_si256(b.0, low_mask);
+        let b_hi = _mm256_srli_epi64(b.0, 32);
 
-    let p_ll = _mm256_mul_epu32(a_lo, b_lo);
-    let p_lh = _mm256_mul_epu32(a_lo, b_hi);
-    let p_hl = _mm256_mul_epu32(a_hi, b_lo);
-    let p_hh = _mm256_mul_epu32(a_hi, b_hi);
+        let p_ll = _mm256_mul_epu32(a_lo, b_lo);
+        let p_lh = _mm256_mul_epu32(a_lo, b_hi);
+        let p_hl = _mm256_mul_epu32(a_hi, b_lo);
+        let p_hh = _mm256_mul_epu32(a_hi, b_hi);
 
-    // Middle term
-    let p_mid = _mm256_add_epi64(p_lh, p_hl);
-    let p_mid_lo = _mm256_and_si256(p_mid, low_mask);
-    let p_mid_hi = _mm256_srli_epi64(p_mid, 32);
+        // Middle term
+        let p_mid = _mm256_add_epi64(p_lh, p_hl);
+        let p_mid_lo = _mm256_and_si256(p_mid, low_mask);
+        let p_mid_hi = _mm256_srli_epi64(p_mid, 32);
 
-    // Detect carry from p_lh + p_hl overflow (at bit 64 of mid, i.e. bit 96 total)
-    // When p_mid < p_lh, overflow happened
-    let mid_overflow = _mm256_cmpgt_epi64(p_lh, p_mid);
-    let mid_carry = _mm256_srli_epi64(mid_overflow, 63); // -1 >> 63 = 1 on overflow lanes
+        // Detect carry from p_lh + p_hl overflow (at bit 64 of mid, i.e. bit 96 total)
+        // When p_mid < p_lh, overflow happened
+        let mid_overflow = _mm256_cmpgt_epi64(p_lh, p_mid);
+        let mid_carry = _mm256_srli_epi64(mid_overflow, 63); // -1 >> 63 = 1 on overflow lanes
 
-    // lo = p_ll + (p_mid_lo << 32)
-    let mid_lo_shifted = _mm256_slli_epi64(p_mid_lo, 32);
-    let lo = _mm256_add_epi64(p_ll, mid_lo_shifted);
-    let lo_overflow = _mm256_cmpgt_epi64(p_ll, lo);
-    let lo_carry = _mm256_srli_epi64(lo_overflow, 63);
+        // lo = p_ll + (p_mid_lo << 32)
+        let mid_lo_shifted = _mm256_slli_epi64(p_mid_lo, 32);
+        let lo = _mm256_add_epi64(p_ll, mid_lo_shifted);
+        let lo_overflow = _mm256_cmpgt_epi64(p_ll, lo);
+        let lo_carry = _mm256_srli_epi64(lo_overflow, 63);
 
-    // hi = p_hh + p_mid_hi + mid_carry_shifted + lo_carry
-    let mid_carry_shifted = _mm256_slli_epi64(mid_carry, 32);
-    let hi = _mm256_add_epi64(
-        _mm256_add_epi64(p_hh, p_mid_hi),
-        _mm256_add_epi64(mid_carry_shifted, lo_carry),
-    );
+        // hi = p_hh + p_mid_hi + mid_carry_shifted + lo_carry
+        let mid_carry_shifted = _mm256_slli_epi64(mid_carry, 32);
+        let hi = _mm256_add_epi64(
+            _mm256_add_epi64(p_hh, p_mid_hi),
+            _mm256_add_epi64(mid_carry_shifted, lo_carry),
+        );
 
-    reduce_128_avx2(lo, hi)
+        reduce_128_avx2(lo, hi)
+    }
 }
 
 #[inline]
 #[target_feature(enable = "avx2")]
 unsafe fn reduce_128_avx2(lo: __m256i, hi: __m256i) -> PackedGoldilocks4 {
-    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-    let low_mask = epsilon; // same bit pattern
+    unsafe {
+        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+        let low_mask = epsilon; // same bit pattern
 
-    let hi_lo = _mm256_and_si256(hi, low_mask);
-    let hi_hi = _mm256_srli_epi64(hi, 32);
+        let hi_lo = _mm256_and_si256(hi, low_mask);
+        let hi_hi = _mm256_srli_epi64(hi, 32);
 
-    // t0 = lo - hi_hi
-    let borrow = _mm256_cmpgt_epi64(hi_hi, lo);
-    let t0 = _mm256_sub_epi64(lo, hi_hi);
-    let borrow_correction = _mm256_and_si256(borrow, epsilon);
-    let t0 = _mm256_sub_epi64(t0, borrow_correction);
+        // t0 = lo - hi_hi
+        let borrow = _mm256_cmpgt_epi64(hi_hi, lo);
+        let t0 = _mm256_sub_epi64(lo, hi_hi);
+        let borrow_correction = _mm256_and_si256(borrow, epsilon);
+        let t0 = _mm256_sub_epi64(t0, borrow_correction);
 
-    // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
-    let hi_lo_shifted = _mm256_slli_epi64(hi_lo, 32);
-    let t1 = _mm256_sub_epi64(hi_lo_shifted, hi_lo);
+        // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
+        let hi_lo_shifted = _mm256_slli_epi64(hi_lo, 32);
+        let t1 = _mm256_sub_epi64(hi_lo_shifted, hi_lo);
 
-    // result = t0 + t1
-    let sum = _mm256_add_epi64(t0, t1);
-    let carry = _mm256_cmpgt_epi64(t0, sum);
-    let carry_correction = _mm256_and_si256(carry, epsilon);
-    PackedGoldilocks4(_mm256_add_epi64(sum, carry_correction))
+        // result = t0 + t1
+        let sum = _mm256_add_epi64(t0, t1);
+        let carry = _mm256_cmpgt_epi64(t0, sum);
+        let carry_correction = _mm256_and_si256(carry, epsilon);
+        PackedGoldilocks4(_mm256_add_epi64(sum, carry_correction))
+    }
 }
 
 #[cfg(test)]

--- a/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
+++ b/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
@@ -29,20 +29,20 @@ impl PackedGoldilocks4 {
     #[target_feature(enable = "avx2")]
     pub unsafe fn load(slice: &[u64]) -> Self {
         debug_assert!(slice.len() >= 4);
-        Self(_mm256_loadu_si256(slice.as_ptr() as *const __m256i))
+        unsafe { Self(_mm256_loadu_si256(slice.as_ptr() as *const __m256i)) }
     }
 
     #[inline(always)]
     #[target_feature(enable = "avx2")]
     pub unsafe fn store(self, slice: &mut [u64]) {
         debug_assert!(slice.len() >= 4);
-        _mm256_storeu_si256(slice.as_mut_ptr() as *mut __m256i, self.0)
+        unsafe { _mm256_storeu_si256(slice.as_mut_ptr() as *mut __m256i, self.0) }
     }
 
     #[inline(always)]
     #[target_feature(enable = "avx2")]
     pub unsafe fn broadcast(val: u64) -> Self {
-        Self(_mm256_set1_epi64x(val as i64))
+        unsafe { Self(_mm256_set1_epi64x(val as i64)) }
     }
 
     #[inline(always)]
@@ -82,98 +82,106 @@ impl Mul for PackedGoldilocks4 {
 #[inline(always)]
 #[target_feature(enable = "avx2")]
 unsafe fn add_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-    let sum = _mm256_add_epi64(a.0, b.0);
-    // Unsigned overflow: sum < a (signed cmpgt detects wrapping)
-    let overflow = _mm256_cmpgt_epi64(a.0, sum);
-    let correction = _mm256_and_si256(overflow, epsilon);
-    let result = _mm256_add_epi64(sum, correction);
-    // Second overflow from adding epsilon
-    let overflow2 = _mm256_cmpgt_epi64(sum, result);
-    let correction2 = _mm256_and_si256(overflow2, epsilon);
-    PackedGoldilocks4(_mm256_add_epi64(result, correction2))
+    unsafe {
+        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+        let sum = _mm256_add_epi64(a.0, b.0);
+        // Unsigned overflow: sum < a (signed cmpgt detects wrapping)
+        let overflow = _mm256_cmpgt_epi64(a.0, sum);
+        let correction = _mm256_and_si256(overflow, epsilon);
+        let result = _mm256_add_epi64(sum, correction);
+        // Second overflow from adding epsilon
+        let overflow2 = _mm256_cmpgt_epi64(sum, result);
+        let correction2 = _mm256_and_si256(overflow2, epsilon);
+        PackedGoldilocks4(_mm256_add_epi64(result, correction2))
+    }
 }
 
 #[inline(always)]
 #[target_feature(enable = "avx2")]
 unsafe fn sub_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-    let diff = _mm256_sub_epi64(a.0, b.0);
-    // Unsigned underflow: b > a (signed cmpgt)
-    let underflow = _mm256_cmpgt_epi64(b.0, a.0);
-    let correction = _mm256_and_si256(underflow, epsilon);
-    let result = _mm256_sub_epi64(diff, correction);
-    // Second underflow from subtracting epsilon
-    let underflow2 = _mm256_cmpgt_epi64(diff, result);
-    let correction2 = _mm256_and_si256(underflow2, epsilon);
-    PackedGoldilocks4(_mm256_sub_epi64(result, correction2))
+    unsafe {
+        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+        let diff = _mm256_sub_epi64(a.0, b.0);
+        // Unsigned underflow: b > a (signed cmpgt)
+        let underflow = _mm256_cmpgt_epi64(b.0, a.0);
+        let correction = _mm256_and_si256(underflow, epsilon);
+        let result = _mm256_sub_epi64(diff, correction);
+        // Second underflow from subtracting epsilon
+        let underflow2 = _mm256_cmpgt_epi64(diff, result);
+        let correction2 = _mm256_and_si256(underflow2, epsilon);
+        PackedGoldilocks4(_mm256_sub_epi64(result, correction2))
+    }
 }
 
 #[inline(always)]
 #[target_feature(enable = "avx2")]
 unsafe fn mul_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
-    let low_mask = _mm256_set1_epi64x(0xFFFF_FFFF_i64);
+    unsafe {
+        let low_mask = _mm256_set1_epi64x(0xFFFF_FFFF_i64);
 
-    let a_lo = _mm256_and_si256(a.0, low_mask);
-    let a_hi = _mm256_srli_epi64(a.0, 32);
-    let b_lo = _mm256_and_si256(b.0, low_mask);
-    let b_hi = _mm256_srli_epi64(b.0, 32);
+        let a_lo = _mm256_and_si256(a.0, low_mask);
+        let a_hi = _mm256_srli_epi64(a.0, 32);
+        let b_lo = _mm256_and_si256(b.0, low_mask);
+        let b_hi = _mm256_srli_epi64(b.0, 32);
 
-    let p_ll = _mm256_mul_epu32(a_lo, b_lo);
-    let p_lh = _mm256_mul_epu32(a_lo, b_hi);
-    let p_hl = _mm256_mul_epu32(a_hi, b_lo);
-    let p_hh = _mm256_mul_epu32(a_hi, b_hi);
+        let p_ll = _mm256_mul_epu32(a_lo, b_lo);
+        let p_lh = _mm256_mul_epu32(a_lo, b_hi);
+        let p_hl = _mm256_mul_epu32(a_hi, b_lo);
+        let p_hh = _mm256_mul_epu32(a_hi, b_hi);
 
-    // Middle term
-    let p_mid = _mm256_add_epi64(p_lh, p_hl);
-    let p_mid_lo = _mm256_and_si256(p_mid, low_mask);
-    let p_mid_hi = _mm256_srli_epi64(p_mid, 32);
+        // Middle term
+        let p_mid = _mm256_add_epi64(p_lh, p_hl);
+        let p_mid_lo = _mm256_and_si256(p_mid, low_mask);
+        let p_mid_hi = _mm256_srli_epi64(p_mid, 32);
 
-    // Detect carry from p_lh + p_hl overflow (at bit 64 of mid, i.e. bit 96 total)
-    // When p_mid < p_lh, overflow happened
-    let mid_overflow = _mm256_cmpgt_epi64(p_lh, p_mid);
-    let mid_carry = _mm256_srli_epi64(mid_overflow, 63); // -1 >> 63 = 1 on overflow lanes
+        // Detect carry from p_lh + p_hl overflow (at bit 64 of mid, i.e. bit 96 total)
+        // When p_mid < p_lh, overflow happened
+        let mid_overflow = _mm256_cmpgt_epi64(p_lh, p_mid);
+        let mid_carry = _mm256_srli_epi64(mid_overflow, 63); // -1 >> 63 = 1 on overflow lanes
 
-    // lo = p_ll + (p_mid_lo << 32)
-    let mid_lo_shifted = _mm256_slli_epi64(p_mid_lo, 32);
-    let lo = _mm256_add_epi64(p_ll, mid_lo_shifted);
-    let lo_overflow = _mm256_cmpgt_epi64(p_ll, lo);
-    let lo_carry = _mm256_srli_epi64(lo_overflow, 63);
+        // lo = p_ll + (p_mid_lo << 32)
+        let mid_lo_shifted = _mm256_slli_epi64(p_mid_lo, 32);
+        let lo = _mm256_add_epi64(p_ll, mid_lo_shifted);
+        let lo_overflow = _mm256_cmpgt_epi64(p_ll, lo);
+        let lo_carry = _mm256_srli_epi64(lo_overflow, 63);
 
-    // hi = p_hh + p_mid_hi + mid_carry_shifted + lo_carry
-    let mid_carry_shifted = _mm256_slli_epi64(mid_carry, 32);
-    let hi = _mm256_add_epi64(
-        _mm256_add_epi64(p_hh, p_mid_hi),
-        _mm256_add_epi64(mid_carry_shifted, lo_carry),
-    );
+        // hi = p_hh + p_mid_hi + mid_carry_shifted + lo_carry
+        let mid_carry_shifted = _mm256_slli_epi64(mid_carry, 32);
+        let hi = _mm256_add_epi64(
+            _mm256_add_epi64(p_hh, p_mid_hi),
+            _mm256_add_epi64(mid_carry_shifted, lo_carry),
+        );
 
-    reduce_128_avx2(lo, hi)
+        reduce_128_avx2(lo, hi)
+    }
 }
 
 #[inline(always)]
 #[target_feature(enable = "avx2")]
 unsafe fn reduce_128_avx2(lo: __m256i, hi: __m256i) -> PackedGoldilocks4 {
-    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
-    let low_mask = epsilon; // same bit pattern
+    unsafe {
+        let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+        let low_mask = epsilon; // same bit pattern
 
-    let hi_lo = _mm256_and_si256(hi, low_mask);
-    let hi_hi = _mm256_srli_epi64(hi, 32);
+        let hi_lo = _mm256_and_si256(hi, low_mask);
+        let hi_hi = _mm256_srli_epi64(hi, 32);
 
-    // t0 = lo - hi_hi
-    let borrow = _mm256_cmpgt_epi64(hi_hi, lo);
-    let t0 = _mm256_sub_epi64(lo, hi_hi);
-    let borrow_correction = _mm256_and_si256(borrow, epsilon);
-    let t0 = _mm256_sub_epi64(t0, borrow_correction);
+        // t0 = lo - hi_hi
+        let borrow = _mm256_cmpgt_epi64(hi_hi, lo);
+        let t0 = _mm256_sub_epi64(lo, hi_hi);
+        let borrow_correction = _mm256_and_si256(borrow, epsilon);
+        let t0 = _mm256_sub_epi64(t0, borrow_correction);
 
-    // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
-    let hi_lo_shifted = _mm256_slli_epi64(hi_lo, 32);
-    let t1 = _mm256_sub_epi64(hi_lo_shifted, hi_lo);
+        // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
+        let hi_lo_shifted = _mm256_slli_epi64(hi_lo, 32);
+        let t1 = _mm256_sub_epi64(hi_lo_shifted, hi_lo);
 
-    // result = t0 + t1
-    let sum = _mm256_add_epi64(t0, t1);
-    let carry = _mm256_cmpgt_epi64(t0, sum);
-    let carry_correction = _mm256_and_si256(carry, epsilon);
-    PackedGoldilocks4(_mm256_add_epi64(sum, carry_correction))
+        // result = t0 + t1
+        let sum = _mm256_add_epi64(t0, t1);
+        let carry = _mm256_cmpgt_epi64(t0, sum);
+        let carry_correction = _mm256_and_si256(carry, epsilon);
+        PackedGoldilocks4(_mm256_add_epi64(sum, carry_correction))
+    }
 }
 
 #[cfg(test)]
@@ -184,7 +192,7 @@ mod tests {
 
     unsafe fn to_array(p: PackedGoldilocks4) -> [u64; 4] {
         let mut out = [0u64; 4];
-        p.store(&mut out);
+        unsafe { p.store(&mut out) };
         out
     }
 

--- a/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
+++ b/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
@@ -14,8 +14,6 @@ use core::arch::x86_64::*;
 
 use core::ops::{Add, Mul, Sub};
 
-use super::u64_goldilocks::GOLDILOCKS_PRIME;
-
 const EPSILON: u64 = 0xFFFF_FFFF;
 
 /// Unsigned `a > b` via signed comparison with sign-bit flip.
@@ -118,8 +116,8 @@ unsafe fn sub_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldiloc
     let underflow = unsafe { unsigned_cmpgt(b.0, a.0) };
     let correction = _mm256_and_si256(underflow, epsilon);
     let result = _mm256_sub_epi64(diff, correction);
-    // Second underflow from subtracting epsilon
-    let underflow2 = unsafe { unsigned_cmpgt(diff, result) };
+    // Second underflow: borrow from subtracting epsilon (result wraps past diff)
+    let underflow2 = unsafe { unsigned_cmpgt(result, diff) };
     let correction2 = _mm256_and_si256(underflow2, epsilon);
     PackedGoldilocks4(_mm256_sub_epi64(result, correction2))
 }
@@ -193,7 +191,7 @@ unsafe fn reduce_128_avx2(lo: __m256i, hi: __m256i) -> PackedGoldilocks4 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::fields::fft_friendly::u64_goldilocks::GoldilocksField;
+    use crate::field::fields::fft_friendly::u64_goldilocks::{GOLDILOCKS_PRIME, GoldilocksField};
     use crate::field::traits::IsField;
 
     unsafe fn to_array(p: PackedGoldilocks4) -> [u64; 4] {
@@ -286,7 +284,7 @@ mod tests {
 #[cfg(test)]
 mod proptests {
     use super::*;
-    use crate::field::fields::fft_friendly::u64_goldilocks::GoldilocksField;
+    use crate::field::fields::fft_friendly::u64_goldilocks::{GOLDILOCKS_PRIME, GoldilocksField};
     use crate::field::traits::IsField;
     use proptest::prelude::*;
 

--- a/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
+++ b/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
@@ -1,0 +1,311 @@
+//! AVX2-accelerated Goldilocks field arithmetic.
+//!
+//! Provides `PackedGoldilocks4`, holding 4 Goldilocks field elements with
+//! parallel AVX2 operations. Used by the FFT butterfly kernels.
+//!
+//! **Important**: `_mm256_cmpgt_epi64` is signed. For unsigned overflow
+//! detection we compare `(a_signed > sum_signed)` which works because
+//! wrapping addition flips the sign bit on overflow.
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+use core::ops::{Add, Mul, Sub};
+
+use super::u64_goldilocks::GOLDILOCKS_PRIME;
+
+const P: u64 = GOLDILOCKS_PRIME;
+const EPSILON: u64 = 0xFFFF_FFFF;
+
+/// 4-wide packed Goldilocks field elements using AVX2 `__m256i`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct PackedGoldilocks4(__m256i);
+
+impl PackedGoldilocks4 {
+    #[inline(always)]
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn load(slice: &[u64]) -> Self {
+        debug_assert!(slice.len() >= 4);
+        Self(_mm256_loadu_si256(slice.as_ptr() as *const __m256i))
+    }
+
+    #[inline(always)]
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn store(self, slice: &mut [u64]) {
+        debug_assert!(slice.len() >= 4);
+        _mm256_storeu_si256(slice.as_mut_ptr() as *mut __m256i, self.0)
+    }
+
+    #[inline(always)]
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn broadcast(val: u64) -> Self {
+        Self(_mm256_set1_epi64x(val as i64))
+    }
+
+    #[inline(always)]
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn square(self) -> Self {
+        self * self
+    }
+}
+
+impl Add for PackedGoldilocks4 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self {
+        unsafe { add_avx2(self, rhs) }
+    }
+}
+
+impl Sub for PackedGoldilocks4 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self {
+        unsafe { sub_avx2(self, rhs) }
+    }
+}
+
+impl Mul for PackedGoldilocks4 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self {
+        unsafe { mul_avx2(self, rhs) }
+    }
+}
+
+#[inline(always)]
+#[target_feature(enable = "avx2")]
+unsafe fn add_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
+    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+    let sum = _mm256_add_epi64(a.0, b.0);
+    // Unsigned overflow: sum < a (signed cmpgt detects wrapping)
+    let overflow = _mm256_cmpgt_epi64(a.0, sum);
+    let correction = _mm256_and_si256(overflow, epsilon);
+    let result = _mm256_add_epi64(sum, correction);
+    // Second overflow from adding epsilon
+    let overflow2 = _mm256_cmpgt_epi64(sum, result);
+    let correction2 = _mm256_and_si256(overflow2, epsilon);
+    PackedGoldilocks4(_mm256_add_epi64(result, correction2))
+}
+
+#[inline(always)]
+#[target_feature(enable = "avx2")]
+unsafe fn sub_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
+    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+    let diff = _mm256_sub_epi64(a.0, b.0);
+    // Unsigned underflow: b > a (signed cmpgt)
+    let underflow = _mm256_cmpgt_epi64(b.0, a.0);
+    let correction = _mm256_and_si256(underflow, epsilon);
+    let result = _mm256_sub_epi64(diff, correction);
+    // Second underflow from subtracting epsilon
+    let underflow2 = _mm256_cmpgt_epi64(diff, result);
+    let correction2 = _mm256_and_si256(underflow2, epsilon);
+    PackedGoldilocks4(_mm256_sub_epi64(result, correction2))
+}
+
+#[inline(always)]
+#[target_feature(enable = "avx2")]
+unsafe fn mul_avx2(a: PackedGoldilocks4, b: PackedGoldilocks4) -> PackedGoldilocks4 {
+    let low_mask = _mm256_set1_epi64x(0xFFFF_FFFF_i64);
+
+    let a_lo = _mm256_and_si256(a.0, low_mask);
+    let a_hi = _mm256_srli_epi64(a.0, 32);
+    let b_lo = _mm256_and_si256(b.0, low_mask);
+    let b_hi = _mm256_srli_epi64(b.0, 32);
+
+    let p_ll = _mm256_mul_epu32(a_lo, b_lo);
+    let p_lh = _mm256_mul_epu32(a_lo, b_hi);
+    let p_hl = _mm256_mul_epu32(a_hi, b_lo);
+    let p_hh = _mm256_mul_epu32(a_hi, b_hi);
+
+    // Middle term
+    let p_mid = _mm256_add_epi64(p_lh, p_hl);
+    let p_mid_lo = _mm256_and_si256(p_mid, low_mask);
+    let p_mid_hi = _mm256_srli_epi64(p_mid, 32);
+
+    // Detect carry from p_lh + p_hl overflow (at bit 64 of mid, i.e. bit 96 total)
+    // When p_mid < p_lh, overflow happened
+    let mid_overflow = _mm256_cmpgt_epi64(p_lh, p_mid);
+    let mid_carry = _mm256_srli_epi64(mid_overflow, 63); // -1 >> 63 = 1 on overflow lanes
+
+    // lo = p_ll + (p_mid_lo << 32)
+    let mid_lo_shifted = _mm256_slli_epi64(p_mid_lo, 32);
+    let lo = _mm256_add_epi64(p_ll, mid_lo_shifted);
+    let lo_overflow = _mm256_cmpgt_epi64(p_ll, lo);
+    let lo_carry = _mm256_srli_epi64(lo_overflow, 63);
+
+    // hi = p_hh + p_mid_hi + mid_carry_shifted + lo_carry
+    let mid_carry_shifted = _mm256_slli_epi64(mid_carry, 32);
+    let hi = _mm256_add_epi64(
+        _mm256_add_epi64(p_hh, p_mid_hi),
+        _mm256_add_epi64(mid_carry_shifted, lo_carry),
+    );
+
+    reduce_128_avx2(lo, hi)
+}
+
+#[inline(always)]
+#[target_feature(enable = "avx2")]
+unsafe fn reduce_128_avx2(lo: __m256i, hi: __m256i) -> PackedGoldilocks4 {
+    let epsilon = _mm256_set1_epi64x(EPSILON as i64);
+    let low_mask = epsilon; // same bit pattern
+
+    let hi_lo = _mm256_and_si256(hi, low_mask);
+    let hi_hi = _mm256_srli_epi64(hi, 32);
+
+    // t0 = lo - hi_hi
+    let borrow = _mm256_cmpgt_epi64(hi_hi, lo);
+    let t0 = _mm256_sub_epi64(lo, hi_hi);
+    let borrow_correction = _mm256_and_si256(borrow, epsilon);
+    let t0 = _mm256_sub_epi64(t0, borrow_correction);
+
+    // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
+    let hi_lo_shifted = _mm256_slli_epi64(hi_lo, 32);
+    let t1 = _mm256_sub_epi64(hi_lo_shifted, hi_lo);
+
+    // result = t0 + t1
+    let sum = _mm256_add_epi64(t0, t1);
+    let carry = _mm256_cmpgt_epi64(t0, sum);
+    let carry_correction = _mm256_and_si256(carry, epsilon);
+    PackedGoldilocks4(_mm256_add_epi64(sum, carry_correction))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::fields::fft_friendly::u64_goldilocks::GoldilocksField;
+    use crate::field::traits::IsField;
+
+    unsafe fn to_array(p: PackedGoldilocks4) -> [u64; 4] {
+        let mut out = [0u64; 4];
+        p.store(&mut out);
+        out
+    }
+
+    #[test]
+    fn add_matches_scalar() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let cases: [(u64, u64); 4] = [(1, 3), (P - 1, 2), (P - 1, P - 1), (0, 0)];
+        for (a, b) in cases {
+            unsafe {
+                let pa = PackedGoldilocks4::broadcast(a);
+                let pb = PackedGoldilocks4::broadcast(b);
+                let out = to_array(pa + pb);
+                assert_eq!(out[0], GoldilocksField::add(&a, &b), "add({a}, {b})");
+                assert_eq!(out[3], GoldilocksField::add(&a, &b));
+            }
+        }
+    }
+
+    #[test]
+    fn sub_matches_scalar() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let cases: [(u64, u64); 4] = [(5, 3), (3, 5), (0, P - 1), (P - 1, P - 1)];
+        for (a, b) in cases {
+            unsafe {
+                let pa = PackedGoldilocks4::broadcast(a);
+                let pb = PackedGoldilocks4::broadcast(b);
+                let out = to_array(pa - pb);
+                assert_eq!(out[0], GoldilocksField::sub(&a, &b), "sub({a}, {b})");
+            }
+        }
+    }
+
+    #[test]
+    fn mul_matches_scalar() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let cases: [(u64, u64); 6] = [
+            (0, 0),
+            (1, 1),
+            (2, 3),
+            (EPSILON, EPSILON),
+            (P - 1, 2),
+            (P - 1, P - 1),
+        ];
+        for (a, b) in cases {
+            unsafe {
+                let pa = PackedGoldilocks4::broadcast(a);
+                let pb = PackedGoldilocks4::broadcast(b);
+                let out = to_array(pa * pb);
+                assert_eq!(out[0], GoldilocksField::mul(&a, &b), "mul({a}, {b})");
+            }
+        }
+    }
+
+    #[test]
+    fn load_store_roundtrip() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let data = [42u64, 99, 7, 13];
+        unsafe {
+            let p = PackedGoldilocks4::load(&data);
+            let out = to_array(p);
+            assert_eq!(out, data);
+        }
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use crate::field::fields::fft_friendly::u64_goldilocks::GoldilocksField;
+    use crate::field::traits::IsField;
+    use proptest::prelude::*;
+
+    fn arb_fe() -> impl Strategy<Value = u64> {
+        0..P
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10000))]
+
+        #[test]
+        fn prop_add(a in arb_fe(), b in arb_fe()) {
+            if !is_x86_feature_detected!("avx2") { return Ok(()); }
+            unsafe {
+                let pa = PackedGoldilocks4::broadcast(a);
+                let pb = PackedGoldilocks4::broadcast(b);
+                let mut out = [0u64; 4];
+                (pa + pb).store(&mut out);
+                prop_assert_eq!(out[0], GoldilocksField::add(&a, &b));
+            }
+        }
+
+        #[test]
+        fn prop_sub(a in arb_fe(), b in arb_fe()) {
+            if !is_x86_feature_detected!("avx2") { return Ok(()); }
+            unsafe {
+                let pa = PackedGoldilocks4::broadcast(a);
+                let pb = PackedGoldilocks4::broadcast(b);
+                let mut out = [0u64; 4];
+                (pa - pb).store(&mut out);
+                prop_assert_eq!(out[0], GoldilocksField::sub(&a, &b));
+            }
+        }
+
+        #[test]
+        fn prop_mul(a in arb_fe(), b in arb_fe()) {
+            if !is_x86_feature_detected!("avx2") { return Ok(()); }
+            unsafe {
+                let pa = PackedGoldilocks4::broadcast(a);
+                let pb = PackedGoldilocks4::broadcast(b);
+                let mut out = [0u64; 4];
+                (pa * pb).store(&mut out);
+                prop_assert_eq!(out[0], GoldilocksField::mul(&a, &b));
+            }
+        }
+    }
+}

--- a/crypto/math/src/field/fields/fft_friendly/goldilocks_neon.rs
+++ b/crypto/math/src/field/fields/fft_friendly/goldilocks_neon.rs
@@ -1,0 +1,320 @@
+//! SIMD-accelerated Goldilocks field arithmetic using ARM NEON.
+//!
+//! Provides `PackedGoldilocks2`, holding 2 Goldilocks field elements with
+//! parallel NEON operations. Used by the FFT butterfly kernels.
+
+use core::arch::aarch64::*;
+use core::ops::{Add, Mul, Neg, Sub};
+
+use super::u64_goldilocks::GOLDILOCKS_PRIME;
+
+const P: u64 = GOLDILOCKS_PRIME;
+const EPSILON: u64 = 0xFFFF_FFFF;
+
+/// 2-wide packed Goldilocks field elements using NEON `uint64x2_t`.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct PackedGoldilocks2(uint64x2_t);
+
+impl PackedGoldilocks2 {
+    #[inline(always)]
+    pub fn load(slice: &[u64]) -> Self {
+        debug_assert!(slice.len() >= 2);
+        unsafe { Self(vld1q_u64(slice.as_ptr())) }
+    }
+
+    #[inline(always)]
+    pub fn store(self, slice: &mut [u64]) {
+        debug_assert!(slice.len() >= 2);
+        unsafe { vst1q_u64(slice.as_mut_ptr(), self.0) }
+    }
+
+    #[inline(always)]
+    pub fn broadcast(val: u64) -> Self {
+        unsafe { Self(vdupq_n_u64(val)) }
+    }
+
+    #[inline(always)]
+    pub fn square(self) -> Self {
+        self * self
+    }
+
+    /// Reduce values in [0, 2P) to canonical [0, P).
+    #[inline(always)]
+    fn reduce(self) -> Self {
+        unsafe {
+            let p = vdupq_n_u64(P);
+            let reduced = vsubq_u64(self.0, p);
+            let mask = vcgeq_u64(self.0, p);
+            Self(vbslq_u64(mask, reduced, self.0))
+        }
+    }
+}
+
+impl Add for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self {
+        unsafe {
+            let sum = vaddq_u64(self.0, rhs.0);
+            let overflow_mask = vcltq_u64(sum, self.0);
+            let epsilon = vdupq_n_u64(EPSILON);
+            let correction = vandq_u64(overflow_mask, epsilon);
+            let result = vaddq_u64(sum, correction);
+            Self(result).reduce()
+        }
+    }
+}
+
+impl Sub for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn sub(self, rhs: Self) -> Self {
+        unsafe {
+            let underflow_mask = vcltq_u64(self.0, rhs.0);
+            let diff = vsubq_u64(self.0, rhs.0);
+            let p = vdupq_n_u64(P);
+            let correction = vandq_u64(underflow_mask, p);
+            Self(vaddq_u64(diff, correction))
+        }
+    }
+}
+
+impl Neg for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn neg(self) -> Self {
+        unsafe {
+            let p = vdupq_n_u64(P);
+            let zero = vdupq_n_u64(0);
+            let is_zero = vceqq_u64(self.0, zero);
+            let neg = vsubq_u64(p, self.0);
+            Self(vbslq_u64(is_zero, zero, neg))
+        }
+    }
+}
+
+impl Mul for PackedGoldilocks2 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self {
+        unsafe {
+            let a_32: uint32x4_t = vreinterpretq_u32_u64(self.0);
+            let b_32: uint32x4_t = vreinterpretq_u32_u64(rhs.0);
+
+            let a_lo_32 = vuzp1q_u32(a_32, a_32);
+            let a_hi_32 = vuzp2q_u32(a_32, a_32);
+            let b_lo_32 = vuzp1q_u32(b_32, b_32);
+            let b_hi_32 = vuzp2q_u32(b_32, b_32);
+
+            let a_lo = vget_low_u32(a_lo_32);
+            let a_hi = vget_low_u32(a_hi_32);
+            let b_lo = vget_low_u32(b_lo_32);
+            let b_hi = vget_low_u32(b_hi_32);
+
+            let p_ll: uint64x2_t = vmull_u32(a_lo, b_lo);
+            let p_lh: uint64x2_t = vmull_u32(a_lo, b_hi);
+            let p_hl: uint64x2_t = vmull_u32(a_hi, b_lo);
+            let p_hh: uint64x2_t = vmull_u32(a_hi, b_hi);
+
+            let p_mid = vaddq_u64(p_lh, p_hl);
+            let mid_overflow = vcltq_u64(p_mid, p_lh);
+            let mid_carry = vandq_u64(mid_overflow, vdupq_n_u64(1));
+
+            let mid_lo_shifted = vshlq_n_u64(p_mid, 32);
+            let lo = vaddq_u64(p_ll, mid_lo_shifted);
+            let lo_overflow = vcltq_u64(lo, p_ll);
+            let lo_carry = vandq_u64(lo_overflow, vdupq_n_u64(1));
+
+            let mid_hi = vshrq_n_u64(p_mid, 32);
+            let mid_carry_shifted = vshlq_n_u64(mid_carry, 32);
+            let hi = vaddq_u64(
+                vaddq_u64(vaddq_u64(p_hh, mid_hi), mid_carry_shifted),
+                lo_carry,
+            );
+
+            reduce_128_neon(lo, hi)
+        }
+    }
+}
+
+#[inline(always)]
+unsafe fn reduce_128_neon(lo: uint64x2_t, hi: uint64x2_t) -> PackedGoldilocks2 {
+    unsafe {
+        let epsilon = vdupq_n_u64(EPSILON);
+
+        let hi_lo = vandq_u64(hi, epsilon);
+        let hi_hi = vshrq_n_u64(hi, 32);
+
+        // t0 = lo - hi_hi
+        let borrow_mask = vcltq_u64(lo, hi_hi);
+        let t0 = vsubq_u64(lo, hi_hi);
+        let borrow_correction = vandq_u64(borrow_mask, epsilon);
+        let t0 = vsubq_u64(t0, borrow_correction);
+
+        // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
+        let hi_lo_shifted = vshlq_n_u64(hi_lo, 32);
+        let t1 = vsubq_u64(hi_lo_shifted, hi_lo);
+
+        // result = t0 + t1
+        let sum = vaddq_u64(t0, t1);
+        let carry_mask = vcltq_u64(sum, t0);
+        let carry_correction = vandq_u64(carry_mask, epsilon);
+        let result = vaddq_u64(sum, carry_correction);
+
+        PackedGoldilocks2(result).reduce()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::fields::fft_friendly::u64_goldilocks::GoldilocksField;
+    use crate::field::traits::{IsField, IsPrimeField};
+
+    /// Canonicalize to [0, P) for comparison. Scalar ops may return non-canonical values.
+    fn canon(x: u64) -> u64 {
+        GoldilocksField::canonical(&x)
+    }
+
+    fn scalar_add(a: u64, b: u64) -> u64 {
+        GoldilocksField::add(&a, &b)
+    }
+    fn scalar_sub(a: u64, b: u64) -> u64 {
+        GoldilocksField::sub(&a, &b)
+    }
+    fn scalar_mul(a: u64, b: u64) -> u64 {
+        GoldilocksField::mul(&a, &b)
+    }
+    fn scalar_neg(a: u64) -> u64 {
+        GoldilocksField::neg(&a)
+    }
+
+    #[test]
+    fn add_matches_scalar() {
+        let cases: [(u64, u64); 4] = [(1, 3), (P - 1, 2), (P - 1, P - 1), (0, 0)];
+        for (a, b) in cases {
+            let pa = PackedGoldilocks2::broadcast(a);
+            let pb = PackedGoldilocks2::broadcast(b);
+            let mut out = [0u64; 2];
+            (pa + pb).store(&mut out);
+            assert_eq!(canon(out[0]), canon(scalar_add(a, b)), "add({a}, {b})");
+        }
+    }
+
+    #[test]
+    fn sub_matches_scalar() {
+        let cases: [(u64, u64); 4] = [(5, 3), (3, 5), (0, P - 1), (P - 1, P - 1)];
+        for (a, b) in cases {
+            let pa = PackedGoldilocks2::broadcast(a);
+            let pb = PackedGoldilocks2::broadcast(b);
+            let mut out = [0u64; 2];
+            (pa - pb).store(&mut out);
+            assert_eq!(canon(out[0]), canon(scalar_sub(a, b)), "sub({a}, {b})");
+        }
+    }
+
+    #[test]
+    fn neg_matches_scalar() {
+        for a in [0u64, 1, 5, P - 1, EPSILON] {
+            let pa = PackedGoldilocks2::broadcast(a);
+            let mut out = [0u64; 2];
+            (-pa).store(&mut out);
+            assert_eq!(canon(out[0]), canon(scalar_neg(a)), "neg({a})");
+        }
+    }
+
+    #[test]
+    fn mul_matches_scalar() {
+        let cases: [(u64, u64); 6] = [
+            (0, 0),
+            (1, 1),
+            (2, 3),
+            (EPSILON, EPSILON),
+            (P - 1, 2),
+            (P - 1, P - 1),
+        ];
+        for (a, b) in cases {
+            let pa = PackedGoldilocks2::broadcast(a);
+            let pb = PackedGoldilocks2::broadcast(b);
+            let mut out = [0u64; 2];
+            (pa * pb).store(&mut out);
+            assert_eq!(canon(out[0]), canon(scalar_mul(a, b)), "mul({a}, {b})");
+        }
+    }
+
+    #[test]
+    fn load_store_roundtrip() {
+        let data = [42u64, 99];
+        let p = PackedGoldilocks2::load(&data);
+        let mut out = [0u64; 2];
+        p.store(&mut out);
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn square_matches_mul() {
+        for a in [7u64, P - 1, EPSILON, 1 << 32] {
+            let pa = PackedGoldilocks2::broadcast(a);
+            let mut sq = [0u64; 2];
+            let mut ml = [0u64; 2];
+            pa.square().store(&mut sq);
+            (pa * pa).store(&mut ml);
+            assert_eq!(sq, ml, "square({a})");
+        }
+    }
+}
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use crate::field::fields::fft_friendly::u64_goldilocks::GoldilocksField;
+    use crate::field::traits::{IsField, IsPrimeField};
+    use proptest::prelude::*;
+
+    fn canon(x: u64) -> u64 {
+        GoldilocksField::canonical(&x)
+    }
+
+    fn arb_fe() -> impl Strategy<Value = u64> {
+        0..P
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10000))]
+
+        #[test]
+        fn prop_add(a0 in arb_fe(), a1 in arb_fe(), b0 in arb_fe(), b1 in arb_fe()) {
+            let a = PackedGoldilocks2::load(&[a0, a1]);
+            let b = PackedGoldilocks2::load(&[b0, b1]);
+            let mut out = [0u64; 2];
+            (a + b).store(&mut out);
+            prop_assert_eq!(canon(out[0]), canon(GoldilocksField::add(&a0, &b0)));
+            prop_assert_eq!(canon(out[1]), canon(GoldilocksField::add(&a1, &b1)));
+        }
+
+        #[test]
+        fn prop_sub(a0 in arb_fe(), a1 in arb_fe(), b0 in arb_fe(), b1 in arb_fe()) {
+            let a = PackedGoldilocks2::load(&[a0, a1]);
+            let b = PackedGoldilocks2::load(&[b0, b1]);
+            let mut out = [0u64; 2];
+            (a - b).store(&mut out);
+            prop_assert_eq!(canon(out[0]), canon(GoldilocksField::sub(&a0, &b0)));
+            prop_assert_eq!(canon(out[1]), canon(GoldilocksField::sub(&a1, &b1)));
+        }
+
+        #[test]
+        fn prop_mul(a0 in arb_fe(), a1 in arb_fe(), b0 in arb_fe(), b1 in arb_fe()) {
+            let a = PackedGoldilocks2::load(&[a0, a1]);
+            let b = PackedGoldilocks2::load(&[b0, b1]);
+            let mut out = [0u64; 2];
+            (a * b).store(&mut out);
+            prop_assert_eq!(canon(out[0]), canon(GoldilocksField::mul(&a0, &b0)));
+            prop_assert_eq!(canon(out[1]), canon(GoldilocksField::mul(&a1, &b1)));
+        }
+    }
+}

--- a/crypto/math/src/field/fields/fft_friendly/mod.rs
+++ b/crypto/math/src/field/fields/fft_friendly/mod.rs
@@ -2,3 +2,11 @@
 pub mod extensions_goldilocks;
 /// Optimized Goldilocks field p = 2^64 - 2^32 + 1 (no Montgomery form)
 pub mod u64_goldilocks;
+
+/// NEON 2-wide packed Goldilocks arithmetic
+#[cfg(target_arch = "aarch64")]
+pub mod goldilocks_neon;
+
+/// AVX2 4-wide packed Goldilocks arithmetic
+#[cfg(target_arch = "x86_64")]
+pub mod goldilocks_avx2;

--- a/crypto/math/src/tests/fft_friendly_u64_goldilocks_tests.rs
+++ b/crypto/math/src/tests/fft_friendly_u64_goldilocks_tests.rs
@@ -100,7 +100,7 @@ mod fft_tests {
         input.iter().map(|x| poly.evaluate(x)).collect()
     }
 
-    fn gen_fft_and_naive_evaluation<F: IsFFTField + Send + Sync>(
+    fn gen_fft_and_naive_evaluation<F: IsFFTField + Send + Sync + 'static>(
         poly: Polynomial<FieldElement<F>>,
     ) -> (Vec<FieldElement<F>>, Vec<FieldElement<F>>) {
         let len = poly.coeff_len().next_power_of_two();
@@ -114,7 +114,7 @@ mod fft_tests {
         (fft_eval, naive_eval)
     }
 
-    fn gen_fft_coset_and_naive_evaluation<F: IsFFTField + Send + Sync>(
+    fn gen_fft_coset_and_naive_evaluation<F: IsFFTField + Send + Sync + 'static>(
         poly: Polynomial<FieldElement<F>>,
         offset: FieldElement<F>,
         blowup_factor: usize,
@@ -131,7 +131,7 @@ mod fft_tests {
         (fft_eval, naive_eval)
     }
 
-    fn gen_fft_and_naive_interpolate<F: IsFFTField + Send + Sync>(
+    fn gen_fft_and_naive_interpolate<F: IsFFTField + Send + Sync + 'static>(
         fft_evals: &[FieldElement<F>],
     ) -> (Polynomial<FieldElement<F>>, Polynomial<FieldElement<F>>) {
         let order = fft_evals.len().trailing_zeros() as u64;
@@ -144,7 +144,7 @@ mod fft_tests {
         (fft_poly, naive_poly)
     }
 
-    fn gen_fft_and_naive_coset_interpolate<F: IsFFTField + Send + Sync>(
+    fn gen_fft_and_naive_coset_interpolate<F: IsFFTField + Send + Sync + 'static>(
         fft_evals: &[FieldElement<F>],
         offset: &FieldElement<F>,
     ) -> (Polynomial<FieldElement<F>>, Polynomial<FieldElement<F>>) {
@@ -157,7 +157,7 @@ mod fft_tests {
         (fft_poly, naive_poly)
     }
 
-    fn gen_fft_interpolate_and_evaluate<F: IsFFTField + Send + Sync>(
+    fn gen_fft_interpolate_and_evaluate<F: IsFFTField + Send + Sync + 'static>(
         poly: Polynomial<FieldElement<F>>,
     ) -> (Polynomial<FieldElement<F>>, Polynomial<FieldElement<F>>) {
         let eval = Polynomial::evaluate_fft::<F>(&poly, 1, None).unwrap();

--- a/crypto/math/src/tests/fft_tests.rs
+++ b/crypto/math/src/tests/fft_tests.rs
@@ -67,7 +67,7 @@ mod fft_polynomial_tests {
         input.iter().map(|x| poly.evaluate(x)).collect()
     }
 
-    fn gen_fft_and_naive_evaluation<F: IsFFTField + Send + Sync>(
+    fn gen_fft_and_naive_evaluation<F: IsFFTField + Send + Sync + 'static>(
         poly: Polynomial<FieldElement<F>>,
     ) -> (Vec<FieldElement<F>>, Vec<FieldElement<F>>) {
         let len = poly.coeff_len().next_power_of_two();
@@ -81,7 +81,7 @@ mod fft_polynomial_tests {
         (fft_eval, naive_eval)
     }
 
-    fn gen_fft_coset_and_naive_evaluation<F: IsFFTField + Send + Sync>(
+    fn gen_fft_coset_and_naive_evaluation<F: IsFFTField + Send + Sync + 'static>(
         poly: Polynomial<FieldElement<F>>,
         offset: FieldElement<F>,
         blowup_factor: usize,
@@ -98,7 +98,7 @@ mod fft_polynomial_tests {
         (fft_eval, naive_eval)
     }
 
-    fn gen_fft_and_naive_interpolate<F: IsFFTField + Send + Sync>(
+    fn gen_fft_and_naive_interpolate<F: IsFFTField + Send + Sync + 'static>(
         fft_evals: &[FieldElement<F>],
     ) -> (Polynomial<FieldElement<F>>, Polynomial<FieldElement<F>>) {
         let order = fft_evals.len().trailing_zeros() as u64;
@@ -111,7 +111,7 @@ mod fft_polynomial_tests {
         (fft_poly, naive_poly)
     }
 
-    fn gen_fft_and_naive_coset_interpolate<F: IsFFTField + Send + Sync>(
+    fn gen_fft_and_naive_coset_interpolate<F: IsFFTField + Send + Sync + 'static>(
         fft_evals: &[FieldElement<F>],
         offset: &FieldElement<F>,
     ) -> (Polynomial<FieldElement<F>>, Polynomial<FieldElement<F>>) {
@@ -124,7 +124,7 @@ mod fft_polynomial_tests {
         (fft_poly, naive_poly)
     }
 
-    fn gen_fft_interpolate_and_evaluate<F: IsFFTField + Send + Sync>(
+    fn gen_fft_interpolate_and_evaluate<F: IsFFTField + Send + Sync + 'static>(
         poly: Polynomial<FieldElement<F>>,
     ) -> (Polynomial<FieldElement<F>>, Polynomial<FieldElement<F>>) {
         let eval = Polynomial::evaluate_fft::<F>(&poly, 1, None).unwrap();

--- a/crypto/stark/src/constraints/evaluator.rs
+++ b/crypto/stark/src/constraints/evaluator.rs
@@ -31,8 +31,8 @@ pub struct ConstraintEvaluator<
 }
 impl<Field, FieldExtension, PI> ConstraintEvaluator<Field, FieldExtension, PI>
 where
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
 {
     /// Evaluate transition + boundary constraints across the entire LDE domain.
     ///

--- a/crypto/stark/src/constraints/transition.rs
+++ b/crypto/stark/src/constraints/transition.rs
@@ -12,7 +12,7 @@ use math::polynomial::Polynomial;
 /// over the computation that wants to be proven must comply with.
 pub trait TransitionConstraint<F, E>: Send + Sync
 where
-    F: IsSubFieldOf<E> + IsFFTField + Send + Sync,
+    F: IsSubFieldOf<E> + IsFFTField + Send + Sync + 'static,
     E: IsField + Send + Sync,
 {
     /// The degree of the constraint interpreting it as a multivariate polynomial.

--- a/crypto/stark/src/debug.rs
+++ b/crypto/stark/src/debug.rs
@@ -18,8 +18,8 @@ use math::{
 /// Accepts a `TraceTable` directly (no coefficient-form polynomials needed).
 /// The trace table contains the original trace values on the interpolation domain.
 pub fn validate_trace<
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
     PI,
 >(
     air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,

--- a/crypto/stark/src/domain.rs
+++ b/crypto/stark/src/domain.rs
@@ -85,8 +85,8 @@ pub fn new_domain<Field, FieldExtension, PI>(
     trace_length: usize,
 ) -> Domain<Field>
 where
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
 {
     // Initial definitions
     let blowup_factor = air.options().blowup_factor as usize;
@@ -128,8 +128,8 @@ pub fn new_verifier_domain<Field, FieldExtension, PI>(
     trace_length: usize,
 ) -> VerifierDomain<Field>
 where
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
 {
     let blowup_factor = air.options().blowup_factor as usize;
     let coset_offset = FieldElement::from(air.options().coset_offset);

--- a/crypto/stark/src/examples/dummy_air.rs
+++ b/crypto/stark/src/examples/dummy_air.rs
@@ -31,7 +31,7 @@ impl<F: IsFFTField> FibConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for FibConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         1
@@ -93,7 +93,7 @@ impl<F: IsFFTField> BitConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for BitConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         2
@@ -204,7 +204,7 @@ impl AIR for DummyAIR {
     }
 }
 
-pub fn dummy_trace<F: IsFFTField>(trace_length: usize) -> TraceTable<F, F> {
+pub fn dummy_trace<F: IsFFTField + 'static>(trace_length: usize) -> TraceTable<F, F> {
     let mut ret: Vec<FieldElement<F>> = vec![];
 
     let a0 = FieldElement::one();

--- a/crypto/stark/src/examples/fibonacci_2_cols_shifted.rs
+++ b/crypto/stark/src/examples/fibonacci_2_cols_shifted.rs
@@ -29,7 +29,7 @@ impl<F: IsFFTField> ShiftedFibTransition1<F> {
 
 impl<F> TransitionConstraint<F, F> for ShiftedFibTransition1<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         1
@@ -90,7 +90,7 @@ impl<F: IsFFTField> ShiftedFibTransition2<F> {
 
 impl<F> TransitionConstraint<F, F> for ShiftedFibTransition2<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         1
@@ -239,7 +239,7 @@ where
     }
 }
 
-pub fn compute_trace<F: IsFFTField>(
+pub fn compute_trace<F: IsFFTField + 'static>(
     initial_value: FieldElement<F>,
     trace_length: usize,
 ) -> TraceTable<F, F> {

--- a/crypto/stark/src/examples/fibonacci_2_columns.rs
+++ b/crypto/stark/src/examples/fibonacci_2_columns.rs
@@ -28,7 +28,7 @@ impl<F: IsFFTField> FibTransition1<F> {
 
 impl<F> TransitionConstraint<F, F> for FibTransition1<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         1
@@ -91,7 +91,7 @@ impl<F: IsFFTField> FibTransition2<F> {
 
 impl<F> TransitionConstraint<F, F> for FibTransition2<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         1
@@ -210,7 +210,7 @@ where
     }
 }
 
-pub fn compute_trace<F: IsFFTField>(
+pub fn compute_trace<F: IsFFTField + 'static>(
     initial_values: [FieldElement<F>; 2],
     trace_length: usize,
 ) -> TraceTable<F, F> {

--- a/crypto/stark/src/examples/fibonacci_multi_column.rs
+++ b/crypto/stark/src/examples/fibonacci_multi_column.rs
@@ -46,7 +46,7 @@ where
 
 impl<F, E> TransitionConstraint<F, E> for FibColumnConstraint<F, E>
 where
-    F: IsSubFieldOf<E> + IsFFTField + Send + Sync,
+    F: IsSubFieldOf<E> + IsFFTField + Send + Sync + 'static,
     E: IsField + Send + Sync,
 {
     fn degree(&self) -> usize {
@@ -239,7 +239,7 @@ pub fn compute_trace<F, E>(
     trace_length: usize,
 ) -> TraceTable<F, E>
 where
-    F: IsSubFieldOf<E> + IsFFTField + Send + Sync,
+    F: IsSubFieldOf<E> + IsFFTField + Send + Sync + 'static,
     E: IsField + Send + Sync,
 {
     let num_columns = initial_values.len();

--- a/crypto/stark/src/examples/fibonacci_rap.rs
+++ b/crypto/stark/src/examples/fibonacci_rap.rs
@@ -32,7 +32,7 @@ impl<F: IsFFTField> FibConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for FibConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         1
@@ -97,7 +97,7 @@ impl<F: IsFFTField> PermutationConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for PermutationConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         2
@@ -278,7 +278,7 @@ where
     }
 }
 
-pub fn fibonacci_rap_trace<F: IsFFTField>(
+pub fn fibonacci_rap_trace<F: IsFFTField + 'static>(
     initial_values: [FieldElement<F>; 2],
     trace_length: usize,
 ) -> TraceTable<F, F> {

--- a/crypto/stark/src/examples/quadratic_air.rs
+++ b/crypto/stark/src/examples/quadratic_air.rs
@@ -27,7 +27,7 @@ impl<F: IsFFTField> QuadraticConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for QuadraticConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         2
@@ -149,7 +149,7 @@ where
     }
 }
 
-pub fn quadratic_trace<F: IsFFTField>(
+pub fn quadratic_trace<F: IsFFTField + 'static>(
     initial_value: FieldElement<F>,
     trace_length: usize,
 ) -> TraceTable<F, F> {

--- a/crypto/stark/src/examples/read_only_memory.rs
+++ b/crypto/stark/src/examples/read_only_memory.rs
@@ -34,7 +34,7 @@ impl<F: IsFFTField> ContinuityConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for ContinuityConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         2
@@ -100,7 +100,7 @@ impl<F: IsFFTField> SingleValueConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for SingleValueConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         2
@@ -168,7 +168,7 @@ impl<F: IsFFTField> PermutationConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for PermutationConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         2
@@ -379,7 +379,7 @@ where
 
 /// Given the adress and value columns, it returns the trace table with 5 columns, which are:
 /// Addres, Value, Adress Sorted, Value Sorted and a Column of Zeroes (where we'll insert the auxiliary colunn).
-pub fn sort_rap_trace<F: IsFFTField + IsPrimeField>(
+pub fn sort_rap_trace<F: IsFFTField + IsPrimeField + 'static>(
     address: Vec<FieldElement<F>>,
     value: Vec<FieldElement<F>>,
 ) -> TraceTable<F, F> {

--- a/crypto/stark/src/examples/read_only_memory_logup.rs
+++ b/crypto/stark/src/examples/read_only_memory_logup.rs
@@ -47,7 +47,7 @@ where
 
 impl<F, E> TransitionConstraint<F, E> for ContinuityConstraint<F, E>
 where
-    F: IsFFTField + IsSubFieldOf<E> + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static,
     E: IsField + Send + Sync,
 {
     fn degree(&self) -> usize {
@@ -141,7 +141,7 @@ where
 
 impl<F, E> TransitionConstraint<F, E> for SingleValueConstraint<F, E>
 where
-    F: IsFFTField + IsSubFieldOf<E> + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static,
     E: IsField + Send + Sync,
 {
     fn degree(&self) -> usize {
@@ -242,7 +242,7 @@ where
 
 impl<F, E> TransitionConstraint<F, E> for PermutationConstraint<F, E>
 where
-    F: IsSubFieldOf<E> + IsFFTField + Send + Sync,
+    F: IsSubFieldOf<E> + IsFFTField + Send + Sync + 'static,
     E: IsField + Send + Sync,
 {
     fn degree(&self) -> usize {
@@ -526,7 +526,7 @@ where
 /// the multiplicities of each sorted address and value in the original ones (i.e. how many times
 /// they appear in the original address an value columns).
 pub fn read_only_logup_trace<
-    F: IsPrimeField + IsFFTField + IsSubFieldOf<E> + Send + Sync,
+    F: IsPrimeField + IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static,
     E: IsField + Send + Sync,
 >(
     addresses: Vec<FieldElement<F>>,

--- a/crypto/stark/src/examples/simple_addition.rs
+++ b/crypto/stark/src/examples/simple_addition.rs
@@ -32,7 +32,7 @@ impl<F: IsFFTField> AdditionConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for AdditionConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         1
@@ -165,7 +165,7 @@ where
 
 /// Creates a trace table with `num_rows` rows where each row satisfies col0 + col1 = col2.
 /// The values are: row i has col0=i+1, col1=i+2, col2=2i+3
-pub fn simple_addition_trace<F: IsFFTField>(num_rows: usize) -> TraceTable<F, F> {
+pub fn simple_addition_trace<F: IsFFTField + 'static>(num_rows: usize) -> TraceTable<F, F> {
     let mut col0 = Vec::with_capacity(num_rows);
     let mut col1 = Vec::with_capacity(num_rows);
     let mut col2 = Vec::with_capacity(num_rows);

--- a/crypto/stark/src/examples/simple_fibonacci.rs
+++ b/crypto/stark/src/examples/simple_fibonacci.rs
@@ -26,7 +26,7 @@ impl<F: IsFFTField> FibConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for FibConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         1
@@ -150,7 +150,7 @@ where
     }
 }
 
-pub fn fibonacci_trace<F: IsFFTField>(
+pub fn fibonacci_trace<F: IsFFTField + 'static>(
     initial_values: [FieldElement<F>; 2],
     trace_length: usize,
 ) -> TraceTable<F, F> {

--- a/crypto/stark/src/examples/simple_periodic_cols.rs
+++ b/crypto/stark/src/examples/simple_periodic_cols.rs
@@ -30,7 +30,7 @@ impl<F: IsFFTField> Default for PeriodicConstraint<F> {
 
 impl<F> TransitionConstraint<F, F> for PeriodicConstraint<F>
 where
-    F: IsFFTField + Send + Sync,
+    F: IsFFTField + Send + Sync + 'static,
 {
     fn degree(&self) -> usize {
         1
@@ -175,7 +175,7 @@ where
     }
 }
 
-pub fn simple_periodic_trace<F: IsFFTField>(trace_length: usize) -> TraceTable<F, F> {
+pub fn simple_periodic_trace<F: IsFFTField + 'static>(trace_length: usize) -> TraceTable<F, F> {
     let mut ret: Vec<FieldElement<F>> = vec![];
 
     ret.push(FieldElement::one());

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -786,8 +786,8 @@ impl<
 
 impl<F, E, B, PI> crate::traits::AIR for AirWithBuses<F, E, B, PI>
 where
-    F: IsFFTField + IsSubFieldOf<E> + IsPrimeField + Send + Sync,
-    E: IsField + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + IsPrimeField + Send + Sync + 'static,
+    E: IsField + Send + Sync + 'static,
     B: BoundaryConstraintBuilder<F, E, PI>,
     PI: Send + Sync,
 {
@@ -1330,7 +1330,7 @@ fn build_accumulated_column_from_terms<F, E>(
     term_columns: &[Vec<FieldElement<E>>],
     trace: &mut TraceTable<F, E>,
 ) where
-    F: IsFFTField + IsSubFieldOf<E> + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static,
     E: IsField + Send + Sync,
 {
     if term_columns.is_empty() {
@@ -1421,7 +1421,7 @@ impl LookupTermConstraint {
 
 impl<F, E> TransitionConstraint<F, E> for LookupTermConstraint
 where
-    F: IsFFTField + IsSubFieldOf<E> + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static,
     E: IsField + Send + Sync,
 {
     fn degree(&self) -> usize {
@@ -1728,7 +1728,7 @@ impl LookupAccumulatedConstraint {
 
 impl<F, E> TransitionConstraint<F, E> for LookupAccumulatedConstraint
 where
-    F: IsFFTField + IsSubFieldOf<E> + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static,
     E: IsField + Send + Sync,
 {
     fn degree(&self) -> usize {

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1361,7 +1361,7 @@ fn compute_debug_bus_sums<F, E>(
     HashMap<u64, FieldElement<E>>,
 )
 where
-    F: IsFFTField + IsSubFieldOf<E> + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + Send + Sync + 'static,
     E: IsField + Send + Sync,
 {
     let mut bus_sums: HashMap<u64, FieldElement<E>> = HashMap::new();

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -50,16 +50,16 @@ type AirTracePair<'a, Field, FieldExtension, PI> = (
 
 /// A default STARK prover implementing `IsStarkProver`.
 pub struct Prover<
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
     PI,
 > {
     p: PhantomData<(Field, FieldExtension, PI)>,
 }
 
 impl<
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
     PI,
 > IsStarkProver<Field, FieldExtension, PI> for Prover<Field, FieldExtension, PI>
 {
@@ -249,8 +249,8 @@ pub fn evaluate_polynomial_on_lde_domain<F, E>(
     offset: &FieldElement<F>,
 ) -> Result<Vec<FieldElement<E>>, FFTError>
 where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField + Send + Sync,
+    F: IsFFTField + IsSubFieldOf<E> + 'static,
+    E: IsField + Send + Sync + 'static,
 {
     let evaluations = Polynomial::evaluate_offset_fft(p, blowup_factor, Some(domain_size), offset)?;
     let step = evaluations.len() / (domain_size * blowup_factor);
@@ -265,8 +265,8 @@ where
 /// The default implementation is complete and is compatible with Stone prover
 /// https://github.com/starkware-libs/stone-prover
 pub trait IsStarkProver<
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
     PI,
 >
 {
@@ -358,7 +358,7 @@ pub trait IsStarkProver<
         twiddles: &LdeTwiddles<Field>,
     ) -> Vec<Vec<FieldElement<E>>>
     where
-        E: IsSubFieldOf<FieldExtension> + Send + Sync,
+        E: IsSubFieldOf<FieldExtension> + Send + Sync + 'static,
         Field: IsSubFieldOf<E>,
         FieldElement<E>: Send + Sync,
     {
@@ -397,7 +397,7 @@ pub trait IsStarkProver<
         twiddles: &LdeTwiddles<Field>,
     ) where
         Field: IsSubFieldOf<E>,
-        E: IsSubFieldOf<FieldExtension> + IsField + Send + Sync,
+        E: IsSubFieldOf<FieldExtension> + IsField + Send + Sync + 'static,
         FieldElement<E>: Send + Sync,
     {
         if num_cols == 0 {

--- a/crypto/stark/src/trace.rs
+++ b/crypto/stark/src/trace.rs
@@ -37,7 +37,7 @@ where
 impl<F, E> TraceTable<F, E>
 where
     E: IsField,
-    F: IsSubFieldOf<E> + IsFFTField,
+    F: IsSubFieldOf<E> + IsFFTField + 'static,
 {
     /// Creates a new TraceTable from from a one-dimensional array in row major order and the intended width of the table.
     /// Step size is how many are needed to represent a state of the VM
@@ -152,7 +152,7 @@ where
 
     pub fn compute_trace_polys_main<S>(&self) -> Vec<Polynomial<FieldElement<F>>>
     where
-        S: IsFFTField + IsSubFieldOf<F>,
+        S: IsFFTField + IsSubFieldOf<F> + 'static,
         F: Send + Sync,
         FieldElement<F>: Send + Sync,
     {

--- a/crypto/stark/src/traits.rs
+++ b/crypto/stark/src/traits.rs
@@ -122,8 +122,8 @@ where
 
 /// AIR is a representation of the Constraints
 pub trait AIR: Send + Sync {
-    type Field: IsFFTField + IsSubFieldOf<Self::FieldExtension> + Send + Sync;
-    type FieldExtension: IsField + Send + Sync;
+    type Field: IsFFTField + IsSubFieldOf<Self::FieldExtension> + Send + Sync + 'static;
+    type FieldExtension: IsField + Send + Sync + 'static;
     type PublicInputs;
 
     fn step_size(&self) -> usize;

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -31,16 +31,16 @@ use std::time::Instant;
 
 /// A default STARK verifier implementing `IsStarkVerifier`.
 pub struct Verifier<
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
     PI,
 > {
     phantom: PhantomData<(Field, FieldExtension, PI)>,
 }
 
 impl<
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: IsField + Send + Sync,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: IsField + Send + Sync + 'static,
     PI,
 > IsStarkVerifier<Field, FieldExtension, PI> for Verifier<Field, FieldExtension, PI>
 {
@@ -77,8 +77,8 @@ pub type DeepPolynomialEvaluations<F> = (Vec<FieldElement<F>>, Vec<FieldElement<
 /// The functionality of a STARK verifier providing methods to run the STARK Verify protocol
 /// https://lambdaclass.github.io/lambdaworks/starks/protocol.html
 pub trait IsStarkVerifier<
-    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
-    FieldExtension: Send + Sync + IsField,
+    Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync + 'static,
+    FieldExtension: Send + Sync + IsField + 'static,
     PI,
 >
 {


### PR DESCRIPTION
TypeId dispatch in the FFT butterfly helpers (`process_fused_block`, `process_single_layer_block`, `process_ifft_single_layer_block`). When `F=E=GoldilocksField` on a supported arch, casts `&mut [FieldElement<E>]` to `&mut [u64]` via `#[repr(transparent)]` and calls SIMD kernels. The TypeId comparison is a compile-time constant after monomorphization — zero runtime cost for non-Goldilocks fields.

- **NEON (aarch64)**: 2-wide `PackedGoldilocks2` — processes 2 butterflies per iteration
- **AVX2 (x86_64)**: 4-wide `PackedGoldilocks4` — processes 4 butterflies per iteration
- Scalar tail handles remainders when `half_block` is not a multiple of the SIMD width
- Both parallel and sequential FFT paths get SIMD (fallback loops now route through the helper functions)
- `'static` bounds propagated through the FFT call chain (all concrete callers already use `'static` types)