### PR TITLE
AVX2 LogUp fingerprint optimization for Phase C

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -117,7 +117,7 @@ jobs:
           for i in $(seq 1 $RUNS); do
             echo "--- Run $i/$RUNS ---"
             ./target/release/cli prove "$ELF" -o /tmp/proof.bin --time \
-              2>&1 | tee /tmp/cli_output_$i.txt
+              | tee /tmp/cli_output_$i.txt
             rm -f /tmp/proof.bin
 
             T=$(grep -o 'Proving time: [0-9.]*' /tmp/cli_output_$i.txt | awk '{print $3}')
@@ -155,15 +155,6 @@ jobs:
           ALL_TIMES=$(echo $TIMES | tr ' ' '\n' | paste -sd '/' -)
           ALL_HEAPS=$(echo $HEAPS | tr ' ' '\n' | paste -sd '/' -)
 
-          # Detect AVX2 usage from CLI output
-          if grep -q '\[BENCH\] LogUp fingerprints: AVX2' /tmp/cli_output_1.txt; then
-            LOGUP_SIMD="AVX2"
-          elif grep -q '\[BENCH\] LogUp fingerprints: scalar' /tmp/cli_output_1.txt; then
-            LOGUP_SIMD="scalar"
-          else
-            LOGUP_SIMD="unknown"
-          fi
-
           echo "peak_mb=$HEAP_MEDIAN" >> "$GITHUB_OUTPUT"
           echo "time_s=$TIME_MEDIAN" >> "$GITHUB_OUTPUT"
           echo "time_spread=$TIME_SPREAD" >> "$GITHUB_OUTPUT"
@@ -171,7 +162,6 @@ jobs:
           echo "all_times=$ALL_TIMES" >> "$GITHUB_OUTPUT"
           echo "all_heaps=$ALL_HEAPS" >> "$GITHUB_OUTPUT"
           echo "runs=$RUNS" >> "$GITHUB_OUTPUT"
-          echo "logup_simd=$LOGUP_SIMD" >> "$GITHUB_OUTPUT"
 
           echo "peak_mb=$HEAP_MEDIAN" > /tmp/metrics.txt
           echo "time_s=$TIME_MEDIAN" >> /tmp/metrics.txt
@@ -427,8 +417,7 @@ jobs:
             }
 
             const sha = '${{ steps.pr-ref.outputs.sha || github.sha }}'.substring(0, 8);
-            const logupSimd = '${{ steps.pr.outputs.logup_simd }}';
-            body += `\n<sub>Commit: ${sha} · Baseline: ${baseSrc} · Runner: self-hosted bench · LogUp SIMD: ${logupSimd}</sub>\n`;
+            body += `\n<sub>Commit: ${sha} · Baseline: ${baseSrc} · Runner: self-hosted bench</sub>\n`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -117,7 +117,7 @@ jobs:
           for i in $(seq 1 $RUNS); do
             echo "--- Run $i/$RUNS ---"
             ./target/release/cli prove "$ELF" -o /tmp/proof.bin --time \
-              | tee /tmp/cli_output_$i.txt
+              2>&1 | tee /tmp/cli_output_$i.txt
             rm -f /tmp/proof.bin
 
             T=$(grep -o 'Proving time: [0-9.]*' /tmp/cli_output_$i.txt | awk '{print $3}')
@@ -155,6 +155,15 @@ jobs:
           ALL_TIMES=$(echo $TIMES | tr ' ' '\n' | paste -sd '/' -)
           ALL_HEAPS=$(echo $HEAPS | tr ' ' '\n' | paste -sd '/' -)
 
+          # Detect AVX2 usage from CLI output
+          if grep -q '\[BENCH\] LogUp fingerprints: AVX2' /tmp/cli_output_1.txt; then
+            LOGUP_SIMD="AVX2"
+          elif grep -q '\[BENCH\] LogUp fingerprints: scalar' /tmp/cli_output_1.txt; then
+            LOGUP_SIMD="scalar"
+          else
+            LOGUP_SIMD="unknown"
+          fi
+
           echo "peak_mb=$HEAP_MEDIAN" >> "$GITHUB_OUTPUT"
           echo "time_s=$TIME_MEDIAN" >> "$GITHUB_OUTPUT"
           echo "time_spread=$TIME_SPREAD" >> "$GITHUB_OUTPUT"
@@ -162,6 +171,7 @@ jobs:
           echo "all_times=$ALL_TIMES" >> "$GITHUB_OUTPUT"
           echo "all_heaps=$ALL_HEAPS" >> "$GITHUB_OUTPUT"
           echo "runs=$RUNS" >> "$GITHUB_OUTPUT"
+          echo "logup_simd=$LOGUP_SIMD" >> "$GITHUB_OUTPUT"
 
           echo "peak_mb=$HEAP_MEDIAN" > /tmp/metrics.txt
           echo "time_s=$TIME_MEDIAN" >> /tmp/metrics.txt
@@ -417,7 +427,8 @@ jobs:
             }
 
             const sha = '${{ steps.pr-ref.outputs.sha || github.sha }}'.substring(0, 8);
-            body += `\n<sub>Commit: ${sha} · Baseline: ${baseSrc} · Runner: self-hosted bench</sub>\n`;
+            const logupSimd = '${{ steps.pr.outputs.logup_simd }}';
+            body += `\n<sub>Commit: ${sha} · Baseline: ${baseSrc} · Runner: self-hosted bench · LogUp SIMD: ${logupSimd}</sub>\n`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/crypto/math/src/field/element.rs
+++ b/crypto/math/src/field/element.rs
@@ -56,19 +56,33 @@ impl<F: IsField> FieldElement<F> {
         if numbers.is_empty() {
             return Ok(());
         }
+
+        // Cache-tiled Montgomery's trick: process in blocks that fit L2 cache.
+        // 32K elements × 2 arrays (numbers + prod_prefix) × 24 bytes ≈ 1.5 MB.
+        const BLOCK_SIZE: usize = 32 * 1024;
+
         let count = numbers.len();
-        let mut prod_prefix = alloc::vec::Vec::with_capacity(count);
-        prod_prefix.push(numbers[0].clone());
-        for i in 1..count {
-            prod_prefix.push(&prod_prefix[i - 1] * &numbers[i]);
+        let mut prod_prefix = alloc::vec::Vec::with_capacity(count.min(BLOCK_SIZE));
+
+        for block_start in (0..count).step_by(BLOCK_SIZE) {
+            let block_end = (block_start + BLOCK_SIZE).min(count);
+            let block = &mut numbers[block_start..block_end];
+            let block_len = block.len();
+
+            prod_prefix.clear();
+            prod_prefix.push(block[0].clone());
+            for i in 1..block_len {
+                prod_prefix.push(&prod_prefix[i - 1] * &block[i]);
+            }
+
+            let mut bi_inv = prod_prefix[block_len - 1].inv()?;
+            for i in (1..block_len).rev() {
+                let ai_inv = &bi_inv * &prod_prefix[i - 1];
+                bi_inv = &bi_inv * &block[i];
+                block[i] = ai_inv;
+            }
+            block[0] = bi_inv;
         }
-        let mut bi_inv = prod_prefix[count - 1].inv()?;
-        for i in (1..count).rev() {
-            let ai_inv = &bi_inv * &prod_prefix[i - 1];
-            bi_inv = &bi_inv * &numbers[i];
-            numbers[i] = ai_inv;
-        }
-        numbers[0] = bi_inv;
         Ok(())
     }
 

--- a/crypto/math/src/field/element.rs
+++ b/crypto/math/src/field/element.rs
@@ -41,6 +41,7 @@ use super::traits::{IsPrimeField, IsSubFieldOf, LegendreSymbol};
 /// A field element with operations algorithms defined in `F`
 #[allow(clippy::derived_hash_with_manual_eq)]
 #[derive(Debug, Clone, Hash, Copy)]
+#[repr(transparent)]
 pub struct FieldElement<F: IsField> {
     value: F::BaseType,
 }

--- a/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
+++ b/crypto/math/src/field/fields/fft_friendly/goldilocks_avx2.rs
@@ -1,0 +1,310 @@
+//! AVX2-accelerated Goldilocks field arithmetic operating on 4 packed u64 elements.
+//!
+//! Each `__m256i` holds 4 Goldilocks field elements (4 × u64).
+//! All functions require the `avx2` target feature.
+//!
+//! The reduction strategy mirrors the scalar `u64_goldilocks.rs` implementation,
+//! but the multiplication uses 32-bit schoolbook decomposition (since x86 lacks
+//! a 64×64→128 SIMD multiply) following the approach from Plonky3.
+
+use core::arch::x86_64::*;
+
+use super::u64_goldilocks::GOLDILOCKS_PRIME;
+
+const EPSILON: u64 = 0xFFFF_FFFF;
+
+/// Add 4 packed Goldilocks elements: a + b mod p.
+///
+/// If a + b overflows u64, we add EPSILON (since 2^64 ≡ EPSILON mod p).
+///
+/// # Safety
+/// Caller must ensure AVX2 is available (`is_x86_feature_detected!("avx2")`).
+#[inline]
+#[target_feature(enable = "avx2")]
+pub unsafe fn add4(a: __m256i, b: __m256i) -> __m256i {
+    let eps = _mm256_set1_epi64x(EPSILON as i64);
+    let sign_bit = _mm256_set1_epi64x(i64::MIN);
+
+    let sum = _mm256_add_epi64(a, b);
+    // Unsigned overflow detection via signed compare with flipped sign bits.
+    let overflow = _mm256_cmpgt_epi64(
+        _mm256_xor_si256(a, sign_bit),
+        _mm256_xor_si256(sum, sign_bit),
+    );
+    let result = _mm256_add_epi64(sum, _mm256_and_si256(overflow, eps));
+    // Handle rare second overflow
+    let overflow2 = _mm256_cmpgt_epi64(
+        _mm256_xor_si256(sum, sign_bit),
+        _mm256_xor_si256(result, sign_bit),
+    );
+    _mm256_add_epi64(result, _mm256_and_si256(overflow2, eps))
+}
+
+/// Subtract 4 packed Goldilocks elements: a - b mod p.
+///
+/// If a - b underflows, we subtract EPSILON (since -2^64 ≡ -EPSILON mod p).
+///
+/// # Safety
+/// Caller must ensure AVX2 is available (`is_x86_feature_detected!("avx2")`).
+#[inline]
+#[target_feature(enable = "avx2")]
+pub unsafe fn sub4(a: __m256i, b: __m256i) -> __m256i {
+    let eps = _mm256_set1_epi64x(EPSILON as i64);
+    let sign_bit = _mm256_set1_epi64x(i64::MIN);
+
+    let diff = _mm256_sub_epi64(a, b);
+    // Underflow where b > a (unsigned)
+    let underflow =
+        _mm256_cmpgt_epi64(_mm256_xor_si256(b, sign_bit), _mm256_xor_si256(a, sign_bit));
+    let result = _mm256_sub_epi64(diff, _mm256_and_si256(underflow, eps));
+    // Handle rare second underflow
+    let underflow2 = _mm256_cmpgt_epi64(
+        _mm256_xor_si256(result, sign_bit),
+        _mm256_xor_si256(diff, sign_bit),
+    );
+    _mm256_sub_epi64(result, _mm256_and_si256(underflow2, eps))
+}
+
+/// Negate 4 packed Goldilocks elements: p - a mod p.
+///
+/// # Safety
+/// Caller must ensure AVX2 is available (`is_x86_feature_detected!("avx2")`).
+#[inline]
+#[target_feature(enable = "avx2")]
+pub unsafe fn neg4(a: __m256i) -> __m256i {
+    unsafe { sub4(_mm256_set1_epi64x(GOLDILOCKS_PRIME as i64), a) }
+}
+
+/// Multiply 4 packed Goldilocks elements using 32-bit schoolbook decomposition.
+///
+/// Since AVX2 has no 64×64→128 multiply, we decompose each u64 into two u32 halves
+/// and use `_mm256_mul_epu32` (32×32→64 unsigned multiply).
+///
+/// # Safety
+/// Caller must ensure AVX2 is available (`is_x86_feature_detected!("avx2")`).
+#[inline]
+#[target_feature(enable = "avx2")]
+pub unsafe fn mul4(a: __m256i, b: __m256i) -> __m256i {
+    unsafe {
+        let sign_bit = _mm256_set1_epi64x(i64::MIN);
+
+        let a_hi = _mm256_srli_epi64(a, 32);
+        let b_hi = _mm256_srli_epi64(b, 32);
+
+        // Four 32×32→64 products
+        let ll = _mm256_mul_epu32(a, b);
+        let lh = _mm256_mul_epu32(a, b_hi);
+        let hl = _mm256_mul_epu32(a_hi, b);
+        let hh = _mm256_mul_epu32(a_hi, b_hi);
+
+        // Middle sum with carry detection
+        let mid = _mm256_add_epi64(lh, hl);
+        let mid_carry = _mm256_cmpgt_epi64(
+            _mm256_xor_si256(lh, sign_bit),
+            _mm256_xor_si256(mid, sign_bit),
+        );
+        let mid_carry_val = _mm256_srli_epi64(mid_carry, 63);
+
+        // Split middle into low 32 and high 32
+        let mid_lo = _mm256_slli_epi64(mid, 32);
+        let mid_hi = _mm256_srli_epi64(mid, 32);
+
+        // result_lo = ll + (mid_lo_32 << 32), with carry detection
+        let res_lo = _mm256_add_epi64(ll, mid_lo);
+        let lo_carry = _mm256_cmpgt_epi64(
+            _mm256_xor_si256(ll, sign_bit),
+            _mm256_xor_si256(res_lo, sign_bit),
+        );
+        let lo_carry_val = _mm256_srli_epi64(lo_carry, 63);
+
+        // result_hi = hh + mid_hi + lo_carry + (mid_carry << 32)
+        let mid_carry_shifted = _mm256_slli_epi64(mid_carry_val, 32);
+        let res_hi = _mm256_add_epi64(
+            _mm256_add_epi64(hh, mid_hi),
+            _mm256_add_epi64(lo_carry_val, mid_carry_shifted),
+        );
+
+        reduce(res_lo, res_hi)
+    }
+}
+
+/// Reduce a 128-bit value (lo + hi * 2^64) to a Goldilocks field element.
+///
+/// hi = hi_hi * 2^32 + hi_lo
+/// lo + hi * 2^64 ≡ lo + hi_lo * EPSILON - hi_hi (mod p)
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn reduce(lo: __m256i, hi: __m256i) -> __m256i {
+    unsafe {
+        let lo_mask = _mm256_set1_epi64x(0xFFFFFFFF);
+        let hi_hi = _mm256_srli_epi64(hi, 32);
+        let hi_lo = _mm256_and_si256(hi, lo_mask);
+
+        // t0 = lo - hi_hi
+        let t0 = sub4(lo, hi_hi);
+
+        // t1 = hi_lo * EPSILON = (hi_lo << 32) - hi_lo
+        let t1 = _mm256_sub_epi64(_mm256_slli_epi64(hi_lo, 32), hi_lo);
+
+        add4(t0, t1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::field::fields::fft_friendly::u64_goldilocks::GoldilocksField;
+    use crate::field::traits::IsField;
+
+    unsafe fn load4(a: [u64; 4]) -> __m256i {
+        unsafe { _mm256_loadu_si256(a.as_ptr() as *const __m256i) }
+    }
+
+    unsafe fn store4(v: __m256i) -> [u64; 4] {
+        let mut out = [0u64; 4];
+        unsafe { _mm256_storeu_si256(out.as_mut_ptr() as *mut __m256i, v) };
+        out
+    }
+
+    fn canon(x: u64) -> u64 {
+        if x >= GOLDILOCKS_PRIME {
+            x - GOLDILOCKS_PRIME
+        } else {
+            x
+        }
+    }
+
+    #[test]
+    fn test_add4() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let cases: [(u64, u64); 5] = [
+            (5, 7),
+            (GOLDILOCKS_PRIME - 1, 2),
+            (GOLDILOCKS_PRIME - 1, GOLDILOCKS_PRIME - 1),
+            (0, 0),
+            (1 << 40, 1 << 40),
+        ];
+        for (a_val, b_val) in cases {
+            let expected = canon(GoldilocksField::add(&a_val, &b_val));
+            unsafe {
+                let a = _mm256_set1_epi64x(a_val as i64);
+                let b = _mm256_set1_epi64x(b_val as i64);
+                let result = store4(add4(a, b));
+                for (lane, &val) in result.iter().enumerate() {
+                    assert_eq!(
+                        canon(val),
+                        expected,
+                        "add4 mismatch for a={a_val}, b={b_val}, lane={lane}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_sub4() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let cases: [(u64, u64); 5] = [
+            (10, 3),
+            (3, 10),
+            (0, GOLDILOCKS_PRIME - 1),
+            (GOLDILOCKS_PRIME - 1, 0),
+            (1 << 40, 1 << 40),
+        ];
+        for (a_val, b_val) in cases {
+            let expected = canon(GoldilocksField::sub(&a_val, &b_val));
+            unsafe {
+                let a = _mm256_set1_epi64x(a_val as i64);
+                let b = _mm256_set1_epi64x(b_val as i64);
+                let result = store4(sub4(a, b));
+                for (lane, &val) in result.iter().enumerate() {
+                    assert_eq!(
+                        canon(val),
+                        expected,
+                        "sub4 mismatch for a={a_val}, b={b_val}, lane={lane}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_neg4() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let cases: [u64; 5] = [0, 1, 5, GOLDILOCKS_PRIME - 1, 0xDEADBEEF];
+        for a_val in cases {
+            let expected = canon(GoldilocksField::neg(&a_val));
+            unsafe {
+                let a = _mm256_set1_epi64x(a_val as i64);
+                let result = store4(neg4(a));
+                for (lane, &val) in result.iter().enumerate() {
+                    assert_eq!(
+                        canon(val),
+                        expected,
+                        "neg4 mismatch for a={a_val}, lane={lane}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_mul4() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let cases: [(u64, u64); 8] = [
+            (5, 7),
+            (0, 12345),
+            (1, GOLDILOCKS_PRIME - 1),
+            (GOLDILOCKS_PRIME - 1, GOLDILOCKS_PRIME - 1),
+            (1 << 40, 1 << 40),
+            (0xDEADBEEF, 0xCAFEBABE),
+            (GOLDILOCKS_PRIME - 1, 2),
+            (0x1234_5678_9ABC_DEF0, 0xFEDC_BA98_7654_3210),
+        ];
+        for (a_val, b_val) in cases {
+            let expected = canon(GoldilocksField::mul(&a_val, &b_val));
+            unsafe {
+                let a = _mm256_set1_epi64x(a_val as i64);
+                let b = _mm256_set1_epi64x(b_val as i64);
+                let result = store4(mul4(a, b));
+                for (lane, &val) in result.iter().enumerate() {
+                    assert_eq!(
+                        canon(val),
+                        expected,
+                        "mul4 mismatch for a={a_val:#x}, b={b_val:#x}, lane={lane}: got {val:#x}, expected {expected:#x}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_mul4_heterogeneous_lanes() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let a_vals = [5u64, 1 << 40, GOLDILOCKS_PRIME - 1, 0xDEADBEEF];
+        let b_vals = [7u64, 1 << 40, 2, 0xCAFEBABE];
+        unsafe {
+            let a = load4(a_vals);
+            let b = load4(b_vals);
+            let result = store4(mul4(a, b));
+            for (lane, &val) in result.iter().enumerate() {
+                let expected = canon(GoldilocksField::mul(&a_vals[lane], &b_vals[lane]));
+                assert_eq!(
+                    canon(val),
+                    expected,
+                    "mul4 heterogeneous mismatch lane={lane}"
+                );
+            }
+        }
+    }
+}

--- a/crypto/math/src/field/fields/fft_friendly/mod.rs
+++ b/crypto/math/src/field/fields/fft_friendly/mod.rs
@@ -1,4 +1,7 @@
 /// Quadratic and cubic extensions of the Goldilocks field
 pub mod extensions_goldilocks;
+/// AVX2-accelerated Goldilocks arithmetic (4-wide packed operations)
+#[cfg(target_arch = "x86_64")]
+pub mod goldilocks_avx2;
 /// Optimized Goldilocks field p = 2^64 - 2^32 + 1 (no Montgomery form)
 pub mod u64_goldilocks;

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1648,12 +1648,12 @@ where
     let mut fingerprints = if let Some(fp) = avx2_fingerprints {
         use std::sync::Once;
         static PRINT: Once = Once::new();
-        PRINT.call_once(|| eprintln!("[BENCH] LogUp fingerprints: AVX2"));
+        PRINT.call_once(|| println!("[BENCH] LogUp fingerprints: AVX2"));
         fp
     } else {
         use std::sync::Once;
         static PRINT: Once = Once::new();
-        PRINT.call_once(|| eprintln!("[BENCH] LogUp fingerprints: scalar"));
+        PRINT.call_once(|| println!("[BENCH] LogUp fingerprints: scalar"));
         // Scalar fallback: accumulate the linear combination directly
         // into the fingerprint without collecting bus elements into intermediate Vecs.
         let bus_id_f = FieldElement::<F>::from(table_interaction.bus_id);

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1582,13 +1582,6 @@ where
     let num_bus_elements = table_interaction.num_bus_elements();
     let alpha_powers = compute_alpha_powers(alpha, num_bus_elements);
 
-    // Sign: +1 for senders, -1 for receivers
-    let sign = if table_interaction.is_sender {
-        FieldElement::<E>::one()
-    } else {
-        -FieldElement::<E>::one()
-    };
-
     // Batch inversion: collect all fingerprints, invert once, then multiply back.
     // Compute fingerprint = z - (bus_id*α^0 + v0*α^1 + v1*α^2 + ...) using
     // base-field × extension-field multiplication (F×E→E) to avoid to_extension().
@@ -1713,11 +1706,34 @@ where
         .expect("fingerprint is zero - probability of sampling zero is negligible");
 
     // Compute terms: term[i] = sign * multiplicity[i] * fingerprint_inv[i]
-    multiplicities
-        .iter()
-        .zip(fingerprints.iter())
-        .map(|(multiplicity, fingerprint_inv)| multiplicity * &sign * fingerprint_inv)
-        .collect()
+    // Restructured to avoid E×E multiply: the original `m * sign * fp_inv` performs
+    // F×E (3 base muls) then E×E (6 base muls). Instead, do F×E + conditional negate
+    // (3 base muls + ~free), or skip arithmetic entirely when multiplicity is 1.
+    let is_sender = table_interaction.is_sender;
+    match (&table_interaction.multiplicity, is_sender) {
+        (Multiplicity::One, true) => {
+            // term = fp_inv, no arithmetic needed
+            fingerprints
+        }
+        (Multiplicity::One, false) => {
+            for fp in fingerprints.iter_mut() {
+                *fp = -&*fp;
+            }
+            fingerprints
+        }
+        (_, true) => {
+            for (fp, m) in fingerprints.iter_mut().zip(multiplicities.iter()) {
+                *fp = m * &*fp;
+            }
+            fingerprints
+        }
+        (_, false) => {
+            for (fp, m) in fingerprints.iter_mut().zip(multiplicities.iter()) {
+                *fp = -(m * &*fp);
+            }
+            fingerprints
+        }
+    }
 }
 
 /// Builds the accumulated column from pre-computed term columns.

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1173,6 +1173,334 @@ where
 {
 }
 
+// =============================================================================
+// AVX2 Fingerprint Acceleration (x86_64 only)
+// =============================================================================
+
+/// AVX2-accelerated fingerprint computation for Goldilocks cubic extension.
+///
+/// Processes 4 rows simultaneously using 256-bit SIMD. Each F×E multiply
+/// (base field × cubic extension) becomes 3 parallel 4-wide Goldilocks multiplies.
+///
+/// # Arguments
+/// * `bus_element_cols` - Pre-computed bus element columns (column-major, raw u64).
+///   Each inner slice has `trace_len` elements.
+/// * `alpha_powers_raw` - Alpha powers as raw [u64; 3] (cubic extension components).
+/// * `z_raw` - The z challenge as raw [u64; 3].
+/// * `trace_len` - Number of rows.
+///
+/// # Returns
+/// Fingerprints as Vec of [u64; 3] (cubic extension, SoA→AoS converted).
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn compute_fingerprints_avx2(
+    bus_element_cols: &[&[u64]],
+    alpha_powers_raw: &[[u64; 3]],
+    z_raw: [u64; 3],
+    trace_len: usize,
+) -> Vec<[u64; 3]> {
+    use core::arch::x86_64::*;
+    use math::field::fields::fft_friendly::goldilocks_avx2::{add4, mul4, sub4};
+
+    let num_elements = bus_element_cols.len();
+    debug_assert_eq!(alpha_powers_raw.len(), num_elements);
+
+    let chunks = trace_len / 4;
+    let mut result = Vec::with_capacity(trace_len);
+
+    // SAFETY: caller verified AVX2 is available via is_x86_feature_detected
+    unsafe {
+        // Broadcast z components
+        let z0 = _mm256_set1_epi64x(z_raw[0] as i64);
+        let z1 = _mm256_set1_epi64x(z_raw[1] as i64);
+        let z2 = _mm256_set1_epi64x(z_raw[2] as i64);
+
+        // Process 4 rows at a time
+        for chunk in 0..chunks {
+            let base_row = chunk * 4;
+
+            // Accumulators for the linear combination (3 cubic components, 4 rows each)
+            let mut acc0 = _mm256_setzero_si256();
+            let mut acc1 = _mm256_setzero_si256();
+            let mut acc2 = _mm256_setzero_si256();
+
+            for k in 0..num_elements {
+                // Load 4 consecutive base-field values from column k
+                let vals = _mm256_loadu_si256(
+                    bus_element_cols[k].as_ptr().add(base_row) as *const __m256i
+                );
+
+                // Broadcast the 3 cubic components of alpha_powers[k]
+                let ap0 = _mm256_set1_epi64x(alpha_powers_raw[k][0] as i64);
+                let ap1 = _mm256_set1_epi64x(alpha_powers_raw[k][1] as i64);
+                let ap2 = _mm256_set1_epi64x(alpha_powers_raw[k][2] as i64);
+
+                // F×E multiply: val * [ap0, ap1, ap2] = [val*ap0, val*ap1, val*ap2]
+                // Accumulate into acc
+                acc0 = add4(acc0, mul4(vals, ap0));
+                acc1 = add4(acc1, mul4(vals, ap1));
+                acc2 = add4(acc2, mul4(vals, ap2));
+            }
+
+            // fingerprint = z - acc
+            let fp0 = sub4(z0, acc0);
+            let fp1 = sub4(z1, acc1);
+            let fp2 = sub4(z2, acc2);
+
+            // Store results (SoA → AoS)
+            let mut out0 = [0u64; 4];
+            let mut out1 = [0u64; 4];
+            let mut out2 = [0u64; 4];
+            _mm256_storeu_si256(out0.as_mut_ptr() as *mut __m256i, fp0);
+            _mm256_storeu_si256(out1.as_mut_ptr() as *mut __m256i, fp1);
+            _mm256_storeu_si256(out2.as_mut_ptr() as *mut __m256i, fp2);
+
+            for i in 0..4 {
+                result.push([out0[i], out1[i], out2[i]]);
+            }
+        }
+    }
+
+    // Scalar tail
+    for row in (chunks * 4)..trace_len {
+        let mut acc = [0u64; 3];
+        for k in 0..num_elements {
+            let val = bus_element_cols[k][row];
+            for (c, acc_c) in acc.iter_mut().enumerate() {
+                let product = (val as u128) * (alpha_powers_raw[k][c] as u128);
+                *acc_c = goldilocks_add(*acc_c, goldilocks_reduce128(product));
+            }
+        }
+        result.push([
+            goldilocks_sub(z_raw[0], acc[0]),
+            goldilocks_sub(z_raw[1], acc[1]),
+            goldilocks_sub(z_raw[2], acc[2]),
+        ]);
+    }
+
+    result
+}
+
+/// Scalar Goldilocks add (used in tail processing).
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn goldilocks_add(a: u64, b: u64) -> u64 {
+    const EPSILON: u64 = 0xFFFF_FFFF;
+    let (sum, over) = a.overflowing_add(b);
+    let (sum, over2) = sum.overflowing_add((over as u64) * EPSILON);
+    if over2 {
+        sum.wrapping_add(EPSILON)
+    } else {
+        sum
+    }
+}
+
+/// Scalar Goldilocks sub (used in tail processing).
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn goldilocks_sub(a: u64, b: u64) -> u64 {
+    const EPSILON: u64 = 0xFFFF_FFFF;
+    let (diff, under) = a.overflowing_sub(b);
+    let (diff, under2) = diff.overflowing_sub((under as u64) * EPSILON);
+    if under2 {
+        diff.wrapping_sub(EPSILON)
+    } else {
+        diff
+    }
+}
+
+/// Scalar Goldilocks reduce128 (used in tail processing).
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn goldilocks_reduce128(x: u128) -> u64 {
+    const EPSILON: u64 = 0xFFFF_FFFF;
+    let x_lo = x as u64;
+    let x_hi = (x >> 64) as u64;
+    let x_hi_hi = x_hi >> 32;
+    let x_hi_lo = x_hi & EPSILON;
+    let (t0, borrow) = x_lo.overflowing_sub(x_hi_hi);
+    let t0 = if borrow { t0.wrapping_sub(EPSILON) } else { t0 };
+    let t1 = (x_hi_lo << 32).wrapping_sub(x_hi_lo);
+    let (result, carry) = t0.overflowing_add(t1);
+    if carry {
+        result.wrapping_add(EPSILON)
+    } else {
+        result
+    }
+}
+
+/// Pre-compute bus element columns as raw u64 values (column-major).
+///
+/// Flattens each `BusInteraction`'s bus elements into a Vec of u64 columns, handling
+/// packing/combining in the base field. The bus_id contributes the first element.
+#[cfg(target_arch = "x86_64")]
+fn precompute_bus_element_columns(
+    table_interaction: &BusInteraction,
+    main_segment_cols: &[Vec<u64>],
+    trace_len: usize,
+) -> Vec<Vec<u64>> {
+    let num_elements = table_interaction.num_bus_elements();
+    let mut columns: Vec<Vec<u64>> = Vec::with_capacity(num_elements);
+
+    // First element: bus_id (constant column)
+    columns.push(vec![table_interaction.bus_id; trace_len]);
+
+    // Remaining elements from bus values
+    for bv in &table_interaction.values {
+        match bv {
+            BusValue::Packed {
+                start_column,
+                packing,
+            } => {
+                precompute_packing_columns(
+                    *packing,
+                    *start_column,
+                    main_segment_cols,
+                    trace_len,
+                    &mut columns,
+                );
+            }
+            BusValue::Linear(terms) => {
+                let mut col = Vec::with_capacity(trace_len);
+                for row in 0..trace_len {
+                    let mut val = 0u64;
+                    for term in terms {
+                        match *term {
+                            LinearTerm::Column {
+                                coefficient,
+                                column,
+                            } => {
+                                let coeff = if coefficient >= 0 {
+                                    coefficient as u64
+                                } else {
+                                    math::field::fields::fft_friendly::u64_goldilocks::GOLDILOCKS_PRIME
+                                        .wrapping_sub((-coefficient) as u64)
+                                };
+                                let product =
+                                    (main_segment_cols[column][row] as u128) * (coeff as u128);
+                                val = goldilocks_add(val, goldilocks_reduce128(product));
+                            }
+                            LinearTerm::ColumnUnsigned {
+                                coefficient,
+                                column,
+                            } => {
+                                let product = (main_segment_cols[column][row] as u128)
+                                    * (coefficient as u128);
+                                val = goldilocks_add(val, goldilocks_reduce128(product));
+                            }
+                            LinearTerm::Constant(value) => {
+                                let c = if value >= 0 {
+                                    value as u64
+                                } else {
+                                    math::field::fields::fft_friendly::u64_goldilocks::GOLDILOCKS_PRIME
+                                        .wrapping_sub((-value) as u64)
+                                };
+                                val = goldilocks_add(val, c);
+                            }
+                        }
+                    }
+                    col.push(val);
+                }
+                columns.push(col);
+            }
+        }
+    }
+
+    debug_assert_eq!(columns.len(), num_elements);
+    columns
+}
+
+/// Pre-compute columns for a specific packing type.
+#[cfg(target_arch = "x86_64")]
+fn precompute_packing_columns(
+    packing: Packing,
+    start_col: usize,
+    main_cols: &[Vec<u64>],
+    trace_len: usize,
+    out: &mut Vec<Vec<u64>>,
+) {
+    match packing {
+        Packing::Direct => {
+            out.push(main_cols[start_col].clone());
+        }
+        Packing::Word2L => {
+            let mut col = Vec::with_capacity(trace_len);
+            for row in 0..trace_len {
+                let combined = goldilocks_add(
+                    main_cols[start_col][row],
+                    goldilocks_reduce128(main_cols[start_col + 1][row] as u128 * SHIFT_16 as u128),
+                );
+                col.push(combined);
+            }
+            out.push(col);
+        }
+        Packing::Word4L => {
+            let mut col = Vec::with_capacity(trace_len);
+            for row in 0..trace_len {
+                let mut combined = main_cols[start_col][row];
+                combined = goldilocks_add(
+                    combined,
+                    goldilocks_reduce128(main_cols[start_col + 1][row] as u128 * SHIFT_8 as u128),
+                );
+                combined = goldilocks_add(
+                    combined,
+                    goldilocks_reduce128(main_cols[start_col + 2][row] as u128 * SHIFT_16 as u128),
+                );
+                let shift_24 = SHIFT_8 as u128 * SHIFT_16 as u128;
+                combined = goldilocks_add(
+                    combined,
+                    goldilocks_reduce128(main_cols[start_col + 3][row] as u128 * shift_24),
+                );
+                col.push(combined);
+            }
+            out.push(col);
+        }
+        // Compound packings: decompose into primitives
+        Packing::DWordWL => {
+            precompute_packing_columns(Packing::Direct, start_col, main_cols, trace_len, out);
+            precompute_packing_columns(Packing::Direct, start_col + 1, main_cols, trace_len, out);
+        }
+        Packing::DWordHHW => {
+            precompute_packing_columns(Packing::Direct, start_col, main_cols, trace_len, out);
+            precompute_packing_columns(Packing::Word2L, start_col + 1, main_cols, trace_len, out);
+        }
+        Packing::DWordWHH => {
+            precompute_packing_columns(Packing::Word2L, start_col, main_cols, trace_len, out);
+            precompute_packing_columns(Packing::Direct, start_col + 2, main_cols, trace_len, out);
+        }
+        Packing::DWordHL => {
+            precompute_packing_columns(Packing::Word2L, start_col, main_cols, trace_len, out);
+            precompute_packing_columns(Packing::Word2L, start_col + 2, main_cols, trace_len, out);
+        }
+        Packing::DWordBL => {
+            precompute_packing_columns(Packing::Word4L, start_col, main_cols, trace_len, out);
+            precompute_packing_columns(Packing::Word4L, start_col + 4, main_cols, trace_len, out);
+        }
+        Packing::QuadHL => {
+            for i in 0..4 {
+                precompute_packing_columns(
+                    Packing::Word2L,
+                    start_col + i * 2,
+                    main_cols,
+                    trace_len,
+                    out,
+                );
+            }
+        }
+        Packing::QuadWL => {
+            for i in 0..4 {
+                precompute_packing_columns(
+                    Packing::Direct,
+                    start_col + i,
+                    main_cols,
+                    trace_len,
+                    out,
+                );
+            }
+        }
+    }
+}
+
 /// Computes a term column for a table interaction without writing to the trace.
 ///
 /// Each row contains the LogUp quotient: `term[i] = sign * multiplicity[i] / fingerprint[i]`
@@ -1265,30 +1593,92 @@ where
     // Compute fingerprint = z - (bus_id*α^0 + v0*α^1 + v1*α^2 + ...) using
     // base-field × extension-field multiplication (F×E→E) to avoid to_extension().
     //
-    // Zero-allocation inner loop: accumulate the linear combination directly
-    // into the fingerprint without collecting bus elements into intermediate Vecs.
-    let bus_id_f = FieldElement::<F>::from(table_interaction.bus_id);
-    let mut fingerprints: Vec<FieldElement<E>> = Vec::with_capacity(trace_len);
-    for row in 0..trace_len {
-        // Accumulate fingerprint directly: bus_id * α^0 + Σ element_i * α^(1+i)
-        let mut linear_combination = &bus_id_f * &alpha_powers[0];
-        let mut alpha_offset = 1;
-        for bv in &table_interaction.values {
-            let consumed = bv.accumulate_fingerprint(
-                main_segment_cols,
-                row,
-                &alpha_powers,
-                alpha_offset,
-                &mut linear_combination,
-            );
-            alpha_offset += consumed;
+    // AVX2 fast path: when on x86_64 with AVX2 support and using Goldilocks + cubic
+    // extension, process 4 rows simultaneously with SIMD.
+    #[cfg(target_arch = "x86_64")]
+    let avx2_fingerprints = 'avx2: {
+        // Check concrete types via size: GoldilocksField has BaseType=u64 (8 bytes),
+        // Degree3GoldilocksExtensionField has BaseType=[FpE;3] (24 bytes).
+        // Also verify FieldElement<F> is repr(transparent) over u64.
+        if std::mem::size_of::<FieldElement<F>>() != 8
+            || std::mem::size_of::<FieldElement<E>>() != 24
+            || !is_x86_feature_detected!("avx2")
+            || trace_len < 4
+        {
+            break 'avx2 None;
         }
 
-        fingerprints.push(z - &linear_combination);
+        // Cast main_segment_cols to raw u64 slices via repr(transparent)
+        let main_cols_raw: &[Vec<u64>] =
+            unsafe { &*(main_segment_cols as *const [Vec<FieldElement<F>>] as *const [Vec<u64>]) };
 
-        #[cfg(feature = "debug-checks")]
-        {
-            // Reconstruct base_elements for debug logging
+        // Pre-compute bus element columns as raw u64
+        let bus_element_cols =
+            precompute_bus_element_columns(table_interaction, main_cols_raw, trace_len);
+        let col_refs: Vec<&[u64]> = bus_element_cols.iter().map(|c| c.as_slice()).collect();
+
+        // Extract alpha_powers as raw [u64; 3]
+        let alpha_powers_raw: Vec<[u64; 3]> = alpha_powers
+            .iter()
+            .map(|ap| {
+                // FieldElement<Degree3GoldilocksExtensionField> has BaseType = [FpE; 3]
+                // FpE = FieldElement<GoldilocksField> has BaseType = u64
+                let ptr = ap as *const FieldElement<E> as *const [u64; 3];
+                unsafe { *ptr }
+            })
+            .collect();
+
+        // Extract z as raw [u64; 3]
+        let z_raw: [u64; 3] = unsafe { *(z as *const FieldElement<E> as *const [u64; 3]) };
+
+        // Run AVX2 kernel
+        let raw_fingerprints =
+            unsafe { compute_fingerprints_avx2(&col_refs, &alpha_powers_raw, z_raw, trace_len) };
+
+        // Convert raw [u64; 3] back to Vec<FieldElement<E>>
+        let fingerprints: Vec<FieldElement<E>> = raw_fingerprints
+            .into_iter()
+            .map(|raw| unsafe {
+                let ptr = &raw as *const [u64; 3] as *const FieldElement<E>;
+                (*ptr).clone()
+            })
+            .collect();
+
+        Some(fingerprints)
+    };
+
+    #[cfg(not(target_arch = "x86_64"))]
+    let avx2_fingerprints: Option<Vec<FieldElement<E>>> = None;
+
+    let mut fingerprints = if let Some(fp) = avx2_fingerprints {
+        fp
+    } else {
+        // Scalar fallback: accumulate the linear combination directly
+        // into the fingerprint without collecting bus elements into intermediate Vecs.
+        let bus_id_f = FieldElement::<F>::from(table_interaction.bus_id);
+        let mut fingerprints: Vec<FieldElement<E>> = Vec::with_capacity(trace_len);
+        for row in 0..trace_len {
+            let mut linear_combination = &bus_id_f * &alpha_powers[0];
+            let mut alpha_offset = 1;
+            for bv in &table_interaction.values {
+                let consumed = bv.accumulate_fingerprint(
+                    main_segment_cols,
+                    row,
+                    &alpha_powers,
+                    alpha_offset,
+                    &mut linear_combination,
+                );
+                alpha_offset += consumed;
+            }
+            fingerprints.push(z - &linear_combination);
+        }
+        fingerprints
+    };
+
+    #[cfg(feature = "debug-checks")]
+    {
+        let bus_id_f = FieldElement::<F>::from(table_interaction.bus_id);
+        for row in 0..trace_len {
             let mut base_elements: Vec<FieldElement<F>> = vec![bus_id_f.clone()];
             base_elements.extend(
                 table_interaction
@@ -1303,7 +1693,7 @@ where
                 table_interaction.is_sender,
                 &multiplicities[row].canonical(),
                 &base_elements,
-                fingerprints.last().unwrap(),
+                &fingerprints[row],
             );
         }
     }

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1607,7 +1607,7 @@ where
 
         // Pre-compute bus element columns as raw u64
         let bus_element_cols =
-            precompute_bus_element_columns(table_interaction, &main_cols_raw, trace_len);
+            precompute_bus_element_columns(table_interaction, main_cols_raw, trace_len);
         let col_refs: Vec<&[u64]> = bus_element_cols.iter().map(|c| c.as_slice()).collect();
 
         // Extract alpha_powers as raw [u64; 3]

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -18,8 +18,6 @@ use math::field::{
     element::FieldElement,
     traits::{IsFFTField, IsField, IsPrimeField, IsSubFieldOf},
 };
-#[cfg(feature = "parallel")]
-use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
 // =============================================================================
 // Shift Constants for Type Combining
@@ -857,19 +855,12 @@ where
         let trace_len = trace.num_rows();
         let table_name = self.name.as_deref().unwrap_or("UNKNOWN");
 
-        // Compute term columns in parallel — even with 1-3 interactions per table,
-        // each column computation is heavy enough to benefit from parallelism on
-        // high-core-count machines. Internal parallelism within each column is also used.
-        #[cfg(feature = "parallel")]
-        let interactions_iter = self
+        // Sequential over interactions (1-3 per table): outer par_iter over ~12 tables
+        // in prover.rs already saturates cores; inner rayon here just adds contention.
+        let term_columns: Vec<Vec<FieldElement<E>>> = self
             .auxiliary_trace_build_data
             .interactions
-            .as_slice()
-            .into_par_iter();
-        #[cfg(not(feature = "parallel"))]
-        let interactions_iter = self.auxiliary_trace_build_data.interactions.iter();
-
-        let term_columns: Vec<Vec<FieldElement<E>>> = interactions_iter
+            .iter()
             .map(|interaction| {
                 compute_logup_term_column(
                     interaction,

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1203,7 +1203,7 @@ unsafe fn compute_fingerprints_avx2(
     use math::field::fields::fft_friendly::goldilocks_avx2::{add4, mul4, sub4};
 
     let num_elements = bus_element_cols.len();
-    debug_assert_eq!(alpha_powers_raw.len(), num_elements);
+    assert_eq!(alpha_powers_raw.len(), num_elements);
 
     let chunks = trace_len / 4;
     let mut result = Vec::with_capacity(trace_len);
@@ -1406,7 +1406,7 @@ fn precompute_bus_element_columns(
         }
     }
 
-    debug_assert_eq!(columns.len(), num_elements);
+    assert_eq!(columns.len(), num_elements);
     columns
 }
 
@@ -1597,51 +1597,62 @@ where
     // extension, process 4 rows simultaneously with SIMD.
     #[cfg(target_arch = "x86_64")]
     let avx2_fingerprints = 'avx2: {
-        // Check concrete types via size: GoldilocksField has BaseType=u64 (8 bytes),
-        // Degree3GoldilocksExtensionField has BaseType=[FpE;3] (24 bytes).
-        // Also verify FieldElement<F> is repr(transparent) over u64.
-        if std::mem::size_of::<FieldElement<F>>() != 8
-            || std::mem::size_of::<FieldElement<E>>() != 24
+        use math::field::fields::fft_friendly::extensions_goldilocks::Degree3GoldilocksExtensionField;
+        use math::field::fields::fft_friendly::u64_goldilocks::GoldilocksField;
+        type FpE = FieldElement<GoldilocksField>;
+        type Fp3E = FieldElement<Degree3GoldilocksExtensionField>;
+
+        // Guard: verify concrete types via size_of. In this codebase F is always
+        // GoldilocksField (BaseType = u64, 8 bytes) and E is always
+        // Degree3GoldilocksExtensionField (BaseType = [FpE; 3], 24 bytes).
+        // The AVX2 kernels use Goldilocks-specific reduction constants, so applying
+        // them to any other field would produce incorrect results immediately.
+        if std::mem::size_of::<FieldElement<F>>() != std::mem::size_of::<FpE>()
+            || std::mem::size_of::<FieldElement<E>>() != std::mem::size_of::<Fp3E>()
             || !is_x86_feature_detected!("avx2")
             || trace_len < 4
         {
             break 'avx2 None;
         }
 
-        // Cast main_segment_cols to raw u64 slices via repr(transparent)
-        let main_cols_raw: &[Vec<u64>] =
-            unsafe { &*(main_segment_cols as *const [Vec<FieldElement<F>>] as *const [Vec<u64>]) };
+        // SAFETY: All pointer casts below are on individual elements (not containers).
+        // FieldElement has #[repr(transparent)], so it has the same layout as its
+        // BaseType. The size checks above confirm FieldElement<F> is u64-sized (8 bytes)
+        // and FieldElement<E> is [u64; 3]-sized (24 bytes), making the casts sound.
+
+        // Extract raw u64 columns from main_segment_cols
+        let main_cols_raw: Vec<Vec<u64>> = main_segment_cols
+            .iter()
+            .map(|col| {
+                col.iter()
+                    .map(|fe| unsafe { std::ptr::read(fe as *const FieldElement<F> as *const u64) })
+                    .collect()
+            })
+            .collect();
 
         // Pre-compute bus element columns as raw u64
         let bus_element_cols =
-            precompute_bus_element_columns(table_interaction, main_cols_raw, trace_len);
+            precompute_bus_element_columns(table_interaction, &main_cols_raw, trace_len);
         let col_refs: Vec<&[u64]> = bus_element_cols.iter().map(|c| c.as_slice()).collect();
 
         // Extract alpha_powers as raw [u64; 3]
         let alpha_powers_raw: Vec<[u64; 3]> = alpha_powers
             .iter()
-            .map(|ap| {
-                // FieldElement<Degree3GoldilocksExtensionField> has BaseType = [FpE; 3]
-                // FpE = FieldElement<GoldilocksField> has BaseType = u64
-                let ptr = ap as *const FieldElement<E> as *const [u64; 3];
-                unsafe { *ptr }
-            })
+            .map(|ap| unsafe { std::ptr::read(ap as *const FieldElement<E> as *const [u64; 3]) })
             .collect();
 
         // Extract z as raw [u64; 3]
-        let z_raw: [u64; 3] = unsafe { *(z as *const FieldElement<E> as *const [u64; 3]) };
+        let z_raw: [u64; 3] =
+            unsafe { std::ptr::read(z as *const FieldElement<E> as *const [u64; 3]) };
 
         // Run AVX2 kernel
         let raw_fingerprints =
             unsafe { compute_fingerprints_avx2(&col_refs, &alpha_powers_raw, z_raw, trace_len) };
 
-        // Convert raw [u64; 3] back to Vec<FieldElement<E>>
+        // Convert raw [u64; 3] back to FieldElement<E>
         let fingerprints: Vec<FieldElement<E>> = raw_fingerprints
             .into_iter()
-            .map(|raw| unsafe {
-                let ptr = &raw as *const [u64; 3] as *const FieldElement<E>;
-                (*ptr).clone()
-            })
+            .map(|raw| unsafe { std::ptr::read(&raw as *const [u64; 3] as *const FieldElement<E>) })
             .collect();
 
         Some(fingerprints)

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1608,20 +1608,11 @@ where
             break 'avx2 None;
         }
 
-        // SAFETY: All pointer casts below are on individual elements (not containers).
-        // FieldElement has #[repr(transparent)], so it has the same layout as its
-        // BaseType. The size checks above confirm FieldElement<F> is u64-sized (8 bytes)
-        // and FieldElement<E> is [u64; 3]-sized (24 bytes), making the casts sound.
-
-        // Extract raw u64 columns from main_segment_cols
-        let main_cols_raw: Vec<Vec<u64>> = main_segment_cols
-            .iter()
-            .map(|col| {
-                col.iter()
-                    .map(|fe| unsafe { std::ptr::read(fe as *const FieldElement<F> as *const u64) })
-                    .collect()
-            })
-            .collect();
+        // SAFETY: FieldElement<F> is #[repr(transparent)] over u64 (verified by the
+        // size check above), so &[Vec<FieldElement<F>>] and &[Vec<u64>] have identical
+        // layout. This is a zero-cost reinterpret cast — no allocation or copy.
+        let main_cols_raw: &[Vec<u64>] =
+            unsafe { &*(main_segment_cols as *const [Vec<FieldElement<F>>] as *const [Vec<u64>]) };
 
         // Pre-compute bus element columns as raw u64
         let bus_element_cols =

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1646,8 +1646,14 @@ where
     let avx2_fingerprints: Option<Vec<FieldElement<E>>> = None;
 
     let mut fingerprints = if let Some(fp) = avx2_fingerprints {
+        use std::sync::Once;
+        static PRINT: Once = Once::new();
+        PRINT.call_once(|| eprintln!("[BENCH] LogUp fingerprints: AVX2"));
         fp
     } else {
+        use std::sync::Once;
+        static PRINT: Once = Once::new();
+        PRINT.call_once(|| eprintln!("[BENCH] LogUp fingerprints: scalar"));
         // Scalar fallback: accumulate the linear combination directly
         // into the fingerprint without collecting bus elements into intermediate Vecs.
         let bus_id_f = FieldElement::<F>::from(table_interaction.bus_id);


### PR DESCRIPTION
AVX2-accelerated fingerprint computation in `compute_logup_term_column`, processing 4 rows simultaneously via 256-bit SIMD on x86_64.

- Add `#[repr(transparent)]` to `FieldElement` for safe u64 reinterpretation
- New `goldilocks_avx2` module: packed `add4`/`sub4`/`mul4`/`neg4` on `__m256i`
- Runtime AVX2 dispatch in `lookup.rs` with scalar fallback
- Pre-computes bus element columns, then runs 4-wide F×E multiply accumulation