### PR TITLE
Parallel Tables

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -185,32 +185,35 @@ jobs:
       - name: Memory growth (PR)
         id: pr-growth
         env:
-          PR_HEAP: ${{ steps.pr.outputs.peak_mb }}
-          PR_TIME: ${{ steps.pr.outputs.time_s }}
+          TABLE_PARALLELISM: "1"
         run: |
           PROGRAMS=($GROWTH_PROGRAMS)
           STEPS_ARR=($GROWTH_STEPS)
           GROWTH_HEAPS=""
           GROWTH_TIMES=""
+          SAMPLES=2
 
           for idx in "${!PROGRAMS[@]}"; do
             prog="${PROGRAMS[$idx]}"
             ELF_PATH="executor/program_artifacts/asm/${prog}.elf"
-            if [ "$prog" = "fib_iterative_2M" ]; then
-              H="${PR_HEAP}"
-              T="${PR_TIME}"
-            else
-              echo "--- Growth: $prog ---"
+            SAMPLE_HEAPS=""
+            SAMPLE_TIMES=""
+            for s in $(seq 1 $SAMPLES); do
+              echo "--- Growth: $prog (sample $s/$SAMPLES, TABLE_PARALLELISM=1) ---"
               ./target/release/cli prove "$ELF_PATH" -o /tmp/proof.bin --time \
-                | tee /tmp/growth_${prog}.txt
+                | tee /tmp/growth_${prog}_${s}.txt
               rm -f /tmp/proof.bin
-              T=$(grep -o 'Proving time: [0-9.]*' /tmp/growth_${prog}.txt | awk '{print $3}')
-              H=$(grep -o 'Peak heap: [0-9]*' /tmp/growth_${prog}.txt | awk '{print $3}')
+              T=$(grep -o 'Proving time: [0-9.]*' /tmp/growth_${prog}_${s}.txt | awk '{print $3}')
+              H=$(grep -o 'Peak heap: [0-9]*' /tmp/growth_${prog}_${s}.txt | awk '{print $3}')
               if [ -z "$T" ] || [ -z "$H" ]; then
-                echo "::error::Failed to parse growth metrics for $prog"
+                echo "::error::Failed to parse growth metrics for $prog sample $s"
                 exit 1
               fi
-            fi
+              SAMPLE_HEAPS="$SAMPLE_HEAPS $H"
+              SAMPLE_TIMES="$SAMPLE_TIMES $T"
+            done
+            H=$(echo $SAMPLE_HEAPS | tr ' ' '\n' | sort -n | head -1)
+            T=$(echo $SAMPLE_TIMES | tr ' ' '\n' | sort -n | head -1)
             GROWTH_HEAPS="${GROWTH_HEAPS:+$GROWTH_HEAPS/}$H"
             GROWTH_TIMES="${GROWTH_TIMES:+$GROWTH_TIMES/}$T"
           done
@@ -361,30 +364,34 @@ jobs:
           echo "all_heaps=$ALL_HEAPS" >> "$GITHUB_OUTPUT"
           echo "runs=$RUNS" >> "$GITHUB_OUTPUT"
 
-          # --- Growth benchmarks (250k, 500k, 1M + reuse 2M median) ---
+          # --- Growth benchmarks (TABLE_PARALLELISM=1, 2 samples each) ---
           PROGRAMS=($GROWTH_PROGRAMS)
           STEPS_ARR=($GROWTH_STEPS)
           GROWTH_HEAPS=""
           GROWTH_TIMES=""
+          SAMPLES=2
 
           for idx in "${!PROGRAMS[@]}"; do
             prog="${PROGRAMS[$idx]}"
             ELF_PATH="executor/program_artifacts/asm/${prog}.elf"
-            if [ "$prog" = "fib_iterative_2M" ]; then
-              H="$HEAP_MEDIAN"
-              T="$TIME_MEDIAN"
-            else
-              echo "--- Baseline growth: $prog ---"
-              ./target/release/cli prove "$ELF_PATH" -o /tmp/proof.bin --time \
-                | tee /tmp/baseline_growth_${prog}.txt
+            SAMPLE_HEAPS=""
+            SAMPLE_TIMES=""
+            for s in $(seq 1 $SAMPLES); do
+              echo "--- Baseline growth: $prog (sample $s/$SAMPLES, TABLE_PARALLELISM=1) ---"
+              TABLE_PARALLELISM=1 ./target/release/cli prove "$ELF_PATH" -o /tmp/proof.bin --time \
+                | tee /tmp/baseline_growth_${prog}_${s}.txt
               rm -f /tmp/proof.bin
-              T=$(grep -o 'Proving time: [0-9.]*' /tmp/baseline_growth_${prog}.txt | awk '{print $3}')
-              H=$(grep -o 'Peak heap: [0-9]*' /tmp/baseline_growth_${prog}.txt | awk '{print $3}')
+              T=$(grep -o 'Proving time: [0-9.]*' /tmp/baseline_growth_${prog}_${s}.txt | awk '{print $3}')
+              H=$(grep -o 'Peak heap: [0-9]*' /tmp/baseline_growth_${prog}_${s}.txt | awk '{print $3}')
               if [ -z "$T" ] || [ -z "$H" ]; then
-                echo "::error::Failed to parse baseline growth metrics for $prog"
+                echo "::error::Failed to parse baseline growth metrics for $prog sample $s"
                 exit 1
               fi
-            fi
+              SAMPLE_HEAPS="$SAMPLE_HEAPS $H"
+              SAMPLE_TIMES="$SAMPLE_TIMES $T"
+            done
+            H=$(echo $SAMPLE_HEAPS | tr ' ' '\n' | sort -n | head -1)
+            T=$(echo $SAMPLE_TIMES | tr ' ' '\n' | sort -n | head -1)
             GROWTH_HEAPS="${GROWTH_HEAPS:+$GROWTH_HEAPS/}$H"
             GROWTH_TIMES="${GROWTH_TIMES:+$GROWTH_TIMES/}$T"
           done
@@ -614,6 +621,7 @@ jobs:
             // --- Section 1: Primary benchmark ---
             const nLabel = parseInt(runs) > 1 ? ` (median of ${runs})` : '';
             let body = `## Benchmark — fib_iterative_2M${nLabel}\n\n`;
+            body += `<sub>Table parallelism: 32 (auto = cores / 3)</sub>\n\n`;
             body += `| Metric | main | PR | Δ |\n`;
             body += `|--------|------|----|---|\n`;
             body += `| **Peak heap** | ${basePeak} MB | ${peak} MB | ${fmt(peakDiff)} MB (${fmt(peakPct)}%) ${icon(peakPct)} |\n`;
@@ -671,6 +679,7 @@ jobs:
               const programs = ['fib_iterative_250k', 'fib_iterative_500k', 'fib_iterative_1M', 'fib_iterative_2M'];
 
               body += `\n## Memory Growth\n\n`;
+              body += `<sub>Measured with \`TABLE_PARALLELISM=1\` (sequential) · best of 2 samples per point</sub>\n\n`;
 
               if (baseHeaps && baseHeaps.length === 4 && baseHeaps[0]) {
                 body += `| Program | Steps | main (MB) | PR (MB) | Δ |\n`;

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1509,10 +1509,8 @@ pub trait IsStarkProver<
                 let (tree, root, pre_tree, pre_root, n_pre) = result?;
                 if let Some(ref pre_r) = pre_root {
                     transcript.append_bytes(pre_r);
-                    transcript.append_bytes(&root);
-                } else {
-                    transcript.append_bytes(&root);
                 }
+                transcript.append_bytes(&root);
                 main_commits.push(MainCommitData {
                     main_tree: Arc::new(tree),
                     main_root: root,
@@ -1634,8 +1632,8 @@ pub trait IsStarkProver<
             Vec::with_capacity(num_airs);
         for ((main_commit, (aux_tree, aux_root)), bus_public_inputs) in main_commits
             .into_iter()
-            .zip(aux_results.into_iter())
-            .zip(bus_inputs_vec.into_iter())
+            .zip(aux_results)
+            .zip(bus_inputs_vec)
         {
             metadatas.push(Round1Metadata {
                 main_merkle_tree: Arc::clone(&main_commit.main_tree),

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1703,7 +1703,6 @@ pub trait IsStarkProver<
                         &mut pool.aux,
                     )?;
 
-                    // Bind table_contribution (L) to transcript for defense-in-depth.
                     if let Some(ref bpi) = round_1_result.bus_public_inputs {
                         table_transcript.append_field_element(&bpi.table_contribution);
                     }

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1563,13 +1563,8 @@ pub trait IsStarkProver<
             })
             .collect();
 
-        #[cfg(feature = "instruments")]
-        let aux_build_elapsed = phase_start.elapsed();
-
         // Pass 2: Parallel fork transcript → extract → LDE → commit in chunks of K.
         // Each table gets its own transcript fork and pool set.
-        #[cfg(feature = "instruments")]
-        let phase_start = Instant::now();
 
         // Pre-fork all transcripts (cheap, sequential — must match verifier ordering)
         let mut table_transcripts: Vec<_> = (0..num_airs)
@@ -1583,8 +1578,11 @@ pub trait IsStarkProver<
             .collect();
 
         // Parallel aux commit in chunks of K
-        let mut aux_results: Vec<(Option<Arc<BatchedMerkleTree<FieldExtension>>>, Option<Commitment>)> =
-            Vec::with_capacity(num_airs);
+        #[allow(clippy::type_complexity)]
+        let mut aux_results: Vec<(
+            Option<Arc<BatchedMerkleTree<FieldExtension>>>,
+            Option<Commitment>,
+        )> = Vec::with_capacity(num_airs);
 
         for chunk_start in (0..num_airs).step_by(k) {
             let chunk_end = (chunk_start + k).min(num_airs);
@@ -1670,12 +1668,6 @@ pub trait IsStarkProver<
         // =====================================================================
         // Each chunk of K tables is processed in parallel. Each worker gets its
         // own pool set and transcript fork. Pool sets are reused across chunks.
-
-        #[cfg(feature = "instruments")]
-        let phase_start = Instant::now();
-        #[cfg(feature = "instruments")]
-        let table_timings: Vec<(String, usize, std::time::Duration, crate::instruments::TableSubOps)> =
-            Vec::with_capacity(num_airs);
 
         let mut proofs = Vec::with_capacity(num_airs);
         for chunk_start in (0..num_airs).step_by(k) {

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::rc::Rc;
+use std::sync::Arc;
 #[cfg(feature = "instruments")]
 use std::time::Instant;
 
@@ -19,7 +19,8 @@ use math::{
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::{
-    IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
+    IntoParallelRefMutIterator, ParallelIterator,
 };
 
 #[cfg(feature = "debug-checks")]
@@ -80,12 +81,12 @@ where
 {
     /// The Merkle trees constructed to obtain the commitment of the entire trace table.
     /// For preprocessed tables, this contains only the multiplicity columns.
-    /// Wrapped in Rc to share with Round1Metadata without deep-cloning (~64MB per table).
-    pub(crate) lde_trace_merkle_tree: Rc<BatchedMerkleTree<F>>,
+    /// Wrapped in Arc to share with Round1Metadata without deep-cloning (~64MB per table).
+    pub(crate) lde_trace_merkle_tree: Arc<BatchedMerkleTree<F>>,
     /// The root of the Merkle tree in `lde_trace_merkle_tree`.
     pub(crate) lde_trace_merkle_root: Commitment,
     /// For preprocessed tables: Merkle tree over precomputed columns only.
-    pub(crate) precomputed_merkle_tree: Option<Rc<BatchedMerkleTree<F>>>,
+    pub(crate) precomputed_merkle_tree: Option<Arc<BatchedMerkleTree<F>>>,
     /// For preprocessed tables: root of the precomputed Merkle tree.
     pub(crate) precomputed_merkle_root: Option<Commitment>,
     /// For preprocessed tables: number of precomputed columns (for splitting during opening).
@@ -118,9 +119,9 @@ struct MainCommitData<Field: IsFFTField>
 where
     FieldElement<Field>: AsBytes,
 {
-    main_tree: Rc<BatchedMerkleTree<Field>>,
+    main_tree: Arc<BatchedMerkleTree<Field>>,
     main_root: Commitment,
-    precomputed_tree: Option<Rc<BatchedMerkleTree<Field>>>,
+    precomputed_tree: Option<Arc<BatchedMerkleTree<Field>>>,
     precomputed_root: Option<Commitment>,
     num_precomputed_cols: usize,
 }
@@ -136,18 +137,18 @@ where
     FieldElement<FieldExtension>: AsBytes,
 {
     /// Merkle tree of the main trace (multiplicities for preprocessed tables).
-    /// Wrapped in Rc to share with Round1CommitmentData without deep-cloning.
-    main_merkle_tree: Rc<BatchedMerkleTree<Field>>,
+    /// Wrapped in Arc to share with Round1CommitmentData without deep-cloning.
+    main_merkle_tree: Arc<BatchedMerkleTree<Field>>,
     /// Root of the main trace Merkle tree.
     main_merkle_root: Commitment,
     /// For preprocessed tables: Merkle tree over precomputed columns.
-    precomputed_merkle_tree: Option<Rc<BatchedMerkleTree<Field>>>,
+    precomputed_merkle_tree: Option<Arc<BatchedMerkleTree<Field>>>,
     /// For preprocessed tables: root of the precomputed Merkle tree.
     precomputed_merkle_root: Option<Commitment>,
     /// For preprocessed tables: number of precomputed columns.
     num_precomputed_cols: usize,
     /// Merkle tree of the auxiliary trace (None if no aux trace).
-    aux_merkle_tree: Option<Rc<BatchedMerkleTree<FieldExtension>>>,
+    aux_merkle_tree: Option<Arc<BatchedMerkleTree<FieldExtension>>>,
     /// Root of the auxiliary trace Merkle tree (None if no aux trace).
     aux_merkle_root: Option<Commitment>,
     /// The RAP challenges used for auxiliary trace construction.
@@ -199,6 +200,34 @@ impl<F: IsFFTField> LdeTwiddles<F> {
             coset_weights,
         }
     }
+}
+
+/// Number of tables to process concurrently in `multi_prove`.
+/// Default: num_cores / 3 (benchmarked optimal on both M3 Pro and EPYC 9454P).
+/// Override with `TABLE_PARALLELISM` env var.
+fn table_parallelism() -> usize {
+    #[cfg(feature = "parallel")]
+    {
+        std::env::var("TABLE_PARALLELISM")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| {
+                let cores = std::thread::available_parallelism()
+                    .map(|n| n.get())
+                    .unwrap_or(4);
+                (cores / 3).max(1)
+            })
+    }
+    #[cfg(not(feature = "parallel"))]
+    {
+        1
+    }
+}
+
+/// A set of LDE column buffer pools for one concurrent table slot.
+struct PoolSet<F: IsField, E: IsField> {
+    main: Vec<Vec<FieldElement<F>>>,
+    aux: Vec<Vec<FieldElement<E>>>,
 }
 
 /// A container for the results of the second round of the STARK Prove protocol.
@@ -426,7 +455,6 @@ pub trait IsStarkProver<
     fn commit_main_trace(
         trace: &TraceTable<Field, FieldExtension>,
         domain: &Domain<Field>,
-        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
         twiddles: &LdeTwiddles<Field>,
         main_pool: &mut [Vec<FieldElement<Field>>],
     ) -> Result<
@@ -450,8 +478,6 @@ pub trait IsStarkProver<
         let (tree, root) = Self::commit_columns_bit_reversed(&main_pool[..num_cols])
             .ok_or(ProvingError::EmptyCommitment)?;
 
-        transcript.append_bytes(&root);
-
         // Pool buffers retain capacity; tree is returned to caller
         Ok((tree, root, None, None, 0))
     }
@@ -462,7 +488,6 @@ pub trait IsStarkProver<
     fn commit_preprocessed_trace(
         trace: &TraceTable<Field, FieldExtension>,
         domain: &Domain<Field>,
-        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
         precomputed_commitment: Commitment,
         num_precomputed_cols: usize,
         twiddles: &LdeTwiddles<Field>,
@@ -498,9 +523,6 @@ pub trait IsStarkProver<
             "Prover's precomputed commitment doesn't match hardcoded AIR commitment"
         );
 
-        transcript.append_bytes(&precomputed_commitment);
-        transcript.append_bytes(&mult_root);
-
         // Pool buffers retain capacity; trees are returned to caller
         Ok((
             mult_tree,
@@ -534,11 +556,11 @@ pub trait IsStarkProver<
         trace.extract_columns_main_into(main_pool);
         Self::expand_pool_to_lde::<Field>(main_pool, num_main_cols, domain, twiddles);
 
-        // Use stored Merkle trees from Phase A/C via Rc (pointer copy, no deep clone)
+        // Use stored Merkle trees from Phase A/C via Arc (pointer copy, no deep clone)
         let main = Round1CommitmentData::<Field> {
-            lde_trace_merkle_tree: Rc::clone(&metadata.main_merkle_tree),
+            lde_trace_merkle_tree: Arc::clone(&metadata.main_merkle_tree),
             lde_trace_merkle_root: metadata.main_merkle_root,
-            precomputed_merkle_tree: metadata.precomputed_merkle_tree.as_ref().map(Rc::clone),
+            precomputed_merkle_tree: metadata.precomputed_merkle_tree.as_ref().map(Arc::clone),
             precomputed_merkle_root: metadata.precomputed_merkle_root,
             num_precomputed_cols: metadata.num_precomputed_cols,
         };
@@ -550,7 +572,7 @@ pub trait IsStarkProver<
             Self::expand_pool_to_lde::<FieldExtension>(aux_pool, n_aux, domain, twiddles);
             // Safe: has_aux_trace() is true only when Phase C stored aux tree/root
             let aux_commitment = Round1CommitmentData::<FieldExtension> {
-                lde_trace_merkle_tree: Rc::clone(
+                lde_trace_merkle_tree: Arc::clone(
                     metadata
                         .aux_merkle_tree
                         .as_ref()
@@ -1389,7 +1411,7 @@ pub trait IsStarkProver<
     /// The transcript must be safely initialized before passing it to this method.
     fn multi_prove(
         mut air_trace_pairs: Vec<AirTracePair<'_, Field, FieldExtension, PI>>,
-        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone),
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone + Send),
     ) -> Result<MultiProof<Field, FieldExtension, PI>, ProvingError>
     where
         FieldElement<Field>: AsBytes,
@@ -1430,48 +1452,75 @@ pub trait IsStarkProver<
             twiddle_caches.push(twiddles);
         }
 
-        // Allocate LDE column buffer pools — reused across all tables and phases.
-        let mut main_pool: Vec<Vec<FieldElement<Field>>> = (0..max_main_cols)
-            .map(|_| Vec::with_capacity(max_lde_size))
-            .collect();
-        let mut aux_pool: Vec<Vec<FieldElement<FieldExtension>>> = (0..max_aux_cols)
-            .map(|_| Vec::with_capacity(max_lde_size))
+        // Allocate K independent LDE column buffer pool sets for parallel table processing.
+        let k = table_parallelism().min(num_airs).max(1);
+        let mut pool_sets: Vec<PoolSet<Field, FieldExtension>> = (0..k)
+            .map(|_| PoolSet {
+                main: (0..max_main_cols)
+                    .map(|_| Vec::with_capacity(max_lde_size))
+                    .collect(),
+                aux: (0..max_aux_cols)
+                    .map(|_| Vec::with_capacity(max_lde_size))
+                    .collect(),
+            })
             .collect();
 
         // =====================================================================
-        // Round 1, Phase A: Commit all main traces (lightweight)
+        // Round 1, Phase A: Commit all main traces (parallel in chunks of K)
         // =====================================================================
         // All main trace commitments must be in the transcript before sampling
-        // LogUp challenges. Pool buffers are reused across tables.
+        // LogUp challenges. Pool buffers are reused across chunks.
 
         let mut main_commits: Vec<MainCommitData<Field>> = Vec::with_capacity(num_airs);
 
-        for ((air, trace, _pub_inputs), twiddles) in
-            air_trace_pairs.iter().zip(twiddle_caches.iter())
-        {
-            let domain = &domains[main_commits.len()];
+        for chunk_start in (0..num_airs).step_by(k) {
+            let chunk_end = (chunk_start + k).min(num_airs);
+            let chunk_size = chunk_end - chunk_start;
 
-            let (tree, root, pre_tree, pre_root, n_pre) = if air.is_preprocessed() {
-                Self::commit_preprocessed_trace(
-                    *trace,
-                    domain,
-                    transcript,
-                    air.precomputed_commitment(),
-                    air.num_precomputed_columns(),
-                    twiddles,
-                    &mut main_pool,
-                )?
-            } else {
-                Self::commit_main_trace(*trace, domain, transcript, twiddles, &mut main_pool)?
-            };
+            #[cfg(feature = "parallel")]
+            let iter = pool_sets[..chunk_size].par_iter_mut().enumerate();
+            #[cfg(not(feature = "parallel"))]
+            let iter = pool_sets[..chunk_size].iter_mut().enumerate();
 
-            main_commits.push(MainCommitData {
-                main_tree: Rc::new(tree),
-                main_root: root,
-                precomputed_tree: pre_tree.map(Rc::new),
-                precomputed_root: pre_root,
-                num_precomputed_cols: n_pre,
-            });
+            let chunk_results: Vec<Result<_, ProvingError>> = iter
+                .map(|(j, pool)| {
+                    let idx = chunk_start + j;
+                    let (air, trace, _) = &air_trace_pairs[idx];
+                    let domain = &domains[idx];
+                    let twiddles = &twiddle_caches[idx];
+
+                    if air.is_preprocessed() {
+                        Self::commit_preprocessed_trace(
+                            *trace,
+                            domain,
+                            air.precomputed_commitment(),
+                            air.num_precomputed_columns(),
+                            twiddles,
+                            &mut pool.main,
+                        )
+                    } else {
+                        Self::commit_main_trace(*trace, domain, twiddles, &mut pool.main)
+                    }
+                })
+                .collect();
+
+            // Sequential: append roots to shared transcript (Fiat-Shamir ordering)
+            for result in chunk_results {
+                let (tree, root, pre_tree, pre_root, n_pre) = result?;
+                if let Some(ref pre_r) = pre_root {
+                    transcript.append_bytes(pre_r);
+                    transcript.append_bytes(&root);
+                } else {
+                    transcript.append_bytes(&root);
+                }
+                main_commits.push(MainCommitData {
+                    main_tree: Arc::new(tree),
+                    main_root: root,
+                    precomputed_tree: pre_tree.map(Arc::new),
+                    precomputed_root: pre_root,
+                    num_precomputed_cols: n_pre,
+                });
+            }
         }
 
         // =====================================================================
@@ -1514,50 +1563,86 @@ pub trait IsStarkProver<
             })
             .collect();
 
-        // Pass 2: Sequential fork transcript → extract → LDE → commit.
-        // Uses shared aux_pool. Each table gets its own transcript fork.
+        #[cfg(feature = "instruments")]
+        let aux_build_elapsed = phase_start.elapsed();
+
+        // Pass 2: Parallel fork transcript → extract → LDE → commit in chunks of K.
+        // Each table gets its own transcript fork and pool set.
+        #[cfg(feature = "instruments")]
+        let phase_start = Instant::now();
+
+        // Pre-fork all transcripts (cheap, sequential — must match verifier ordering)
+        let mut table_transcripts: Vec<_> = (0..num_airs)
+            .map(|idx| {
+                let mut t = transcript.clone();
+                if num_airs > 1 {
+                    t.append_bytes(&(idx as u64).to_le_bytes());
+                }
+                t
+            })
+            .collect();
+
+        // Parallel aux commit in chunks of K
+        let mut aux_results: Vec<(Option<Arc<BatchedMerkleTree<FieldExtension>>>, Option<Commitment>)> =
+            Vec::with_capacity(num_airs);
+
+        for chunk_start in (0..num_airs).step_by(k) {
+            let chunk_end = (chunk_start + k).min(num_airs);
+            let chunk_size = chunk_end - chunk_start;
+
+            #[cfg(feature = "parallel")]
+            let iter = pool_sets[..chunk_size].par_iter_mut().enumerate();
+            #[cfg(not(feature = "parallel"))]
+            let iter = pool_sets[..chunk_size].iter_mut().enumerate();
+
+            let chunk_aux: Vec<Result<_, ProvingError>> = iter
+                .map(|(j, pool)| {
+                    let idx = chunk_start + j;
+                    let (air, trace, _) = &air_trace_pairs[idx];
+                    let domain = &domains[idx];
+                    let twiddles = &twiddle_caches[idx];
+
+                    if air.has_aux_trace() {
+                        let num_aux_cols = trace.num_aux_columns;
+                        trace.extract_columns_aux_into(&mut pool.aux);
+                        Self::expand_pool_to_lde::<FieldExtension>(
+                            &mut pool.aux,
+                            num_aux_cols,
+                            domain,
+                            twiddles,
+                        );
+                        let (tree, root) =
+                            Self::commit_columns_bit_reversed(&pool.aux[..num_aux_cols])
+                                .ok_or(ProvingError::EmptyCommitment)?;
+                        Ok((Some(Arc::new(tree)), Some(root)))
+                    } else {
+                        Ok((None, None))
+                    }
+                })
+                .collect();
+
+            // Sequential: append aux roots to forked transcripts
+            for (j, result) in chunk_aux.into_iter().enumerate() {
+                let (aux_tree, aux_root) = result?;
+                if let Some(ref root) = aux_root {
+                    table_transcripts[chunk_start + j].append_bytes(root);
+                }
+                aux_results.push((aux_tree, aux_root));
+            }
+        }
+
+        // Build metadata sequentially from main_commits + aux_results + bus_inputs
         let mut metadatas: Vec<Round1Metadata<Field, FieldExtension>> =
             Vec::with_capacity(num_airs);
-        let mut table_transcripts = Vec::with_capacity(num_airs);
-        for (
-            idx,
-            ((((air, trace, _pub_inputs), bus_public_inputs), main_commit), (domain, twiddles)),
-        ) in air_trace_pairs
-            .iter()
+        for ((main_commit, (aux_tree, aux_root)), bus_public_inputs) in main_commits
+            .into_iter()
+            .zip(aux_results.into_iter())
             .zip(bus_inputs_vec.into_iter())
-            .zip(main_commits.into_iter())
-            .zip(domains.iter().zip(twiddle_caches.iter()))
-            .enumerate()
         {
-            // Fork transcript with domain separator (must match verifier)
-            let mut table_transcript = transcript.clone();
-            if num_airs > 1 {
-                table_transcript.append_bytes(&(idx as u64).to_le_bytes());
-            }
-
-            let (aux_tree, aux_root) = if air.has_aux_trace() {
-                let num_aux_cols = trace.num_aux_columns;
-                trace.extract_columns_aux_into(&mut aux_pool);
-                Self::expand_pool_to_lde::<FieldExtension>(
-                    &mut aux_pool,
-                    num_aux_cols,
-                    domain,
-                    twiddles,
-                );
-
-                let (tree, root) = Self::commit_columns_bit_reversed(&aux_pool[..num_aux_cols])
-                    .ok_or(ProvingError::EmptyCommitment)?;
-
-                table_transcript.append_bytes(&root);
-                (Some(Rc::new(tree)), Some(root))
-            } else {
-                (None, None)
-            };
-
             metadatas.push(Round1Metadata {
-                main_merkle_tree: Rc::clone(&main_commit.main_tree),
+                main_merkle_tree: Arc::clone(&main_commit.main_tree),
                 main_merkle_root: main_commit.main_root,
-                precomputed_merkle_tree: main_commit.precomputed_tree.as_ref().map(Rc::clone),
+                precomputed_merkle_tree: main_commit.precomputed_tree.as_ref().map(Arc::clone),
                 precomputed_merkle_root: main_commit.precomputed_root,
                 num_precomputed_cols: main_commit.num_precomputed_cols,
                 aux_merkle_tree: aux_tree,
@@ -1565,67 +1650,97 @@ pub trait IsStarkProver<
                 rap_challenges: lookup_challenges.clone(),
                 bus_public_inputs,
             });
-            table_transcripts.push(table_transcript);
         }
 
         #[cfg(feature = "debug-checks")]
-        Self::run_debug_checks(
-            &air_trace_pairs,
-            &metadatas,
-            &domains,
-            &twiddle_caches,
-            &mut main_pool,
-            &mut aux_pool,
-        );
+        {
+            let debug_pool = &mut pool_sets[0];
+            Self::run_debug_checks(
+                &air_trace_pairs,
+                &metadatas,
+                &domains,
+                &twiddle_caches,
+                &mut debug_pool.main,
+                &mut debug_pool.aux,
+            );
+        }
 
         // =====================================================================
-        // Rounds 2-4: Sequential per-table proving with forked transcripts
+        // Rounds 2-4: Parallel per-table proving in chunks of K
         // =====================================================================
-        // For each table, recompute LDE into pool buffers, reuse stored Merkle trees,
-        // run rounds 2-4 with the table's forked transcript, then drop table data.
+        // Each chunk of K tables is processed in parallel. Each worker gets its
+        // own pool set and transcript fork. Pool sets are reused across chunks.
+
+        #[cfg(feature = "instruments")]
+        let phase_start = Instant::now();
+        #[cfg(feature = "instruments")]
+        let table_timings: Vec<(String, usize, std::time::Duration, crate::instruments::TableSubOps)> =
+            Vec::with_capacity(num_airs);
 
         let mut proofs = Vec::with_capacity(num_airs);
-        for (((((air, trace, pub_inputs), metadata), domain), twiddles), table_transcript) in
-            air_trace_pairs
-                .iter()
-                .zip(metadatas.iter())
-                .zip(domains.iter())
-                .zip(twiddle_caches.iter())
-                .zip(table_transcripts.iter_mut())
-        {
-            // Recompute LDE evaluations into pool, reuse stored Merkle trees
-            let round_1_result = Self::reconstruct_round1(
-                *air,
-                *trace,
-                domain,
-                metadata,
-                twiddles,
-                &mut main_pool,
-                &mut aux_pool,
-            )?;
+        for chunk_start in (0..num_airs).step_by(k) {
+            let chunk_end = (chunk_start + k).min(num_airs);
+            let chunk_size = chunk_end - chunk_start;
 
-            // Bind table_contribution (L) to transcript for defense-in-depth.
-            if let Some(ref bpi) = round_1_result.bus_public_inputs {
-                table_transcript.append_field_element(&bpi.table_contribution);
-            }
+            let chunk_transcripts = &mut table_transcripts[chunk_start..chunk_end];
 
-            let proof = Self::prove_rounds_2_to_4(
-                *air,
-                *pub_inputs,
-                &round_1_result,
-                table_transcript,
-                domain,
-            )?;
-            proofs.push(proof);
+            #[cfg(feature = "parallel")]
+            let iter = pool_sets[..chunk_size]
+                .par_iter_mut()
+                .zip(chunk_transcripts.par_iter_mut())
+                .enumerate();
+            #[cfg(not(feature = "parallel"))]
+            let iter = pool_sets[..chunk_size]
+                .iter_mut()
+                .zip(chunk_transcripts.iter_mut())
+                .enumerate();
 
-            // Return column Vecs to pool (zero-copy move back). Pool slots that were
-            // `take`n in reconstruct_round1 get their buffers back with capacity intact.
-            let (main_cols, aux_cols) = round_1_result.lde_trace.into_columns();
-            for (slot, col) in main_pool.iter_mut().zip(main_cols) {
-                *slot = col;
-            }
-            for (slot, col) in aux_pool.iter_mut().zip(aux_cols) {
-                *slot = col;
+            let chunk_results: Vec<Result<_, ProvingError>> = iter
+                .map(|(j, (pool, table_transcript))| {
+                    let idx = chunk_start + j;
+                    let (air, trace, pub_inputs) = &air_trace_pairs[idx];
+                    let metadata = &metadatas[idx];
+                    let domain = &domains[idx];
+                    let twiddles = &twiddle_caches[idx];
+
+                    let round_1_result = Self::reconstruct_round1(
+                        *air,
+                        *trace,
+                        domain,
+                        metadata,
+                        twiddles,
+                        &mut pool.main,
+                        &mut pool.aux,
+                    )?;
+
+                    // Bind table_contribution (L) to transcript for defense-in-depth.
+                    if let Some(ref bpi) = round_1_result.bus_public_inputs {
+                        table_transcript.append_field_element(&bpi.table_contribution);
+                    }
+
+                    let proof = Self::prove_rounds_2_to_4(
+                        *air,
+                        *pub_inputs,
+                        &round_1_result,
+                        table_transcript,
+                        domain,
+                    )?;
+
+                    // Return column Vecs to pool (zero-copy move back)
+                    let (main_cols, aux_cols) = round_1_result.lde_trace.into_columns();
+                    for (slot, col) in pool.main.iter_mut().zip(main_cols) {
+                        *slot = col;
+                    }
+                    for (slot, col) in pool.aux.iter_mut().zip(aux_cols) {
+                        *slot = col;
+                    }
+
+                    Ok(proof)
+                })
+                .collect();
+
+            for result in chunk_results {
+                proofs.push(result?);
             }
         }
 
@@ -1638,7 +1753,7 @@ pub trait IsStarkProver<
         air: &dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>,
         trace: &mut TraceTable<Field, FieldExtension>,
         pub_inputs: &PI,
-        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone),
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone + Send),
     ) -> Result<StarkProof<Field, FieldExtension, PI>, ProvingError>
     where
         FieldElement<Field>: AsBytes,


### PR DESCRIPTION
## Parallel table processing in `multi_prove`, update benchmarks to be more representatives

  ### Problem

  `multi_prove` processes ~12 tables sequentially through 3 phases (main trace commit → aux trace commit → rounds 2-4). Each phase has internal parallelism via rayon within a single table, but tables wait for each other. On a 96-core EPYC, this
  creates a ~48s serial floor that can't be reduced by adding more threads.

  ### Solution

Process tables concurrently in chunks of K, where K = `num_cores / 3` (configurable via `TABLE_PARALLELISM` env var). Each concurrent slot gets its own LDE column buffer pool (`PoolSet`), eliminating the shared mutable state that forced sequential execution.

This K was measured in a couple of machines and it tends to be the current optimal (K/2 gives the same results but adds more memory pressure

  ### What changed

  **Thread safety**: `Rc<BatchedMerkleTree>` → `Arc<BatchedMerkleTree>` in all internal structs (`Round1CommitmentData`, `MainCommitData`, `Round1Metadata`). Added `+ Send` bound on transcript parameters.

  **Pool allocation**: Instead of 1 shared `main_pool` + `aux_pool`, allocate K independent `PoolSet` structs. Each pool set is reused across chunks — only K are live at once.

  **Phase A (main trace commit)**: Process tables in chunks of K via `par_iter_mut`. Transcript root appending stays sequential after each chunk to preserve Fiat-Shamir ordering. Removed `transcript` parameter from `commit_main_trace` /
  `commit_preprocessed_trace`.

  **Phase C (aux trace commit)**: Pre-fork all transcripts, then parallelize extract → LDE → commit in chunks of K. Aux roots appended to forked transcripts sequentially after each chunk.

  **Rounds 2-4**: Chunked parallel `reconstruct_round1` + `prove_rounds_2_to_4`. Each worker gets its own pool set and transcript fork via zip. Column buffers returned to pool within the closure.

  ### Fiat-Shamir security

  - Phase A: roots appended sequentially in table order after each parallel chunk
  - Phase B: unchanged (single shared transcript)
  - Phase C + Rounds 2-4: use forked transcripts (already independent per table, matches verifier)

  ### Benchmark results

  | Machine | Cores | Optimal K | Speedup |
  |---------|-------|-----------|---------|
  | Mac M3 Pro | 11 | 3-4 | ~5% (47.2s → 44.6s on 1M steps) |
  | EPYC 9454P | 96 | 32 | **2× (68.8s → 33.6s on 2M steps)** |

  Default K = `cores / 3`, which is optimal on both architectures. Override with `TABLE_PARALLELISM=N`. When K=1, behavior is identical to the previous sequential code.

  ### Memory impact

  K × current pool size. On Mac (K=3-4): ~3-4× pool memory. On EPYC (K=32): ~32× pool memory, well within 128 GB budget.
  
  
  ## Benchmark

Problem: With parallel tables, the primary benchmark now uses multiple LDE buffer pools (cores/3 copies), inflating heap. The growth section was reusing the 2M heap from the primary run, so memory scaling numbers would reflect parallel overhead, not true memory growth.

  Changes:

  1. TABLE_PARALLELISM=1 for all growth runs — measures memory without parallel pool duplication. The PR growth step sets it via env:, the baseline growth step sets it inline (TABLE_PARALLELISM=1 ./target/release/cli prove ...) because it shares a step with the primary benchmark that needs default parallelism.
  2. 2M no longer reused — previously the growth section skipped running 2M and grabbed the heap/time from the primary benchmark. Now it runs all 4 points fresh with TABLE_PARALLELISM=1, so all points are measured under the same conditions.
  3. 2 samples per point, take min — each growth program runs twice. Takes the lower value for both heap and time. Insurance against transient noise; jemalloc peak heap should be identical across runs anyway.
  4. Labels in the PR comment — primary benchmark table now says "Table parallelism: 32 (auto = cores / 3)". Memory growth section says "Measured with TABLE_PARALLELISM=1 (sequential) · best of 2 samples per point". Makes it clear what each section measures.