### PR TITLE
fix: add cargo to PATH in benchmark CI

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -88,6 +88,9 @@ jobs:
             fi
           done
 
+      - name: Add cargo to PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - name: Build CLI (PR)
         run: cargo build --release -p cli --features jemalloc-stats
 


### PR DESCRIPTION
## Summary
- The self-hosted bench runner has Rust installed at `~/.cargo/bin` but GitHub Actions uses a non-login shell (`bash -e`) that doesn't source `.profile`, so `cargo` is not in PATH
- Adds a step to write `$HOME/.cargo/bin` to `$GITHUB_PATH`, making `cargo` available for all subsequent steps in the job

## Test plan
- [ ] Trigger the benchmark workflow and verify the `Build CLI (PR)` step succeeds