### PR TITLE
Parallel tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ resolver = "2"
 [profile.dev]
 opt-level = 3
 debug = true
+
+# debug=1 = line tables only: enables function names in profilers (samply, perf)
+# without slowing compilation or bloating the binary significantly.
+[profile.release]
+debug = 1

--- a/bin/cli/Cargo.toml
+++ b/bin/cli/Cargo.toml
@@ -15,3 +15,4 @@ tikv-jemalloc-ctl = { version = "0.6", features = ["stats"], optional = true }
 
 [features]
 jemalloc-stats = ["dep:tikv-jemalloc-ctl"]
+instruments = ["prover/instruments"]

--- a/crypto/stark/src/constraints/evaluator.rs
+++ b/crypto/stark/src/constraints/evaluator.rs
@@ -18,8 +18,6 @@ use rayon::{
 };
 
 use std::marker::PhantomData;
-#[cfg(feature = "instruments")]
-use std::time::Instant;
 
 pub struct ConstraintEvaluator<
     Field: IsSubFieldOf<FieldExtension> + IsFFTField + Send + Sync,
@@ -226,9 +224,6 @@ where
         #[cfg(all(debug_assertions, not(feature = "parallel")))]
         let boundary_polys: Vec<Polynomial<FieldElement<Field>>> = Vec::new();
 
-        #[cfg(feature = "instruments")]
-        let timer = Instant::now();
-
         let trace_length = domain.interpolation_domain_size;
         let lde_periodic_columns = air
             .get_periodic_column_polynomials(trace_length)
@@ -243,15 +238,6 @@ where
             })
             .collect::<Result<Vec<Vec<FieldElement<Field>>>, FFTError>>()
             .unwrap();
-
-        #[cfg(feature = "instruments")]
-        println!(
-            "     Evaluating periodic columns on lde: {:#?}",
-            timer.elapsed()
-        );
-
-        #[cfg(feature = "instruments")]
-        let timer = Instant::now();
 
         // Fused boundary evaluation: compute (trace[col] - value) on-the-fly
         // instead of pre-computing all boundary_polys_evaluations.
@@ -282,12 +268,6 @@ where
             })
             .collect();
 
-        #[cfg(feature = "instruments")]
-        println!(
-            "     Evaluated boundary polynomials on LDE: {:#?}",
-            timer.elapsed()
-        );
-
         #[cfg(all(debug_assertions, not(feature = "parallel")))]
         let boundary_zerofiers = Vec::new();
 
@@ -297,21 +277,11 @@ where
         #[cfg(all(debug_assertions, not(feature = "parallel")))]
         let _transition_evaluations: Vec<FieldElement<FieldExtension>> = Vec::new();
 
-        #[cfg(feature = "instruments")]
-        let timer = Instant::now();
         let zerofier_data = air.transition_zerofier_evaluations_grouped(domain);
-        #[cfg(feature = "instruments")]
-        println!(
-            "     Evaluated transition zerofiers: {:#?}",
-            timer.elapsed()
-        );
 
         // Iterate over all LDE domain and compute the part of the composition polynomial
         // related to the transition constraints and add it to the already computed part of the
         // boundary constraints.
-
-        #[cfg(feature = "instruments")]
-        let timer = Instant::now();
 
         let num_transition = air.num_transition_constraints();
         let num_periodic = lde_periodic_columns.len();
@@ -328,12 +298,6 @@ where
             num_transition,
             num_periodic,
             offsets,
-        );
-
-        #[cfg(feature = "instruments")]
-        println!(
-            "     Evaluated transitions and accumulated results: {:#?}",
-            timer.elapsed()
         );
 
         evaluations_t

--- a/crypto/stark/src/instruments.rs
+++ b/crypto/stark/src/instruments.rs
@@ -1,0 +1,127 @@
+use std::cell::RefCell;
+use std::time::Duration;
+
+/// Sub-operation timing breakdown for a single table in Rounds 2-4.
+#[derive(Clone, Debug, Default)]
+pub struct TableSubOps {
+    /// reconstruct_round1 (expand_pool_to_lde)
+    pub trace_lde: Duration,
+    /// evaluator.evaluate()
+    pub constraints: Duration,
+    /// decompose_and_extend_d2
+    pub comp_decompose: Duration,
+    /// commit_composition_polynomial
+    pub comp_commit: Duration,
+    /// Round 3: barycentric OOD evaluation
+    pub ood: Duration,
+    /// Round 4: compute_deep_composition_poly_evaluations
+    pub deep_comp: Duration,
+    /// Round 4: interpolate_fft + evaluate_fft
+    pub deep_extend: Duration,
+    /// fri::commit_phase_from_evaluations
+    pub fri_commit: Duration,
+    /// Round 4: grinding + FRI query + Merkle openings
+    pub queries: Duration,
+}
+
+/// Sub-operation breakdown for Round 1 aux commit pass.
+#[derive(Clone, Debug, Default)]
+pub struct Round1SubOps {
+    /// Main trace: expand_pool_to_lde (LDE/FFT)
+    pub main_lde: Duration,
+    /// Main trace: commit_columns_bit_reversed (Merkle)
+    pub main_merkle: Duration,
+    /// Aux trace: expand_pool_to_lde (LDE/FFT)
+    pub aux_lde: Duration,
+    /// Aux trace: commit_columns_bit_reversed (Merkle)
+    pub aux_merkle: Duration,
+}
+
+/// Timing data collected inside `multi_prove`.
+pub struct MultiProveTiming {
+    pub prepass: Duration,
+    pub main_commits: Duration,
+    pub aux_build: Duration,
+    pub aux_commit: Duration,
+    pub rounds_2_4: Duration,
+    /// Sub-op breakdown for Round 1 (main + aux LDE vs Merkle).
+    pub round1_sub: Round1SubOps,
+    /// (name, rows, duration, sub_ops) per table for rounds 2-4.
+    pub table_timings: Vec<(String, usize, Duration, TableSubOps)>,
+}
+
+thread_local! {
+    static TIMING_DATA: RefCell<Option<MultiProveTiming>> = const { RefCell::new(None) };
+    /// Round 1 sub-timings accumulated across the main-commit and aux-commit loops.
+    static R1_SUB: RefCell<Round1SubOps> = const { RefCell::new(Round1SubOps {
+        main_lde: Duration::ZERO, main_merkle: Duration::ZERO,
+        aux_lde: Duration::ZERO, aux_merkle: Duration::ZERO,
+    }) };
+    /// Round 2 sub-timings: (constraints, fft, merkle)
+    static R2_SUB: RefCell<Option<(Duration, Duration, Duration)>> = const { RefCell::new(None) };
+    /// Round 4 sub-timings: (fft, merkle, deep_comp, queries)
+    static R4_SUB: RefCell<Option<(Duration, Duration, Duration, Duration)>> = const { RefCell::new(None) };
+    /// Assembled sub-ops from prove_rounds_2_to_4 (without reconstruct_round1 LDE time).
+    static ROUND_SUB_OPS: RefCell<Option<TableSubOps>> = const { RefCell::new(None) };
+}
+
+pub fn store(data: MultiProveTiming) {
+    TIMING_DATA.with(|cell| {
+        *cell.borrow_mut() = Some(data);
+    });
+}
+
+pub fn take() -> Option<MultiProveTiming> {
+    TIMING_DATA.with(|cell| cell.borrow_mut().take())
+}
+
+pub fn accum_r1_main(lde: Duration, merkle: Duration) {
+    R1_SUB.with(|cell| {
+        let mut s = cell.borrow_mut();
+        s.main_lde += lde;
+        s.main_merkle += merkle;
+    });
+}
+
+pub fn accum_r1_aux(lde: Duration, merkle: Duration) {
+    R1_SUB.with(|cell| {
+        let mut s = cell.borrow_mut();
+        s.aux_lde += lde;
+        s.aux_merkle += merkle;
+    });
+}
+
+pub fn take_r1_sub() -> Round1SubOps {
+    R1_SUB.with(|cell| {
+        std::mem::replace(
+            &mut *cell.borrow_mut(),
+            Round1SubOps::default(),
+        )
+    })
+}
+
+pub fn store_r2_sub(constraints: Duration, fft: Duration, merkle: Duration) {
+    R2_SUB.with(|cell| *cell.borrow_mut() = Some((constraints, fft, merkle)));
+}
+
+pub fn take_r2_sub() -> Option<(Duration, Duration, Duration)> {
+    R2_SUB.with(|cell| cell.borrow_mut().take())
+}
+
+pub fn store_r4_sub(fft: Duration, merkle: Duration, deep_comp: Duration, queries: Duration) {
+    R4_SUB.with(|cell| *cell.borrow_mut() = Some((fft, merkle, deep_comp, queries)));
+}
+
+pub fn take_r4_sub() -> Option<(Duration, Duration, Duration, Duration)> {
+    R4_SUB.with(|cell| cell.borrow_mut().take())
+}
+
+pub fn store_round_sub_ops(data: TableSubOps) {
+    ROUND_SUB_OPS.with(|cell| {
+        *cell.borrow_mut() = Some(data);
+    });
+}
+
+pub fn take_round_sub_ops() -> Option<TableSubOps> {
+    ROUND_SUB_OPS.with(|cell| cell.borrow_mut().take())
+}

--- a/crypto/stark/src/lib.rs
+++ b/crypto/stark/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "debug-checks")]
 pub mod bus_debug;
 pub mod constraints;
+#[cfg(feature = "instruments")]
+pub mod instruments;
 pub mod context;
 pub mod debug;
 pub mod domain;

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::rc::Rc;
+use std::sync::Arc;
 #[cfg(feature = "instruments")]
 use std::time::Instant;
 
@@ -19,7 +19,8 @@ use math::{
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::{
-    IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
+    IntoParallelRefMutIterator, ParallelIterator,
 };
 
 #[cfg(feature = "debug-checks")]
@@ -80,12 +81,12 @@ where
 {
     /// The Merkle trees constructed to obtain the commitment of the entire trace table.
     /// For preprocessed tables, this contains only the multiplicity columns.
-    /// Wrapped in Rc to share with Round1Metadata without deep-cloning (~64MB per table).
-    pub(crate) lde_trace_merkle_tree: Rc<BatchedMerkleTree<F>>,
+    /// Wrapped in Arc to share with Round1Metadata without deep-cloning (~64MB per table).
+    pub(crate) lde_trace_merkle_tree: Arc<BatchedMerkleTree<F>>,
     /// The root of the Merkle tree in `lde_trace_merkle_tree`.
     pub(crate) lde_trace_merkle_root: Commitment,
     /// For preprocessed tables: Merkle tree over precomputed columns only.
-    pub(crate) precomputed_merkle_tree: Option<Rc<BatchedMerkleTree<F>>>,
+    pub(crate) precomputed_merkle_tree: Option<Arc<BatchedMerkleTree<F>>>,
     /// For preprocessed tables: root of the precomputed Merkle tree.
     pub(crate) precomputed_merkle_root: Option<Commitment>,
     /// For preprocessed tables: number of precomputed columns (for splitting during opening).
@@ -118,9 +119,9 @@ struct MainCommitData<Field: IsFFTField>
 where
     FieldElement<Field>: AsBytes,
 {
-    main_tree: Rc<BatchedMerkleTree<Field>>,
+    main_tree: Arc<BatchedMerkleTree<Field>>,
     main_root: Commitment,
-    precomputed_tree: Option<Rc<BatchedMerkleTree<Field>>>,
+    precomputed_tree: Option<Arc<BatchedMerkleTree<Field>>>,
     precomputed_root: Option<Commitment>,
     num_precomputed_cols: usize,
 }
@@ -136,18 +137,18 @@ where
     FieldElement<FieldExtension>: AsBytes,
 {
     /// Merkle tree of the main trace (multiplicities for preprocessed tables).
-    /// Wrapped in Rc to share with Round1CommitmentData without deep-cloning.
-    main_merkle_tree: Rc<BatchedMerkleTree<Field>>,
+    /// Wrapped in Arc to share with Round1CommitmentData without deep-cloning.
+    main_merkle_tree: Arc<BatchedMerkleTree<Field>>,
     /// Root of the main trace Merkle tree.
     main_merkle_root: Commitment,
     /// For preprocessed tables: Merkle tree over precomputed columns.
-    precomputed_merkle_tree: Option<Rc<BatchedMerkleTree<Field>>>,
+    precomputed_merkle_tree: Option<Arc<BatchedMerkleTree<Field>>>,
     /// For preprocessed tables: root of the precomputed Merkle tree.
     precomputed_merkle_root: Option<Commitment>,
     /// For preprocessed tables: number of precomputed columns.
     num_precomputed_cols: usize,
     /// Merkle tree of the auxiliary trace (None if no aux trace).
-    aux_merkle_tree: Option<Rc<BatchedMerkleTree<FieldExtension>>>,
+    aux_merkle_tree: Option<Arc<BatchedMerkleTree<FieldExtension>>>,
     /// Root of the auxiliary trace Merkle tree (None if no aux trace).
     aux_merkle_root: Option<Commitment>,
     /// The RAP challenges used for auxiliary trace construction.
@@ -199,6 +200,34 @@ impl<F: IsFFTField> LdeTwiddles<F> {
             coset_weights,
         }
     }
+}
+
+/// Number of tables to process concurrently in `multi_prove`.
+/// Default: num_cores / 3 (benchmarked optimal on both M3 Pro and EPYC 9454P).
+/// Override with `TABLE_PARALLELISM` env var.
+fn table_parallelism() -> usize {
+    #[cfg(feature = "parallel")]
+    {
+        std::env::var("TABLE_PARALLELISM")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| {
+                let cores = std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(4);
+                (cores / 3).max(1)
+            })
+    }
+    #[cfg(not(feature = "parallel"))]
+    {
+        1
+    }
+}
+
+/// A set of LDE column buffer pools for one concurrent table slot.
+struct PoolSet<F: IsField, E: IsField> {
+    main: Vec<Vec<FieldElement<F>>>,
+    aux: Vec<Vec<FieldElement<E>>>,
 }
 
 /// A container for the results of the second round of the STARK Prove protocol.
@@ -426,7 +455,6 @@ pub trait IsStarkProver<
     fn commit_main_trace(
         trace: &TraceTable<Field, FieldExtension>,
         domain: &Domain<Field>,
-        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
         twiddles: &LdeTwiddles<Field>,
         main_pool: &mut [Vec<FieldElement<Field>>],
     ) -> Result<
@@ -458,8 +486,6 @@ pub trait IsStarkProver<
         #[cfg(feature = "instruments")]
         crate::instruments::accum_r1_main(main_lde_dur, t_sub.elapsed());
 
-        transcript.append_bytes(&root);
-
         // Pool buffers retain capacity; tree is returned to caller
         Ok((tree, root, None, None, 0))
     }
@@ -470,7 +496,6 @@ pub trait IsStarkProver<
     fn commit_preprocessed_trace(
         trace: &TraceTable<Field, FieldExtension>,
         domain: &Domain<Field>,
-        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
         precomputed_commitment: Commitment,
         num_precomputed_cols: usize,
         twiddles: &LdeTwiddles<Field>,
@@ -514,9 +539,6 @@ pub trait IsStarkProver<
             "Prover's precomputed commitment doesn't match hardcoded AIR commitment"
         );
 
-        transcript.append_bytes(&precomputed_commitment);
-        transcript.append_bytes(&mult_root);
-
         // Pool buffers retain capacity; trees are returned to caller
         Ok((
             mult_tree,
@@ -550,11 +572,11 @@ pub trait IsStarkProver<
         trace.extract_columns_main_into(main_pool);
         Self::expand_pool_to_lde::<Field>(main_pool, num_main_cols, domain, twiddles);
 
-        // Use stored Merkle trees from Phase A/C via Rc (pointer copy, no deep clone)
+        // Use stored Merkle trees from Phase A/C via Arc (pointer copy, no deep clone)
         let main = Round1CommitmentData::<Field> {
-            lde_trace_merkle_tree: Rc::clone(&metadata.main_merkle_tree),
+            lde_trace_merkle_tree: Arc::clone(&metadata.main_merkle_tree),
             lde_trace_merkle_root: metadata.main_merkle_root,
-            precomputed_merkle_tree: metadata.precomputed_merkle_tree.as_ref().map(Rc::clone),
+            precomputed_merkle_tree: metadata.precomputed_merkle_tree.as_ref().map(Arc::clone),
             precomputed_merkle_root: metadata.precomputed_merkle_root,
             num_precomputed_cols: metadata.num_precomputed_cols,
         };
@@ -566,7 +588,7 @@ pub trait IsStarkProver<
             Self::expand_pool_to_lde::<FieldExtension>(aux_pool, n_aux, domain, twiddles);
             // Safe: has_aux_trace() is true only when Phase C stored aux tree/root
             let aux_commitment = Round1CommitmentData::<FieldExtension> {
-                lde_trace_merkle_tree: Rc::clone(
+                lde_trace_merkle_tree: Arc::clone(
                     metadata
                         .aux_merkle_tree
                         .as_ref()
@@ -1440,7 +1462,7 @@ pub trait IsStarkProver<
     /// The transcript must be safely initialized before passing it to this method.
     fn multi_prove(
         mut air_trace_pairs: Vec<AirTracePair<'_, Field, FieldExtension, PI>>,
-        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone),
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone + Send),
     ) -> Result<MultiProof<Field, FieldExtension, PI>, ProvingError>
     where
         FieldElement<Field>: AsBytes,
@@ -1484,54 +1506,81 @@ pub trait IsStarkProver<
             twiddle_caches.push(twiddles);
         }
 
-        // Allocate LDE column buffer pools — reused across all tables and phases.
-        let mut main_pool: Vec<Vec<FieldElement<Field>>> = (0..max_main_cols)
-            .map(|_| Vec::with_capacity(max_lde_size))
-            .collect();
-        let mut aux_pool: Vec<Vec<FieldElement<FieldExtension>>> = (0..max_aux_cols)
-            .map(|_| Vec::with_capacity(max_lde_size))
+        // Allocate K independent LDE column buffer pool sets for parallel table processing.
+        let k = table_parallelism().min(num_airs).max(1);
+        let mut pool_sets: Vec<PoolSet<Field, FieldExtension>> = (0..k)
+            .map(|_| PoolSet {
+                main: (0..max_main_cols)
+                    .map(|_| Vec::with_capacity(max_lde_size))
+                    .collect(),
+                aux: (0..max_aux_cols)
+                    .map(|_| Vec::with_capacity(max_lde_size))
+                    .collect(),
+            })
             .collect();
 
         #[cfg(feature = "instruments")]
         let prepass_elapsed = phase_start.elapsed();
 
         // =====================================================================
-        // Round 1, Phase A: Commit all main traces (lightweight)
+        // Round 1, Phase A: Commit all main traces (parallel in chunks of K)
         // =====================================================================
         // All main trace commitments must be in the transcript before sampling
-        // LogUp challenges. Pool buffers are reused across tables.
+        // LogUp challenges. Pool buffers are reused across chunks.
 
         #[cfg(feature = "instruments")]
         let phase_start = Instant::now();
 
         let mut main_commits: Vec<MainCommitData<Field>> = Vec::with_capacity(num_airs);
 
-        for ((air, trace, _pub_inputs), twiddles) in
-            air_trace_pairs.iter().zip(twiddle_caches.iter())
-        {
-            let domain = &domains[main_commits.len()];
+        for chunk_start in (0..num_airs).step_by(k) {
+            let chunk_end = (chunk_start + k).min(num_airs);
+            let chunk_size = chunk_end - chunk_start;
 
-            let (tree, root, pre_tree, pre_root, n_pre) = if air.is_preprocessed() {
-                Self::commit_preprocessed_trace(
-                    *trace,
-                    domain,
-                    transcript,
-                    air.precomputed_commitment(),
-                    air.num_precomputed_columns(),
-                    twiddles,
-                    &mut main_pool,
-                )?
-            } else {
-                Self::commit_main_trace(*trace, domain, transcript, twiddles, &mut main_pool)?
-            };
+            #[cfg(feature = "parallel")]
+            let iter = pool_sets[..chunk_size].par_iter_mut().enumerate();
+            #[cfg(not(feature = "parallel"))]
+            let iter = pool_sets[..chunk_size].iter_mut().enumerate();
 
-            main_commits.push(MainCommitData {
-                main_tree: Rc::new(tree),
-                main_root: root,
-                precomputed_tree: pre_tree.map(Rc::new),
-                precomputed_root: pre_root,
-                num_precomputed_cols: n_pre,
-            });
+            let chunk_results: Vec<Result<_, ProvingError>> = iter
+                .map(|(j, pool)| {
+                    let idx = chunk_start + j;
+                    let (air, trace, _) = &air_trace_pairs[idx];
+                    let domain = &domains[idx];
+                    let twiddles = &twiddle_caches[idx];
+
+                    if air.is_preprocessed() {
+                        Self::commit_preprocessed_trace(
+                            *trace,
+                            domain,
+                            air.precomputed_commitment(),
+                            air.num_precomputed_columns(),
+                            twiddles,
+                            &mut pool.main,
+                        )
+                    } else {
+                        Self::commit_main_trace(*trace, domain, twiddles, &mut pool.main)
+                    }
+                })
+                .collect();
+
+            // Sequential: append roots to shared transcript (Fiat-Shamir ordering)
+            for result in chunk_results {
+                let (tree, root, pre_tree, pre_root, n_pre) = result?;
+                if let Some(ref pre_r) = pre_root {
+                    transcript.append_bytes(pre_r);
+                    transcript.append_bytes(&root);
+                } else {
+                    transcript.append_bytes(&root);
+                }
+                main_commits.push(MainCommitData {
+                    main_tree: Arc::new(tree),
+                    main_root: root,
+                    precomputed_tree: pre_tree.map(Arc::new),
+                    precomputed_root: pre_root,
+                    num_precomputed_cols: n_pre,
+                });
+            }
         }
 
         #[cfg(feature = "instruments")]
@@ -1583,61 +1632,83 @@ pub trait IsStarkProver<
         #[cfg(feature = "instruments")]
         let aux_build_elapsed = phase_start.elapsed();
 
-        // Pass 2: Sequential fork transcript → extract → LDE → commit.
-        // Uses shared aux_pool. Each table gets its own transcript fork.
+        // Pass 2: Parallel fork transcript → extract → LDE → commit in chunks of K.
+        // Each table gets its own transcript fork and pool set.
         #[cfg(feature = "instruments")]
         let phase_start = Instant::now();
 
+        // Pre-fork all transcripts (cheap, sequential — must match verifier ordering)
+        let mut table_transcripts: Vec<_> = (0..num_airs)
+            .map(|idx| {
+                let mut t = transcript.clone();
+                if num_airs > 1 {
+                    t.append_bytes(&(idx as u64).to_le_bytes());
+                }
+                t
+            })
+            .collect();
+
+        // Parallel aux commit in chunks of K
+        let mut aux_results: Vec<(Option<Arc<BatchedMerkleTree<FieldExtension>>>, Option<Commitment>)> =
+            Vec::with_capacity(num_airs);
+
+        for chunk_start in (0..num_airs).step_by(k) {
+            let chunk_end = (chunk_start + k).min(num_airs);
+            let chunk_size = chunk_end - chunk_start;
+
+            #[cfg(feature = "parallel")]
+            let iter = pool_sets[..chunk_size].par_iter_mut().enumerate();
+            #[cfg(not(feature = "parallel"))]
+            let iter = pool_sets[..chunk_size].iter_mut().enumerate();
+
+            let chunk_aux: Vec<Result<_, ProvingError>> = iter
+                .map(|(j, pool)| {
+                    let idx = chunk_start + j;
+                    let (air, trace, _) = &air_trace_pairs[idx];
+                    let domain = &domains[idx];
+                    let twiddles = &twiddle_caches[idx];
+
+                    if air.has_aux_trace() {
+                        let num_aux_cols = trace.num_aux_columns;
+                        trace.extract_columns_aux_into(&mut pool.aux);
+                        Self::expand_pool_to_lde::<FieldExtension>(
+                            &mut pool.aux,
+                            num_aux_cols,
+                            domain,
+                            twiddles,
+                        );
+                        let (tree, root) =
+                            Self::commit_columns_bit_reversed(&pool.aux[..num_aux_cols])
+                                .ok_or(ProvingError::EmptyCommitment)?;
+                        Ok((Some(Arc::new(tree)), Some(root)))
+                    } else {
+                        Ok((None, None))
+                    }
+                })
+                .collect();
+
+            // Sequential: append aux roots to forked transcripts
+            for (j, result) in chunk_aux.into_iter().enumerate() {
+                let (aux_tree, aux_root) = result?;
+                if let Some(ref root) = aux_root {
+                    table_transcripts[chunk_start + j].append_bytes(root);
+                }
+                aux_results.push((aux_tree, aux_root));
+            }
+        }
+
+        // Build metadata sequentially from main_commits + aux_results + bus_inputs
         let mut metadatas: Vec<Round1Metadata<Field, FieldExtension>> =
             Vec::with_capacity(num_airs);
-        let mut table_transcripts = Vec::with_capacity(num_airs);
-        for (
-            idx,
-            ((((air, trace, _pub_inputs), bus_public_inputs), main_commit), (domain, twiddles)),
-        ) in air_trace_pairs
-            .iter()
+        for ((main_commit, (aux_tree, aux_root)), bus_public_inputs) in main_commits
+            .into_iter()
+            .zip(aux_results.into_iter())
             .zip(bus_inputs_vec.into_iter())
-            .zip(main_commits.into_iter())
-            .zip(domains.iter().zip(twiddle_caches.iter()))
-            .enumerate()
         {
-            // Fork transcript with domain separator (must match verifier)
-            let mut table_transcript = transcript.clone();
-            if num_airs > 1 {
-                table_transcript.append_bytes(&(idx as u64).to_le_bytes());
-            }
-
-            let (aux_tree, aux_root) = if air.has_aux_trace() {
-                let num_aux_cols = trace.num_aux_columns;
-                trace.extract_columns_aux_into(&mut aux_pool);
-                #[cfg(feature = "instruments")]
-                let t_sub = Instant::now();
-                Self::expand_pool_to_lde::<FieldExtension>(
-                    &mut aux_pool,
-                    num_aux_cols,
-                    domain,
-                    twiddles,
-                );
-                #[cfg(feature = "instruments")]
-                let aux_lde_dur = t_sub.elapsed();
-
-                #[cfg(feature = "instruments")]
-                let t_sub = Instant::now();
-                let (tree, root) = Self::commit_columns_bit_reversed(&aux_pool[..num_aux_cols])
-                    .ok_or(ProvingError::EmptyCommitment)?;
-                #[cfg(feature = "instruments")]
-                crate::instruments::accum_r1_aux(aux_lde_dur, t_sub.elapsed());
-
-                table_transcript.append_bytes(&root);
-                (Some(Rc::new(tree)), Some(root))
-            } else {
-                (None, None)
-            };
-
             metadatas.push(Round1Metadata {
-                main_merkle_tree: Rc::clone(&main_commit.main_tree),
+                main_merkle_tree: Arc::clone(&main_commit.main_tree),
                 main_merkle_root: main_commit.main_root,
-                precomputed_merkle_tree: main_commit.precomputed_tree.as_ref().map(Rc::clone),
+                precomputed_merkle_tree: main_commit.precomputed_tree.as_ref().map(Arc::clone),
                 precomputed_merkle_root: main_commit.precomputed_root,
                 num_precomputed_cols: main_commit.num_precomputed_cols,
                 aux_merkle_tree: aux_tree,
@@ -1645,96 +1716,100 @@ pub trait IsStarkProver<
                 rap_challenges: lookup_challenges.clone(),
                 bus_public_inputs,
             });
-            table_transcripts.push(table_transcript);
         }
 
         #[cfg(feature = "instruments")]
         let aux_commit_elapsed = phase_start.elapsed();
 
         #[cfg(feature = "debug-checks")]
-        Self::run_debug_checks(
-            &air_trace_pairs,
-            &metadatas,
-            &domains,
-            &twiddle_caches,
-            &mut main_pool,
-            &mut aux_pool,
-        );
+        {
+            let debug_pool = &mut pool_sets[0];
+            Self::run_debug_checks(
+                &air_trace_pairs,
+                &metadatas,
+                &domains,
+                &twiddle_caches,
+                &mut debug_pool.main,
+                &mut debug_pool.aux,
+            );
+        }
 
         // =====================================================================
-        // Rounds 2-4: Sequential per-table proving with forked transcripts
+        // Rounds 2-4: Parallel per-table proving in chunks of K
         // =====================================================================
-        // For each table, recompute LDE into pool buffers, reuse stored Merkle trees,
-        // run rounds 2-4 with the table's forked transcript, then drop table data.
+        // Each chunk of K tables is processed in parallel. Each worker gets its
+        // own pool set and transcript fork. Pool sets are reused across chunks.
 
         #[cfg(feature = "instruments")]
         let phase_start = Instant::now();
         #[cfg(feature = "instruments")]
-        let mut table_timings: Vec<(String, usize, std::time::Duration, crate::instruments::TableSubOps)> =
+        let table_timings: Vec<(String, usize, std::time::Duration, crate::instruments::TableSubOps)> =
             Vec::with_capacity(num_airs);
 
         let mut proofs = Vec::with_capacity(num_airs);
-        for (((((air, trace, pub_inputs), metadata), domain), twiddles), table_transcript) in
-            air_trace_pairs
-                .iter()
-                .zip(metadatas.iter())
-                .zip(domains.iter())
-                .zip(twiddle_caches.iter())
-                .zip(table_transcripts.iter_mut())
-        {
-            #[cfg(feature = "instruments")]
-            let table_start = Instant::now();
+        for chunk_start in (0..num_airs).step_by(k) {
+            let chunk_end = (chunk_start + k).min(num_airs);
+            let chunk_size = chunk_end - chunk_start;
 
-            // Recompute LDE evaluations into pool, reuse stored Merkle trees
-            #[cfg(feature = "instruments")]
-            let lde_start = Instant::now();
-            let round_1_result = Self::reconstruct_round1(
-                *air,
-                *trace,
-                domain,
-                metadata,
-                twiddles,
-                &mut main_pool,
-                &mut aux_pool,
-            )?;
-            #[cfg(feature = "instruments")]
-            let lde_dur = lde_start.elapsed();
+            let chunk_transcripts = &mut table_transcripts[chunk_start..chunk_end];
 
-            // Bind table_contribution (L) to transcript for defense-in-depth.
-            if let Some(ref bpi) = round_1_result.bus_public_inputs {
-                table_transcript.append_field_element(&bpi.table_contribution);
-            }
+            #[cfg(feature = "parallel")]
+            let iter = pool_sets[..chunk_size]
+                .par_iter_mut()
+                .zip(chunk_transcripts.par_iter_mut())
+                .enumerate();
+            #[cfg(not(feature = "parallel"))]
+            let iter = pool_sets[..chunk_size]
+                .iter_mut()
+                .zip(chunk_transcripts.iter_mut())
+                .enumerate();
 
-            let proof = Self::prove_rounds_2_to_4(
-                *air,
-                *pub_inputs,
-                &round_1_result,
-                table_transcript,
-                domain,
-            )?;
-            proofs.push(proof);
+            let chunk_results: Vec<Result<_, ProvingError>> = iter
+                .map(|(j, (pool, table_transcript))| {
+                    let idx = chunk_start + j;
+                    let (air, trace, pub_inputs) = &air_trace_pairs[idx];
+                    let metadata = &metadatas[idx];
+                    let domain = &domains[idx];
+                    let twiddles = &twiddle_caches[idx];
 
-            #[cfg(feature = "instruments")]
-            {
-                let mut sub_ops = crate::instruments::take_round_sub_ops()
-                    .unwrap_or_default();
-                sub_ops.trace_lde += lde_dur;
-                table_timings.push((
-                    air.name().to_string(),
-                    trace.num_rows(),
-                    table_start.elapsed(),
-                    sub_ops,
-                ));
-            }
+                    let round_1_result = Self::reconstruct_round1(
+                        *air,
+                        *trace,
+                        domain,
+                        metadata,
+                        twiddles,
+                        &mut pool.main,
+                        &mut pool.aux,
+                    )?;
 
-            // Return column Vecs to pool (zero-copy move back). Pool slots that were
-            // `take`n in reconstruct_round1 get their buffers back with capacity intact.
-            let (main_cols, aux_cols) = round_1_result.lde_trace.into_columns();
-            for (slot, col) in main_pool.iter_mut().zip(main_cols) {
-                *slot = col;
-            }
-            for (slot, col) in aux_pool.iter_mut().zip(aux_cols) {
-                *slot = col;
+                    // Bind table_contribution (L) to transcript for defense-in-depth.
+                    if let Some(ref bpi) = round_1_result.bus_public_inputs {
+                        table_transcript.append_field_element(&bpi.table_contribution);
+                    }
+
+                    let proof = Self::prove_rounds_2_to_4(
+                        *air,
+                        *pub_inputs,
+                        &round_1_result,
+                        table_transcript,
+                        domain,
+                    )?;
+
+                    // Return column Vecs to pool (zero-copy move back)
+                    let (main_cols, aux_cols) = round_1_result.lde_trace.into_columns();
+                    for (slot, col) in pool.main.iter_mut().zip(main_cols) {
+                        *slot = col;
+                    }
+                    for (slot, col) in pool.aux.iter_mut().zip(aux_cols) {
+                        *slot = col;
+                    }
+
+                    Ok(proof)
+                })
+                .collect();
+
+            for result in chunk_results {
+                proofs.push(result?);
             }
         }
 
@@ -1762,7 +1837,7 @@ pub trait IsStarkProver<
         air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
         trace: &mut TraceTable<Field, FieldExtension>,
         pub_inputs: &PI,
-        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone),
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone + Send),
     ) -> Result<StarkProof<Field, FieldExtension, PI>, ProvingError>
     where
         FieldElement<Field>: AsBytes,

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -445,10 +445,18 @@ pub trait IsStarkProver<
     {
         let num_cols = trace.num_main_columns;
         trace.extract_columns_main_into(main_pool);
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         Self::expand_pool_to_lde::<Field>(main_pool, num_cols, domain, twiddles);
+        #[cfg(feature = "instruments")]
+        let main_lde_dur = t_sub.elapsed();
 
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         let (tree, root) = Self::commit_columns_bit_reversed(&main_pool[..num_cols])
             .ok_or(ProvingError::EmptyCommitment)?;
+        #[cfg(feature = "instruments")]
+        crate::instruments::accum_r1_main(main_lde_dur, t_sub.elapsed());
 
         transcript.append_bytes(&root);
 
@@ -483,8 +491,14 @@ pub trait IsStarkProver<
     {
         let num_cols = trace.num_main_columns;
         trace.extract_columns_main_into(main_pool);
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         Self::expand_pool_to_lde::<Field>(main_pool, num_cols, domain, twiddles);
+        #[cfg(feature = "instruments")]
+        let main_lde_dur = t_sub.elapsed();
 
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         let (precomputed_tree, precomputed_root) =
             Self::commit_columns_bit_reversed(&main_pool[..num_precomputed_cols])
                 .ok_or(ProvingError::EmptyCommitment)?;
@@ -492,6 +506,8 @@ pub trait IsStarkProver<
         let (mult_tree, mult_root) =
             Self::commit_columns_bit_reversed(&main_pool[num_precomputed_cols..num_cols])
                 .ok_or(ProvingError::EmptyCommitment)?;
+        #[cfg(feature = "instruments")]
+        crate::instruments::accum_r1_main(main_lde_dur, t_sub.elapsed());
 
         debug_assert_eq!(
             precomputed_root, precomputed_commitment,
@@ -806,6 +822,8 @@ pub trait IsStarkProver<
             round_1_result.bus_public_inputs.as_ref(),
             trace_length,
         );
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         let constraint_evaluations = evaluator.evaluate(
             air,
             &round_1_result.lde_trace,
@@ -814,9 +832,13 @@ pub trait IsStarkProver<
             boundary_coefficients,
             &round_1_result.rap_challenges,
         );
+        #[cfg(feature = "instruments")]
+        let constraints_dur = t_sub.elapsed();
 
         let number_of_parts = air.composition_poly_degree_bound(trace_length) / trace_length;
 
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         let lde_composition_poly_parts_evaluations = if number_of_parts == 2 {
             // Direct quotient decomposition: avoid full-size iFFT by algebraically
             // splitting H(x) = H₀(x²) + x·H₁(x²) using:
@@ -846,12 +868,21 @@ pub trait IsStarkProver<
                 })
                 .collect()
         };
+        #[cfg(feature = "instruments")]
+        let fft_dur = t_sub.elapsed();
 
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         let Some((composition_poly_merkle_tree, composition_poly_root)) =
             Self::commit_composition_polynomial(&lde_composition_poly_parts_evaluations)
         else {
             return Err(ProvingError::EmptyCommitment);
         };
+        #[cfg(feature = "instruments")]
+        let merkle_dur = t_sub.elapsed();
+
+        #[cfg(feature = "instruments")]
+        crate::instruments::store_r2_sub(constraints_dur, fft_dur, merkle_dur);
 
         Ok(Round2 {
             lde_composition_poly_evaluations: lde_composition_poly_parts_evaluations,
@@ -974,6 +1005,8 @@ pub trait IsStarkProver<
         let gammas = deep_composition_coefficients;
 
         // Compute p₀ (deep composition polynomial) as N evaluations on trace-size coset
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         let deep_evals = Self::compute_deep_composition_poly_evaluations(
             &round_1_result.lde_trace,
             round_2_result,
@@ -984,18 +1017,26 @@ pub trait IsStarkProver<
             &gammas,
             &trace_term_coeffs,
         );
+        #[cfg(feature = "instruments")]
+        let other_dur_1 = t_sub.elapsed();
 
         // Extend N trace-coset evaluations to 2N LDE-coset evaluations via standard LDE.
         // deep_evals[i] = h(offset·ω_N^i) = f(ω_N^i) where f(x) = h(offset·x).
         // Standard iFFT+FFT recovers f and evaluates on the 2N-th roots: f(Ω^j) = h(offset·Ω^j).
         let domain_size = domain.lde_roots_of_unity_coset.len();
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         let deep_poly =
             Polynomial::interpolate_fft::<Field>(&deep_evals).expect("iFFT should succeed");
         let mut lde_evals = Polynomial::evaluate_fft::<Field>(&deep_poly, 1, Some(domain_size))
             .expect("FFT should succeed");
         in_place_bit_reverse_permute(&mut lde_evals);
+        #[cfg(feature = "instruments")]
+        let r4_fft_dur = t_sub.elapsed();
 
         // FRI commit phase from pre-computed evaluations (no initial FFT)
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         let (fri_last_value, fri_layers) =
             fri::commit_phase_from_evaluations::<Field, FieldExtension>(
                 domain.root_order as usize,
@@ -1004,8 +1045,12 @@ pub trait IsStarkProver<
                 &coset_offset,
                 domain_size,
             );
+        #[cfg(feature = "instruments")]
+        let r4_merkle_dur = t_sub.elapsed();
 
         // grinding: generate nonce and append it to the transcript
+        #[cfg(feature = "instruments")]
+        let t_sub = Instant::now();
         let security_bits = air.context().proof_options.grinding_factor;
         let mut nonce = None;
         if security_bits > 0 {
@@ -1027,6 +1072,12 @@ pub trait IsStarkProver<
 
         let deep_poly_openings =
             Self::open_deep_composition_poly(domain, round_1_result, round_2_result, &iotas);
+
+        #[cfg(feature = "instruments")]
+        {
+            let queries_dur = t_sub.elapsed();
+            crate::instruments::store_r4_sub(r4_fft_dur, r4_merkle_dur, other_dur_1, queries_dur);
+        }
 
         Round4 {
             fri_last_value,
@@ -1408,6 +1459,9 @@ pub trait IsStarkProver<
         // Pre-pass: compute domains, twiddles, and max dimensions for pool allocation
         // =====================================================================
 
+        #[cfg(feature = "instruments")]
+        let phase_start = Instant::now();
+
         let mut domains = Vec::with_capacity(num_airs);
         let mut twiddle_caches: Vec<LdeTwiddles<Field>> = Vec::with_capacity(num_airs);
         let mut max_main_cols = 0usize;
@@ -1437,11 +1491,17 @@ pub trait IsStarkProver<
             .map(|_| Vec::with_capacity(max_lde_size))
             .collect();
 
+        #[cfg(feature = "instruments")]
+        let prepass_elapsed = phase_start.elapsed();
+
         // =====================================================================
         // Round 1, Phase A: Commit all main traces (lightweight)
         // =====================================================================
         // All main trace commitments must be in the transcript before sampling
         // LogUp challenges. Pool buffers are reused across tables.
+
+        #[cfg(feature = "instruments")]
+        let phase_start = Instant::now();
 
         let mut main_commits: Vec<MainCommitData<Field>> = Vec::with_capacity(num_airs);
 
@@ -1473,6 +1533,9 @@ pub trait IsStarkProver<
             });
         }
 
+        #[cfg(feature = "instruments")]
+        let main_commits_elapsed = phase_start.elapsed();
+
         // =====================================================================
         // Round 1, Phase B: Sample shared LogUp challenges
         // =====================================================================
@@ -1499,6 +1562,9 @@ pub trait IsStarkProver<
         // Pass 1: Build aux traces in parallel.
         // Each build_auxiliary_trace has internal parallelism (batch_inverse, par_chunks),
         // but outer parallelism over 12 tables also helps on high-core-count machines.
+        #[cfg(feature = "instruments")]
+        let phase_start = Instant::now();
+
         #[cfg(feature = "parallel")]
         let aux_iter = air_trace_pairs.par_iter_mut();
         #[cfg(not(feature = "parallel"))]
@@ -1513,8 +1579,14 @@ pub trait IsStarkProver<
             })
             .collect();
 
+        #[cfg(feature = "instruments")]
+        let aux_build_elapsed = phase_start.elapsed();
+
         // Pass 2: Sequential fork transcript → extract → LDE → commit.
         // Uses shared aux_pool. Each table gets its own transcript fork.
+        #[cfg(feature = "instruments")]
+        let phase_start = Instant::now();
+
         let mut metadatas: Vec<Round1Metadata<Field, FieldExtension>> =
             Vec::with_capacity(num_airs);
         let mut table_transcripts = Vec::with_capacity(num_airs);
@@ -1537,15 +1609,23 @@ pub trait IsStarkProver<
             let (aux_tree, aux_root) = if air.has_aux_trace() {
                 let num_aux_cols = trace.num_aux_columns;
                 trace.extract_columns_aux_into(&mut aux_pool);
+                #[cfg(feature = "instruments")]
+                let t_sub = Instant::now();
                 Self::expand_pool_to_lde::<FieldExtension>(
                     &mut aux_pool,
                     num_aux_cols,
                     domain,
                     twiddles,
                 );
+                #[cfg(feature = "instruments")]
+                let aux_lde_dur = t_sub.elapsed();
 
+                #[cfg(feature = "instruments")]
+                let t_sub = Instant::now();
                 let (tree, root) = Self::commit_columns_bit_reversed(&aux_pool[..num_aux_cols])
                     .ok_or(ProvingError::EmptyCommitment)?;
+                #[cfg(feature = "instruments")]
+                crate::instruments::accum_r1_aux(aux_lde_dur, t_sub.elapsed());
 
                 table_transcript.append_bytes(&root);
                 (Some(Rc::new(tree)), Some(root))
@@ -1567,6 +1647,9 @@ pub trait IsStarkProver<
             table_transcripts.push(table_transcript);
         }
 
+        #[cfg(feature = "instruments")]
+        let aux_commit_elapsed = phase_start.elapsed();
+
         #[cfg(feature = "debug-checks")]
         Self::run_debug_checks(
             &air_trace_pairs,
@@ -1583,6 +1666,12 @@ pub trait IsStarkProver<
         // For each table, recompute LDE into pool buffers, reuse stored Merkle trees,
         // run rounds 2-4 with the table's forked transcript, then drop table data.
 
+        #[cfg(feature = "instruments")]
+        let phase_start = Instant::now();
+        #[cfg(feature = "instruments")]
+        let mut table_timings: Vec<(String, usize, std::time::Duration, crate::instruments::TableSubOps)> =
+            Vec::with_capacity(num_airs);
+
         let mut proofs = Vec::with_capacity(num_airs);
         for (((((air, trace, pub_inputs), metadata), domain), twiddles), table_transcript) in
             air_trace_pairs
@@ -1592,7 +1681,12 @@ pub trait IsStarkProver<
                 .zip(twiddle_caches.iter())
                 .zip(table_transcripts.iter_mut())
         {
+            #[cfg(feature = "instruments")]
+            let table_start = Instant::now();
+
             // Recompute LDE evaluations into pool, reuse stored Merkle trees
+            #[cfg(feature = "instruments")]
+            let lde_start = Instant::now();
             let round_1_result = Self::reconstruct_round1(
                 *air,
                 *trace,
@@ -1602,6 +1696,8 @@ pub trait IsStarkProver<
                 &mut main_pool,
                 &mut aux_pool,
             )?;
+            #[cfg(feature = "instruments")]
+            let lde_dur = lde_start.elapsed();
 
             let proof = Self::prove_rounds_2_to_4(
                 *air,
@@ -1612,6 +1708,19 @@ pub trait IsStarkProver<
             )?;
             proofs.push(proof);
 
+            #[cfg(feature = "instruments")]
+            {
+                let mut sub_ops = crate::instruments::take_round_sub_ops()
+                    .unwrap_or_default();
+                sub_ops.trace_lde += lde_dur;
+                table_timings.push((
+                    air.name().to_string(),
+                    trace.num_rows(),
+                    table_start.elapsed(),
+                    sub_ops,
+                ));
+            }
+
             // Return column Vecs to pool (zero-copy move back). Pool slots that were
             // `take`n in reconstruct_round1 get their buffers back with capacity intact.
             let (main_cols, aux_cols) = round_1_result.lde_trace.into_columns();
@@ -1621,6 +1730,21 @@ pub trait IsStarkProver<
             for (slot, col) in aux_pool.iter_mut().zip(aux_cols) {
                 *slot = col;
             }
+        }
+
+        #[cfg(feature = "instruments")]
+        {
+            // Store timing data for the top-level report in prove_with_options.
+            // Uses a thread-local to avoid changing multi_prove's return type.
+            crate::instruments::store(crate::instruments::MultiProveTiming {
+                prepass: prepass_elapsed,
+                main_commits: main_commits_elapsed,
+                aux_build: aux_build_elapsed,
+                aux_commit: aux_commit_elapsed,
+                rounds_2_4: phase_start.elapsed(),
+                round1_sub: crate::instruments::take_r1_sub(),
+                table_timings,
+            });
         }
 
         Ok(MultiProof::new(proofs))
@@ -1665,11 +1789,6 @@ pub trait IsStarkProver<
         // ==========|   Round 2   |==========
         // ===================================
 
-        #[cfg(feature = "instruments")]
-        println!("- Started round 2: Compute composition polynomial");
-        #[cfg(feature = "instruments")]
-        let timer2 = Instant::now();
-
         // <<<< Receive challenge: 𝛽
         let beta = transcript.sample_field_element();
         let trace_length = domain.interpolation_domain_size;
@@ -1706,19 +1825,9 @@ pub trait IsStarkProver<
         // >>>> Send commitments: [H₁], [H₂]
         transcript.append_bytes(&round_2_result.composition_poly_root);
 
-        #[cfg(feature = "instruments")]
-        let elapsed2 = timer2.elapsed();
-        #[cfg(feature = "instruments")]
-        println!("  Time spent: {:?}", elapsed2);
-
         // ===================================
         // ==========|   Round 3   |==========
         // ===================================
-
-        #[cfg(feature = "instruments")]
-        println!("- Started round 3: Evaluate polynomial in out of domain elements");
-        #[cfg(feature = "instruments")]
-        let timer3 = Instant::now();
 
         // <<<< Receive challenge: z
         let z = transcript.sample_z_ood(
@@ -1726,6 +1835,8 @@ pub trait IsStarkProver<
             &domain.trace_roots_of_unity,
         );
 
+        #[cfg(feature = "instruments")]
+        let t_r3 = Instant::now();
         let round_3_result = Self::round_3_evaluate_polynomials_in_out_of_domain_element(
             air,
             domain,
@@ -1733,6 +1844,8 @@ pub trait IsStarkProver<
             &round_2_result,
             &z,
         );
+        #[cfg(feature = "instruments")]
+        let round_3_dur = t_r3.elapsed();
 
         // >>>> Send values: tⱼ(zgᵏ)
         let trace_ood_evaluations_columns = round_3_result.trace_ood_evaluations.columns();
@@ -1747,19 +1860,9 @@ pub trait IsStarkProver<
             transcript.append_field_element(element);
         }
 
-        #[cfg(feature = "instruments")]
-        let elapsed3 = timer3.elapsed();
-        #[cfg(feature = "instruments")]
-        println!("  Time spent: {:?}", elapsed3);
-
         // ===================================
         // ==========|   Round 4   |==========
         // ===================================
-
-        #[cfg(feature = "instruments")]
-        println!("- Started round 4: FRI");
-        #[cfg(feature = "instruments")]
-        let timer4 = Instant::now();
 
         // Part of this round is running FRI, which is an interactive
         // protocol on its own. Therefore we pass it the transcript
@@ -1775,19 +1878,23 @@ pub trait IsStarkProver<
         );
 
         #[cfg(feature = "instruments")]
-        let elapsed4 = timer4.elapsed();
-        #[cfg(feature = "instruments")]
-        println!("  Time spent: {:?}", elapsed4);
-
-        #[cfg(feature = "instruments")]
         {
-            let total_time = elapsed2 + elapsed3 + elapsed4;
-            println!(
-                " Fraction of proving time per round: {:.4} {:.4} {:.4}",
-                elapsed2.as_nanos() as f64 / total_time.as_nanos() as f64,
-                elapsed3.as_nanos() as f64 / total_time.as_nanos() as f64,
-                elapsed4.as_nanos() as f64 / total_time.as_nanos() as f64
-            );
+            let zero = std::time::Duration::ZERO;
+            let (r2_constraints, r2_fft, r2_merkle) =
+                crate::instruments::take_r2_sub().unwrap_or((zero, zero, zero));
+            let (r4_fft, r4_merkle, r4_deep_comp, r4_queries) =
+                crate::instruments::take_r4_sub().unwrap_or((zero, zero, zero, zero));
+            crate::instruments::store_round_sub_ops(crate::instruments::TableSubOps {
+                trace_lde: std::time::Duration::ZERO, // added by caller from lde_dur
+                constraints: r2_constraints,
+                comp_decompose: r2_fft,
+                comp_commit: r2_merkle,
+                ood: round_3_dur,
+                deep_comp: r4_deep_comp,
+                deep_extend: r4_fft,
+                fri_commit: r4_merkle,
+                queries: r4_queries,
+            });
         }
 
         info!("End proof generation");

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 default = ["parallel"]
 parallel = ["stark/parallel", "math/parallel", "crypto/parallel", "dep:rayon"]
 debug-checks = ["stark/debug-checks"]
+instruments = ["stark/instruments"]
 
 [dependencies]
 stark = { path = "../crypto/stark" }
@@ -22,4 +23,8 @@ criterion = { version = "0.5", default-features = false }
 
 [[bench]]
 name = "vm_prover_benchmark"
+harness = false
+
+[[bench]]
+name = "profile_vm_prover"
 harness = false

--- a/prover/benches/profile_vm_prover.rs
+++ b/prover/benches/profile_vm_prover.rs
@@ -3,13 +3,17 @@
 // Run with: `samply record cargo bench --bench profile_vm_prover --features parallel`
 // Or with hyperfine: `hyperfine --runs 1 './target/release/deps/profile_vm_prover-*'`
 //
-// Uses all_instructions_64.elf which exercises all supported RISC-V instructions.
+// Default ELF: fib_iterative_372k (~372k steps, realistic workload).
+// Override:    cargo bench --bench profile_vm_prover --features parallel -- <elf_name>
 
 use lambda_vm_prover::test_utils::asm_elf_bytes;
 
 fn main() {
-    let elf_name = "all_instructions_64";
-    let elf_bytes = asm_elf_bytes(elf_name);
+    let elf_name = std::env::args()
+        .skip(1)
+        .find(|a| !a.starts_with('-'))
+        .unwrap_or_else(|| "fib_iterative_372k".to_string());
+    let elf_bytes = asm_elf_bytes(&elf_name);
 
     println!("Starting VM prover profiling...");
     println!("Configuration:");

--- a/prover/src/instruments.rs
+++ b/prover/src/instruments.rs
@@ -1,0 +1,204 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+fn fmt_rows(rows: usize) -> String {
+    if rows >= 1_000_000 {
+        format!("{:.1}M", rows as f64 / 1_000_000.0)
+    } else if rows >= 1_000 {
+        format!("{}K", rows / 1_000)
+    } else {
+        format!("{rows}")
+    }
+}
+
+fn pct(dur: Duration, total: Duration) -> f64 {
+    if total > Duration::ZERO {
+        dur.as_secs_f64() / total.as_secs_f64() * 100.0
+    } else {
+        0.0
+    }
+}
+
+/// Top-level row: % in first column.
+fn row_top(label: &str, dur: Duration, total: Duration) {
+    eprintln!(
+        "  {:<36} {:>7.2}s  {:>5.1}%",
+        label,
+        dur.as_secs_f64(),
+        pct(dur, total),
+    );
+}
+
+/// Sub-level row: % shifted right into its own column.
+fn row_sub(label: &str, dur: Duration, total: Duration) {
+    eprintln!(
+        "  {:<36} {:>7.2}s         {:>5.1}%",
+        label,
+        dur.as_secs_f64(),
+        pct(dur, total),
+    );
+}
+
+/// Strip the `[N]` suffix to get the base table name.
+fn base_name(name: &str) -> &str {
+    name.find('[').map_or(name, |i| &name[..i])
+}
+
+struct MergedTable {
+    total_dur: Duration,
+    total_rows: usize,
+    count: usize,
+    sub_ops: stark::instruments::TableSubOps,
+}
+
+/// Print a unified timing report to stderr.
+pub fn print_report(
+    execute: Duration,
+    trace_build: Duration,
+    air_construction: Duration,
+    _prove: Duration,
+    total: Duration,
+) {
+    let mp = stark::instruments::take();
+
+    eprintln!();
+    eprintln!("=== PROVER TIMING ===");
+    eprintln!(
+        "  {:<36} {:>8}  {:>5}",
+        "Phase", "Wall", "%",
+    );
+    eprintln!("  {}", "─".repeat(58));
+
+    row_top("Execute", execute, total);
+    row_top("Trace build", trace_build, total);
+    row_top("AIR construction", air_construction, total);
+
+    if let Some(mp) = mp {
+        let round1 = mp.main_commits + mp.aux_build + mp.aux_commit;
+
+        row_top("Pre-pass (domains/twiddles)", mp.prepass, total);
+        row_top("Round 1", round1, total);
+        row_sub("  Main trace commits", mp.main_commits, total);
+        row_sub("    expand_pool_to_lde", mp.round1_sub.main_lde, total);
+        row_sub("    commit (Merkle)", mp.round1_sub.main_merkle, total);
+        row_sub("  Aux trace build (parallel)", mp.aux_build, total);
+        row_sub("  Aux trace commit", mp.aux_commit, total);
+        row_sub("    expand_pool_to_lde", mp.round1_sub.aux_lde, total);
+        row_sub("    commit (Merkle)", mp.round1_sub.aux_merkle, total);
+        row_top("Rounds 2\u{2013}4", mp.rounds_2_4, total);
+
+        // Merge split tables: MEMW[0..4] → MEMW x5
+        let mut merged: BTreeMap<String, MergedTable> = BTreeMap::new();
+        for (name, rows, dur, sub_ops) in &mp.table_timings {
+            let base = base_name(name).to_string();
+            let entry = merged.entry(base).or_insert(MergedTable {
+                total_dur: Duration::ZERO,
+                total_rows: 0,
+                count: 0,
+                sub_ops: stark::instruments::TableSubOps::default(),
+            });
+            entry.total_dur += *dur;
+            entry.total_rows += rows;
+            entry.count += 1;
+            entry.sub_ops.trace_lde += sub_ops.trace_lde;
+            entry.sub_ops.constraints += sub_ops.constraints;
+            entry.sub_ops.comp_decompose += sub_ops.comp_decompose;
+            entry.sub_ops.comp_commit += sub_ops.comp_commit;
+            entry.sub_ops.ood += sub_ops.ood;
+            entry.sub_ops.deep_comp += sub_ops.deep_comp;
+            entry.sub_ops.deep_extend += sub_ops.deep_extend;
+            entry.sub_ops.fri_commit += sub_ops.fri_commit;
+            entry.sub_ops.queries += sub_ops.queries;
+        }
+
+        let mut sorted: Vec<_> = merged.into_iter().collect();
+        sorted.sort_by(|a, b| b.1.total_dur.cmp(&a.1.total_dur));
+
+        let threshold = total.as_secs_f64() * 0.02;
+        let mut others_dur = Duration::ZERO;
+        let mut others_count = 0usize;
+
+        for (name, t) in &sorted {
+            if t.total_dur.as_secs_f64() >= threshold {
+                let display_name = if t.count > 1 {
+                    format!("{name} x{}", t.count)
+                } else {
+                    name.clone()
+                };
+                let label = format!(
+                    "    {:<18} {:>6}",
+                    display_name,
+                    fmt_rows(t.total_rows),
+                );
+                row_sub(&label, t.total_dur, total);
+            } else {
+                others_dur += t.total_dur;
+                others_count += 1;
+            }
+        }
+        if others_count > 0 {
+            let label = format!("    ({others_count} others)");
+            row_sub(&label, others_dur, total);
+        }
+
+        // Sub-operation totals across all tables
+        let mut total_trace_lde = Duration::ZERO;
+        let mut total_constraints = Duration::ZERO;
+        let mut total_comp_decompose = Duration::ZERO;
+        let mut total_comp_commit = Duration::ZERO;
+        let mut total_ood = Duration::ZERO;
+        let mut total_deep_comp = Duration::ZERO;
+        let mut total_deep_extend = Duration::ZERO;
+        let mut total_fri_commit = Duration::ZERO;
+        let mut total_queries = Duration::ZERO;
+        for (_, t) in &sorted {
+            total_trace_lde += t.sub_ops.trace_lde;
+            total_constraints += t.sub_ops.constraints;
+            total_comp_decompose += t.sub_ops.comp_decompose;
+            total_comp_commit += t.sub_ops.comp_commit;
+            total_ood += t.sub_ops.ood;
+            total_deep_comp += t.sub_ops.deep_comp;
+            total_deep_extend += t.sub_ops.deep_extend;
+            total_fri_commit += t.sub_ops.fri_commit;
+            total_queries += t.sub_ops.queries;
+        }
+
+        let sub_ops_sum = total_trace_lde + total_constraints + total_comp_decompose
+            + total_comp_commit + total_ood + total_deep_comp + total_deep_extend
+            + total_fri_commit + total_queries;
+        if sub_ops_sum > Duration::ZERO {
+            let mut sub_ops: Vec<(&str, Duration)> = vec![
+                ("R1  expand_pool_to_lde", total_trace_lde),
+                ("R2  evaluate", total_constraints),
+                ("R2  decompose_and_extend_d2", total_comp_decompose),
+                ("R2  commit_composition_poly", total_comp_commit),
+                ("R3  OOD evaluation", total_ood),
+                ("R4  deep_composition_poly_evals", total_deep_comp),
+                ("R4  interpolate+evaluate_fft", total_deep_extend),
+                ("R4  fri::commit_phase", total_fri_commit),
+                ("R4  queries & openings", total_queries),
+            ];
+            sub_ops.sort_by(|a, b| b.1.cmp(&a.1));
+            eprintln!(
+                "  {}",
+                "    \u{2500}\u{2500} sub-operation totals (all tables) \u{2500}\u{2500}",
+            );
+            for (label, dur) in &sub_ops {
+                row_sub(&format!("    {label}"), *dur, total);
+            }
+        }
+
+        // Cross-round totals: all FFT work and all Merkle work
+        let total_fft = mp.round1_sub.main_lde + mp.round1_sub.aux_lde
+            + total_trace_lde + total_comp_decompose + total_deep_extend;
+        let total_merkle = mp.round1_sub.main_merkle + mp.round1_sub.aux_merkle
+            + total_comp_commit + total_fri_commit;
+        eprintln!();
+        eprintln!("  {:<36} {:>7.2}s  {:>5.1}%", "Total FFT", total_fft.as_secs_f64(), pct(total_fft, total));
+        eprintln!("  {:<36} {:>7.2}s  {:>5.1}%", "Total Merkle", total_merkle.as_secs_f64(), pct(total_merkle, total));
+    }
+
+    eprintln!("  {}", "─".repeat(58));
+    eprintln!("  {:<36} {:>7.2}s", "TOTAL", total.as_secs_f64());
+    eprintln!();
+}

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -13,6 +13,8 @@
 pub mod constraints;
 #[cfg(feature = "debug-checks")]
 mod debug_report;
+#[cfg(feature = "instruments")]
+pub mod instruments;
 pub mod tables;
 pub mod test_utils;
 pub mod tests;
@@ -342,15 +344,37 @@ pub fn prove_with_options(
     proof_options: &ProofOptions,
     max_rows: &MaxRowsConfig,
 ) -> Result<VmProof, Error> {
+    #[cfg(feature = "instruments")]
+    let total_start = std::time::Instant::now();
+
+    // Phase 1: Execute (ELF load + run)
+    #[cfg(feature = "instruments")]
+    let phase_start = std::time::Instant::now();
+
     let program = Elf::load(elf_bytes).map_err(|e| Error::ElfLoad(format!("{e}")))?;
     let executor = Executor::new(&program, vec![]).map_err(|e| Error::Execution(format!("{e}")))?;
     let result = executor
         .run()
         .map_err(|e| Error::Execution(format!("{e}")))?;
 
+    #[cfg(feature = "instruments")]
+    let execute_elapsed = phase_start.elapsed();
+
+    // Phase 2: Trace build
+    #[cfg(feature = "instruments")]
+    let phase_start = std::time::Instant::now();
+
     // Generate all traces from ELF and execution logs.
     // Page tables are derived from the prover's MemoryState (all accessed pages).
     let mut traces = Traces::from_elf_and_logs(&program, &result.logs, max_rows)?;
+
+    #[cfg(feature = "instruments")]
+    let trace_build_elapsed = phase_start.elapsed();
+
+    // Phase 3: AIR construction
+    #[cfg(feature = "instruments")]
+    let phase_start = std::time::Instant::now();
+
     let table_counts = traces.table_counts();
     let airs = VmAirs::new(
         &program,
@@ -360,13 +384,32 @@ pub fn prove_with_options(
         &table_counts,
     );
 
+    #[cfg(feature = "instruments")]
+    let air_elapsed = phase_start.elapsed();
+
     let runtime_page_ranges = traces.runtime_page_ranges();
+
+    // Phase 4: Prove (multi_prove)
+    #[cfg(feature = "instruments")]
+    let phase_start = std::time::Instant::now();
 
     let proof = Prover::multi_prove(
         airs.air_trace_pairs(&mut traces),
         &mut DefaultTranscript::<E>::new(&[]),
     )
     .map_err(|e| Error::Prover(format!("{e:?}")))?;
+
+    #[cfg(feature = "instruments")]
+    {
+        let prove_elapsed = phase_start.elapsed();
+        instruments::print_report(
+            execute_elapsed,
+            trace_build_elapsed,
+            air_elapsed,
+            prove_elapsed,
+            total_start.elapsed(),
+        );
+    }
 
     Ok(VmProof {
         proof,


### PR DESCRIPTION
## Parallel table processing in `multi_prove`

  ### Problem

  `multi_prove` processes ~12 tables sequentially through 3 phases (main trace commit → aux trace commit → rounds 2-4). Each phase has internal parallelism via rayon within a single table, but tables wait for each other. On a 96-core EPYC, this
  creates a ~48s serial floor that can't be reduced by adding more threads.

  ### Solution

Process tables concurrently in chunks of K, where K = `num_cores / 3` (configurable via `TABLE_PARALLELISM` env var). Each concurrent slot gets its own LDE column buffer pool (`PoolSet`), eliminating the shared mutable state that forced sequential execution.

This K was measured in a couple of machines and it tends to be the current optimal (K/2 gives the same results but adds more memory pressure

  ### What changed

  **Thread safety**: `Rc<BatchedMerkleTree>` → `Arc<BatchedMerkleTree>` in all internal structs (`Round1CommitmentData`, `MainCommitData`, `Round1Metadata`). Added `+ Send` bound on transcript parameters.

  **Pool allocation**: Instead of 1 shared `main_pool` + `aux_pool`, allocate K independent `PoolSet` structs. Each pool set is reused across chunks — only K are live at once.

  **Phase A (main trace commit)**: Process tables in chunks of K via `par_iter_mut`. Transcript root appending stays sequential after each chunk to preserve Fiat-Shamir ordering. Removed `transcript` parameter from `commit_main_trace` /
  `commit_preprocessed_trace`.

  **Phase C (aux trace commit)**: Pre-fork all transcripts, then parallelize extract → LDE → commit in chunks of K. Aux roots appended to forked transcripts sequentially after each chunk.

  **Rounds 2-4**: Chunked parallel `reconstruct_round1` + `prove_rounds_2_to_4`. Each worker gets its own pool set and transcript fork via zip. Column buffers returned to pool within the closure.

  ### Fiat-Shamir security

  - Phase A: roots appended sequentially in table order after each parallel chunk
  - Phase B: unchanged (single shared transcript)
  - Phase C + Rounds 2-4: use forked transcripts (already independent per table, matches verifier)

  ### Benchmark results

  | Machine | Cores | Optimal K | Speedup |
  |---------|-------|-----------|---------|
  | Mac M3 Pro | 11 | 3-4 | ~5% (47.2s → 44.6s on 1M steps) |
  | EPYC 9454P | 96 | 32 | **2× (68.8s → 33.6s on 2M steps)** |

  Default K = `cores / 3`, which is optimal on both architectures. Override with `TABLE_PARALLELISM=N`. When K=1, behavior is identical to the previous sequential code.

  ### Memory impact

  K × current pool size. On Mac (K=3-4): ~3-4× pool memory. On EPYC (K=32): ~32× pool memory, well within 128 GB budget.