### PR TITLE
fix: update stale syscall numbers in benchmark ELFs

### DIFF
--- a/executor/programs/asm/fib_iterative_250k.s
+++ b/executor/programs/asm/fib_iterative_250k.s
@@ -19,5 +19,5 @@ main:
 	bnez	a0, .loop		# loop if n != 0
 
 	mv	a0, t1			# result = b
-	li	a7, 5
+	li	a7, 93
 	ecall				# halt with result in a0

--- a/executor/programs/asm/fib_iterative_2M.s
+++ b/executor/programs/asm/fib_iterative_2M.s
@@ -19,5 +19,5 @@ main:
 	bnez	a0, .loop		# loop if n != 0
 
 	mv	a0, t1			# result = b
-	li	a7, 5
+	li	a7, 93
 	ecall				# halt with result in a0

--- a/executor/programs/asm/fib_iterative_500k.s
+++ b/executor/programs/asm/fib_iterative_500k.s
@@ -19,5 +19,5 @@ main:
 	bnez	a0, .loop		# loop if n != 0
 
 	mv	a0, t1			# result = b
-	li	a7, 5
+	li	a7, 93
 	ecall				# halt with result in a0


### PR DESCRIPTION

Benchmark programs (fib_iterative_250k.s, fib_iterative_500k.s, fib_iterative_2M.s) still used the old Halt syscall number (5) instead of the new one (93), causing benchmark CI to fail with
  Unknown syscall number: 5.