### PR TITLE
Fix CPU table deviations from spec

### DIFF
--- a/prover/src/constraints/cpu.rs
+++ b/prover/src/constraints/cpu.rs
@@ -1179,6 +1179,79 @@ impl TransitionConstraint<GoldilocksField, GoldilocksExtension> for RvdUpperCons
 }
 
 // =========================================================================
+// read_register - register Constraints (CM48, CM50)
+// =========================================================================
+
+/// Constraint: `(1 - flag_col) * value_col = 0`
+///
+/// Forces `value_col` to zero whenever `flag_col` is 0.
+///
+/// Used for:
+/// - CPU-CM48.i: `(1 - read_register1) * rv1[i] = 0` for i ∈ [0, 2]
+///   When read_register1 = 0 (rs1 is x0), rv1 is not loaded from memory,
+///   so it must be forced to zero by a polynomial constraint.
+/// - CPU-CM50.i: `(1 - read_register2) * rv2[i] = 0` for i ∈ [0, 2]
+///   Same logic for rv2 when read_register2 = 0 (I-type instructions).
+pub struct RegNotReadIsZeroConstraint {
+    flag_col: usize,
+    value_col: usize,
+    constraint_idx: usize,
+}
+
+impl RegNotReadIsZeroConstraint {
+    pub fn new(flag_col: usize, value_col: usize, constraint_idx: usize) -> Self {
+        Self {
+            flag_col,
+            value_col,
+            constraint_idx,
+        }
+    }
+
+    fn compute<F, E>(&self, step: &TableView<F, E>) -> FieldElement<F>
+    where
+        F: IsSubFieldOf<E>,
+        E: IsField,
+    {
+        let flag = step.get_main_evaluation_element(0, self.flag_col).clone();
+        let value = step.get_main_evaluation_element(0, self.value_col).clone();
+        let one = FieldElement::<F>::one();
+        // (1 - flag) * value = 0
+        (one - flag) * value
+    }
+}
+
+impl TransitionConstraint<GoldilocksField, GoldilocksExtension> for RegNotReadIsZeroConstraint {
+    fn degree(&self) -> usize {
+        2
+    }
+
+    fn constraint_idx(&self) -> usize {
+        self.constraint_idx
+    }
+
+    fn end_exemptions(&self) -> usize {
+        0
+    }
+
+    fn evaluate(
+        &self,
+        evaluation_context: &TransitionEvaluationContext<GoldilocksField, GoldilocksExtension>,
+        transition_evaluations: &mut [FieldElement<GoldilocksExtension>],
+    ) {
+        match evaluation_context {
+            TransitionEvaluationContext::Prover { frame, .. } => {
+                let constraint_value = self.compute(frame.get_evaluation_step(0));
+                transition_evaluations[self.constraint_idx] = constraint_value.to_extension();
+            }
+            TransitionEvaluationContext::Verifier { frame, .. } => {
+                let constraint_value = self.compute(frame.get_evaluation_step(0));
+                transition_evaluations[self.constraint_idx] = constraint_value;
+            }
+        }
+    }
+}
+
+// =========================================================================
 // SUB Constraints
 // =========================================================================
 
@@ -1255,7 +1328,7 @@ pub fn create_jalr_constraints(constraint_idx_start: usize) -> (Vec<AddConstrain
 
 /// Total number of CPU constraints.
 ///
-/// - IS_BIT: 30 (all bit flags)
+/// - IS_BIT: 33 (all bit flags, including read_register1/2)
 /// - ADD carry: 2 (for ADD + LOAD)
 /// - STORE ADD carry: 2 (for STORE: res = arg1 + imm)
 /// - SUB carry: 2 (for SUB + BEQ)
@@ -1270,12 +1343,14 @@ pub fn create_jalr_constraints(constraint_idx_start: usize) -> (Vec<AddConstrain
 /// - Rvd upper: 1
 /// - SLT res zero: 7 (bytes 1-7)
 /// - Sign bit zero: 1
+/// - rv1 zero-forcing (CM48): 3 (rv1[0..2] when read_register1 = 0)
+/// - rv2 zero-forcing (CM50): 3 (rv2[0..2] when read_register2 = 0)
 /// - ECALL_COMMIT implies ECALL: 1
 /// - Next PC (non-branching): 2
 ///
-/// Total: 60 constraints (33 IS_BIT + 8 ADD + 19 other)
+/// Total: 66 constraints (33 IS_BIT + 8 ADD + 25 other)
 pub const NUM_CPU_CONSTRAINTS: usize =
-    33 + 2 + 2 + 2 + 2 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 7 + 1 + 1 + 2;
+    33 + 2 + 2 + 2 + 2 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 7 + 1 + 3 + 3 + 1 + 2;
 
 /// Creates all CPU constraints.
 ///
@@ -1318,6 +1393,26 @@ pub fn create_all_cpu_constraints() -> (
     // EBREAK
     other.push(Box::new(EbreakConstraint::new(next_idx)));
     next_idx += 1;
+
+    // rv1 zero-forcing (CM48): (1 - read_register1) * rv1[i] = 0 for i ∈ [0, 2]
+    for &value_col in &[cols::RV1_0, cols::RV1_1, cols::RV1_2] {
+        other.push(Box::new(RegNotReadIsZeroConstraint::new(
+            cols::READ_REGISTER1,
+            value_col,
+            next_idx,
+        )));
+        next_idx += 1;
+    }
+
+    // rv2 zero-forcing (CM50): (1 - read_register2) * rv2[i] = 0 for i ∈ [0, 2]
+    for &value_col in &[cols::RV2_0, cols::RV2_1, cols::RV2_2] {
+        other.push(Box::new(RegNotReadIsZeroConstraint::new(
+            cols::READ_REGISTER2,
+            value_col,
+            next_idx,
+        )));
+        next_idx += 1;
+    }
 
     // Arg1 constraints
     other.push(Box::new(Arg1LowerConstraint::new(next_idx)));

--- a/prover/src/constraints/cpu.rs
+++ b/prover/src/constraints/cpu.rs
@@ -57,6 +57,8 @@ where
 
 /// All bit flag columns that need IS_BIT constraints.
 pub const BIT_FLAG_COLUMNS: &[usize] = &[
+    cols::READ_REGISTER1,
+    cols::READ_REGISTER2,
     cols::WRITE_REGISTER,
     cols::MEMORY_2BYTES,
     cols::MEMORY_4BYTES,
@@ -1271,9 +1273,9 @@ pub fn create_jalr_constraints(constraint_idx_start: usize) -> (Vec<AddConstrain
 /// - ECALL_COMMIT implies ECALL: 1
 /// - Next PC (non-branching): 2
 ///
-/// Total: 58 constraints (31 IS_BIT + 8 ADD + 19 other)
+/// Total: 60 constraints (33 IS_BIT + 8 ADD + 19 other)
 pub const NUM_CPU_CONSTRAINTS: usize =
-    31 + 2 + 2 + 2 + 2 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 7 + 1 + 1 + 2;
+    33 + 2 + 2 + 2 + 2 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 7 + 1 + 1 + 2;
 
 /// Creates all CPU constraints.
 ///

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -648,13 +648,17 @@ impl CpuOperation {
         } else {
             (0, 0)
         };
+        // ECALL sets read_register2=false (spec: rs2 defaults to 0 for ECALL).
+        // CM50 requires rv2=0 when read_register2=0. The commit buf_addr is
+        // carried separately in commit_buf_addr and does not go through rv2.
+        let rv2 = if decode.op_ecall { 0 } else { log.src2_val };
 
         let mut op = Self {
             decode,
             timestamp,
             next_pc: log.next_pc,
             rv1: log.src1_val,
-            rv2: log.src2_val,
+            rv2,
             rvd: log.dst_val,
             res: log.dst_val, // Default: result is destination value
             is_equal: false,
@@ -768,11 +772,10 @@ pub fn generate_cpu_trace(
         data[base + cols::RS1] = FE::from(d.rs1 as u64);
         data[base + cols::RS2] = FE::from(d.rs2 as u64);
         data[base + cols::RD] = FE::from(d.rd as u64);
-        // Only set read/write register flags when register is a real register
-        // Skip x0 (hardwired zero) and x255 (virtual PC register for AUIPC/JAL)
-        // This matches trace_builder which only generates MEMW rows for real registers
-        data[base + cols::READ_REGISTER1] =
-            FE::from((d.read_register1 && d.rs1 != 0 && d.rs1 != 255) as u64);
+        // Skip x0 (hardwired zero). x255 is the register where the pc is stored
+        // (per spec decode.md). read_register1=1 for rs1=255 ensures the CM47 MEMW
+        // interaction is sent and rv1 is not forced to zero by CM48.
+        data[base + cols::READ_REGISTER1] = FE::from((d.read_register1 && d.rs1 != 0) as u64);
         data[base + cols::READ_REGISTER2] = FE::from((d.read_register2 && d.rs2 != 0) as u64);
         data[base + cols::WRITE_REGISTER] = FE::from((d.write_register && d.rd != 0) as u64);
         data[base + cols::MEMORY_2BYTES] = FE::from(d.memory_2bytes as u64);

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -1283,10 +1283,13 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
                 start_column: cols::MP_SELECTOR,
                 packing: Packing::Direct,
             },
-            // result (rvd) as DWordWL (2 words → 2 elements)
+            // result (res) as DWordBL (8 bytes → 2 elements) per spec CPU-CA44.
+            // Must use res, not rvd: for word instructions (MULW), rvd is
+            // sign-extended from res, so upper 32 bits differ when bit 31 is set.
+            // The MUL chip computes the raw product; sign extension is CPU-only.
             BusValue::Packed {
-                start_column: cols::RVD_0,
-                packing: Packing::DWordWL,
+                start_column: cols::RES[0],
+                packing: Packing::DWordBL,
             },
             // muldiv_selector: 0=lo (MUL), 1=hi (MULH/MULHSU/MULHU)
             BusValue::Packed {
@@ -1320,10 +1323,12 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
                 start_column: cols::SIGNED,
                 packing: Packing::Direct,
             },
-            // result (rvd) as DWordWL (2 words → 2 elements)
+            // result (res) as DWordBL (8 bytes → 2 elements) per spec CPU-CA45.
+            // Must use res, not rvd: for word instructions (DIVW, REMW), rvd is
+            // sign-extended from res, so upper 32 bits differ when bit 31 is set.
             BusValue::Packed {
-                start_column: cols::RVD_0,
-                packing: Packing::DWordWL,
+                start_column: cols::RES[0],
+                packing: Packing::DWordBL,
             },
             // muldiv_selector: 0=quotient (DIV), 1=remainder (REM)
             BusValue::Packed {

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -648,10 +648,14 @@ impl CpuOperation {
         } else {
             (0, 0)
         };
-        // ECALL sets read_register2=false (spec: rs2 defaults to 0 for ECALL).
-        // CM50 requires rv2=0 when read_register2=0. The commit buf_addr is
+        // CM50: (1 - read_register2) * rv2[i] = 0. When read_register2=0, rv2 must be 0.
+        // For example, ECALL has read_register2=0 (rs2 defaults to 0). The commit buf_addr is
         // carried separately in commit_buf_addr and does not go through rv2.
-        let rv2 = if decode.op_ecall { 0 } else { log.src2_val };
+        let rv2 = if !decode.read_register2 {
+            0
+        } else {
+            log.src2_val
+        };
 
         let mut op = Self {
             decode,
@@ -1284,9 +1288,8 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
                 packing: Packing::Direct,
             },
             // result (res) as DWordBL (8 bytes → 2 elements) per spec CPU-CA44.
-            // Must use res, not rvd: for word instructions (MULW), rvd is
-            // sign-extended from res, so upper 32 bits differ when bit 31 is set.
-            // The MUL chip computes the raw product; sign extension is CPU-only.
+            // Must send res (raw MUL output), not rvd. For MULW, rvd = sign_extend(res[31:0]),
+            // which can differ from res when bits [63:32] ≠ sign_extend(bit31) of res.
             BusValue::Packed {
                 start_column: cols::RES[0],
                 packing: Packing::DWordBL,
@@ -1324,8 +1327,8 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
                 packing: Packing::Direct,
             },
             // result (res) as DWordBL (8 bytes → 2 elements) per spec CPU-CA45.
-            // Must use res, not rvd: for word instructions (DIVW, REMW), rvd is
-            // sign-extended from res, so upper 32 bits differ when bit 31 is set.
+            // Must send res (raw DVRM output), not rvd. For DIVW/REMW, rvd = sign_extend(res[31:0]),
+            // which can differ from res when bits [63:32] ≠ sign_extend(bit31) of res.
             BusValue::Packed {
                 start_column: cols::RES[0],
                 packing: Packing::DWordBL,

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -482,18 +482,27 @@ fn collect_register_ops_from_cpu(
     let d = &op.decode;
 
     // M1: Read rs1 register at timestamp+0
-    // Skip x0 (hardwired zero) and x255 (virtual PC register for AUIPC/JAL)
-    if d.read_register1 && d.rs1 != 0 && d.rs1 != 255 {
+    // Skip x0 (hardwired zero). x255 (the register where the pc is stored) is handled
+    // via read_pc/write_pc since regs[] only covers indices 0..31.
+    if d.read_register1 && d.rs1 != 0 {
         let reg_value = pack_register_value(op.rv1);
         let reg_addr = 2 * d.rs1 as u64;
-        let (_old_val, old_ts) = register_state.read(d.rs1);
+        let (_old_val, old_ts) = if d.rs1 == 255 {
+            register_state.read_pc()
+        } else {
+            register_state.read(d.rs1)
+        };
         // old_timestamps array is 8 elements but only first 2 are used for registers
         let old_timestamps = [old_ts, old_ts, 0, 0, 0, 0, 0, 0];
 
         let memw_op = MemwOperation::new(true, reg_addr, reg_value, op.timestamp, 2, true)
             .with_old(reg_value, old_timestamps);
         memw_ops.push(memw_op);
-        register_state.write(d.rs1, op.rv1, op.timestamp);
+        if d.rs1 == 255 {
+            register_state.write_pc(op.rv1, op.timestamp);
+        } else {
+            register_state.write(d.rs1, op.rv1, op.timestamp);
+        }
     }
 
     // M3: Read rs2 register at timestamp+1

--- a/prover/src/tables/types.rs
+++ b/prover/src/tables/types.rs
@@ -448,8 +448,10 @@ impl DecodeEntry {
         let mut packed: u64 = 0;
 
         // Control flags (bits 0-10)
-        // Note: Register flags exclude x0 and x255 (virtual PC) to match CPU trace
-        let read_reg1_physical = self.read_register1 && self.rs1 != 0 && self.rs1 != 255;
+        // x0 is hardwired to zero and never physically read.
+        // x255 is the register where the pc is stored (per spec decode.md),
+        // so read_register1=1 for rs1=255.
+        let read_reg1_physical = self.read_register1 && self.rs1 != 0;
         let read_reg2_physical = self.read_register2 && self.rs2 != 0;
         let write_reg_physical = self.write_register && self.rd != 0;
         packed |= (read_reg1_physical as u64) << bits::READ_REG1;

--- a/prover/src/tables/types.rs
+++ b/prover/src/tables/types.rs
@@ -516,7 +516,7 @@ impl DecodeEntry {
                 if dst != 0 {
                     entry.write_register = true;
                 }
-                Self::set_arith_op(&mut entry, op, false);
+                Self::set_arith_op(&mut entry, op);
             }
 
             Instruction::ArithImm { dst, src, imm, op } => {
@@ -528,7 +528,7 @@ impl DecodeEntry {
                 if dst != 0 {
                     entry.write_register = true;
                 }
-                Self::set_arith_op(&mut entry, op, false);
+                Self::set_arith_op(&mut entry, op);
             }
 
             Instruction::ArithW {
@@ -546,7 +546,7 @@ impl DecodeEntry {
                 if dst != 0 {
                     entry.write_register = true;
                 }
-                Self::set_arith_op(&mut entry, op, true);
+                Self::set_arith_op(&mut entry, op);
             }
 
             Instruction::ArithImmW { dst, src, imm, op } => {
@@ -559,7 +559,7 @@ impl DecodeEntry {
                 if dst != 0 {
                     entry.write_register = true;
                 }
-                Self::set_arith_op(&mut entry, op, true);
+                Self::set_arith_op(&mut entry, op);
             }
 
             Instruction::JumpAndLink { dst, offset } => {
@@ -714,7 +714,7 @@ impl DecodeEntry {
     }
 
     /// Helper to set ALU operation flags based on ArithOp.
-    fn set_arith_op(entry: &mut Self, arith_op: ArithOp, _is_word: bool) {
+    fn set_arith_op(entry: &mut Self, arith_op: ArithOp) {
         match arith_op {
             ArithOp::Add => {
                 entry.op_add = true;

--- a/prover/src/tables/types.rs
+++ b/prover/src/tables/types.rs
@@ -714,7 +714,7 @@ impl DecodeEntry {
     }
 
     /// Helper to set ALU operation flags based on ArithOp.
-    fn set_arith_op(entry: &mut Self, arith_op: ArithOp, is_word: bool) {
+    fn set_arith_op(entry: &mut Self, arith_op: ArithOp, _is_word: bool) {
         match arith_op {
             ArithOp::Add => {
                 entry.op_add = true;
@@ -748,9 +748,7 @@ impl DecodeEntry {
             ArithOp::Mul => {
                 entry.op_mul = true;
                 entry.mp_selector = true;
-                if !is_word {
-                    entry.signed = true;
-                }
+                entry.signed = true;
             }
             ArithOp::MulHigh => {
                 entry.op_mul = true;

--- a/prover/src/tests/constraints_tests.rs
+++ b/prover/src/tests/constraints_tests.rs
@@ -624,11 +624,11 @@ fn test_create_all_cpu_constraints() {
     assert_eq!(is_bit.len(), 33);
     // ADD constraints: 2 (ADD+LOAD) + 2 (STORE: arg1+imm) + 2 (SUB+BEQ) + 2 (JALR) = 8
     assert_eq!(add.len(), 8);
-    // Other: branch_cond(1) + ebreak(1) + arg1(2) + arg2(2) + rvd(2) + slt_zero(7) + sign_bit_zero(1) + ecall_commit_implies_ecall(1) + next_pc(2) = 19
-    assert_eq!(other.len(), 19);
+    // Other: branch_cond(1) + ebreak(1) + rv1_zero_forcing(3) + rv2_zero_forcing(3) + arg1(2) + arg2(2) + rvd(2) + slt_zero(7) + sign_bit_zero(1) + ecall_commit_implies_ecall(1) + next_pc(2) = 25
+    assert_eq!(other.len(), 25);
 
-    // Total should be 33 + 8 + 19 = 60
-    assert_eq!(total, 60);
+    // Total should be 33 + 8 + 25 = 66
+    assert_eq!(total, 66);
     assert_eq!(total, NUM_CPU_CONSTRAINTS);
 }
 

--- a/prover/src/tests/constraints_tests.rs
+++ b/prover/src/tests/constraints_tests.rs
@@ -522,8 +522,8 @@ use crate::tables::cpu::cols as cpu_cols;
 
 #[test]
 fn test_cpu_bit_flag_columns_count() {
-    // Should have 31 bit flag columns (includes ECALL_COMMIT)
-    assert_eq!(BIT_FLAG_COLUMNS.len(), 31);
+    // Should have 33 bit flag columns (includes read_register1, read_register2, ECALL_COMMIT)
+    assert_eq!(BIT_FLAG_COLUMNS.len(), 33);
 }
 
 #[test]
@@ -538,8 +538,8 @@ fn test_cpu_bit_flag_columns_valid() {
 fn test_create_is_bit_constraints() {
     let (constraints, next_idx) = create_is_bit_constraints(0);
 
-    assert_eq!(constraints.len(), 31);
-    assert_eq!(next_idx, 31);
+    assert_eq!(constraints.len(), 33);
+    assert_eq!(next_idx, 33);
 
     // Check constraint indices are sequential
     for (i, c) in constraints.iter().enumerate() {
@@ -621,14 +621,14 @@ fn test_next_pc_add_constraint_new_pair() {
 fn test_create_all_cpu_constraints() {
     let (is_bit, add, other, total) = create_all_cpu_constraints();
 
-    assert_eq!(is_bit.len(), 31);
+    assert_eq!(is_bit.len(), 33);
     // ADD constraints: 2 (ADD+LOAD) + 2 (STORE: arg1+imm) + 2 (SUB+BEQ) + 2 (JALR) = 8
     assert_eq!(add.len(), 8);
     // Other: branch_cond(1) + ebreak(1) + arg1(2) + arg2(2) + rvd(2) + slt_zero(7) + sign_bit_zero(1) + ecall_commit_implies_ecall(1) + next_pc(2) = 19
     assert_eq!(other.len(), 19);
 
-    // Total should be 31 + 8 + 19 = 58
-    assert_eq!(total, 58);
+    // Total should be 33 + 8 + 19 = 60
+    assert_eq!(total, 60);
     assert_eq!(total, NUM_CPU_CONSTRAINTS);
 }
 

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -224,6 +224,20 @@ fn test_prove_elfs_arith_lui_8() {
     );
 }
 
+// Test AUIPC.
+// AUIPC uses rs1=x255 (PC register).
+// read_register1 must be 1 for rs1≠0, triggering the MEMW M1 interaction.
+#[test]
+fn test_prove_elfs_auipc() {
+    let (elf, logs, instructions) = run_asm_elf("auipc");
+    let mut traces =
+        Traces::from_logs_minimal(&logs, instructions.clone(), &Default::default()).unwrap();
+    assert!(
+        prove_and_verify_vm_minimal(&elf, &mut traces),
+        "auipc failed"
+    );
+}
+
 /// 8-instruction test with ADD, SUB, ADDW, SUBW
 #[test]
 fn test_prove_elfs_arith_8() {
@@ -424,6 +438,45 @@ fn test_prove_elfs_test_div_8() {
     assert!(
         prove_and_verify_vm_minimal(&elf, &mut traces),
         "test_div_8 failed"
+    );
+}
+
+// Test DIVW with negative operands (−100 / 7 = −14).
+// Result bit 31 is set, so rvd ≠ res. The DVRM bus must send res (CPU-CA46), not rvd.
+#[test]
+fn test_prove_elfs_divw() {
+    let (elf, logs, instructions) = run_asm_elf("divw");
+    let mut traces =
+        Traces::from_logs_minimal(&logs, instructions.clone(), &Default::default()).unwrap();
+    assert!(
+        prove_and_verify_vm_minimal(&elf, &mut traces),
+        "divw failed"
+    );
+}
+
+// Test REMW with negative operands (−100 % 7 = −2).
+// Result bit 31 is set, so rvd ≠ res. The DVRM bus must send res (CPU-CA46), not rvd.
+#[test]
+fn test_prove_elfs_remw() {
+    let (elf, logs, instructions) = run_asm_elf("remw");
+    let mut traces =
+        Traces::from_logs_minimal(&logs, instructions.clone(), &Default::default()).unwrap();
+    assert!(
+        prove_and_verify_vm_minimal(&elf, &mut traces),
+        "remw failed"
+    );
+}
+
+// Test DIVW/REMW with a negative divisor (arg2 bit 31 set).
+// Exercises arg2 sign extension via CPU-CE63 (signed * arg2_sign_bit).
+#[test]
+fn test_prove_elfs_sign_ext_edge_cases_8() {
+    let (elf, logs, instructions) = run_asm_elf("sign_ext_edge_cases_8");
+    let mut traces =
+        Traces::from_logs_minimal(&logs, instructions.clone(), &Default::default()).unwrap();
+    assert!(
+        prove_and_verify_vm_minimal(&elf, &mut traces),
+        "sign_ext_edge_cases_8 failed"
     );
 }
 

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -405,6 +405,17 @@ fn test_prove_elfs_test_mul_8() {
 }
 
 #[test]
+fn test_prove_elfs_mulw_neg() {
+    let (elf, logs, instructions) = run_asm_elf("mulw_neg");
+    let mut traces =
+        Traces::from_logs_minimal(&logs, instructions.clone(), &Default::default()).unwrap();
+    assert!(
+        prove_and_verify_vm_minimal(&elf, &mut traces),
+        "mulw_neg failed"
+    );
+}
+
+#[test]
 fn test_prove_elfs_test_div_8() {
     let (elf, logs, instructions) = run_asm_elf("test_div_8");
     let mut traces =


### PR DESCRIPTION
# Fix CPU table deviations from spec

## Description

Fixes several deviations between the CPU table implementation and the spec. Here are the fixes:

### 1. `read_register1=1` for `rs1=255` (AUIPC/JAL)

_**Bug:**_ The code had `&& d.rs1 != 255` guards that forced `read_register1=0` for AUIPC/JAL,
  preventing the MEMW interaction (CPU-CM47) from firing and causing a LogUp bus imbalance.

_**Spec References:**_
- DECODE table, decoding rule number 2: "_`read_register1`, `read_register2` and `write_register` are set to 1 when respectively `rs1≠0`, `rs2≠0`, or  `rd≠0`._"
- DECODE table, C-type instructions: AUIPC and JAL have `rs1 := x255`, so `read_register1` must be 1.
- CPU table, Memory: CPU-CM47.

### 2. IS_BIT constraints for `read_register1` and `read_register2`

_**Bug:**_ Both columns were missing from the IS_BIT constraint list.

_**Spec References:**_ In CPU table:
- CPU-CR2: `IS_BIT<read_register1>` 
- CPU-CR3: `IS_BIT<read_register2>`

### 3. If the register is not read then `rv` must be zero

_**Bug:**_ The constraints were missing entirely — `rv1` and `rv2` were unconstrained when their read
 flags were 0.

_**Spec References:**_ In CPU table:

- CPU-CM48.i: `!read_register1 ⇒ rv1[i] = 0` for i ∈ [0, 2] 
- CPU-CM50.i: `!read_register2 ⇒ rv2[i] = 0` for i ∈ [0, 2]

### 4. `rv2=0` for ECALL rows

_**Bug:**_ After adding CPU-CM50, the COMMIT ecall broke: the executor sets `src2_val = buf_addr`
(non-zero), which was being copied into `rv2`. Since ECALL has `read_register2=0`, CPU-CM50
requires `rv2=0`.

_**Spec References:**_ 
- CPU-CM50: `read_register2=0` means "place a 0 in rv2".
- DECODE table, C-type instructions: ECALL doens't map `rs2` to any value. 
- DECODE table, decoding rule number 1:" _`rd`, `rs1`, `rs2`, and `imm` are mapped to the values provided by the instruction; when a value is not specified by  an instruction it defaults to 0._"

### 5. MUL and DVRM bus interactions send `res` instead of `rvd`

_**Bug:**_ The MUL and DVRM bus sender were sending `rvd` (sign-extended result) instead of `res`. For word instructions where bit 31 of the result is set, `rvd ≠ res`, causing a LogUp bus mismatch.

_**Spec References:**_ CPU table:
- CPU-CA45: `MUL[res::DWordWL; arg1::DWordHL, signed, arg2::DWordHL, mp_selector,
muldiv_selector]`
- CPU-CA46: `DVRM[res::DWordWL; arg1::DWordHL, arg2::DWordHL, signed, muldiv_selector]`

### 6. MULW `signed=1` in decode

_**Bug:**_ The decode set `signed=false` for MULW via `if !is_word { entry.signed = true; }`. This
caused `arg1` to be zero-extended instead of sign-extended for negative operands, making the MUL
chip compute the wrong product (upper 32 bits mismatch between `lo` and `res`).

_**Spec References:**_
- DECODE table: `MUL[W]` row has `signed=1` with no `[W]` bracket — it applies to both MUL and MULW
- CPU-CE60: `arg1[4:] = rv1[2]*(1-word_instr) + (2^32-1)*rv1_sign_bit*signed` — with `signed=0`,
arg1 is always zero-extended regardless of the operand's sign.