### PR TITLE
perf: eliminate hot-path allocations in bus constraint evaluation

### DIFF
--- a/crypto/stark/src/constraints/evaluator.rs
+++ b/crypto/stark/src/constraints/evaluator.rs
@@ -2,7 +2,7 @@ use super::boundary::BoundaryConstraints;
 #[cfg(all(debug_assertions, not(feature = "parallel")))]
 use crate::debug::check_boundary_polys_divisibility;
 use crate::domain::Domain;
-use crate::lookup::{BusPublicInputs, LOGUP_CHALLENGE_ALPHA, compute_alpha_powers};
+use crate::lookup::{BusPublicInputs, LOGUP_CHALLENGE_ALPHA, PackingShifts, compute_alpha_powers};
 use crate::trace::LDETraceTable;
 use crate::traits::{AIR, TransitionEvaluationContext, ZerofierEvaluations};
 use crate::{frame::Frame, prover::evaluate_polynomial_on_lde_domain};
@@ -65,6 +65,9 @@ where
                 Vec::new()
             };
 
+        // Precompute packing shift constants once for all LDE domain points.
+        let packing_shifts = PackingShifts::<Field>::new();
+
         // Per-thread buffers via map_init: each Rayon worker allocates once,
         // then reuses for all iterations assigned to that thread.
         // The Frame is pre-allocated and filled in-place to avoid Vec allocations
@@ -107,6 +110,7 @@ where
                             rap_challenges,
                             &logup_alpha_powers,
                             logup_table_offset,
+                            &packing_shifts,
                         );
                         air.compute_transition_into(&ctx, transition_buf);
 
@@ -158,6 +162,7 @@ where
                         rap_challenges,
                         &logup_alpha_powers,
                         logup_table_offset,
+                        &packing_shifts,
                     );
                     air.compute_transition_into(&ctx, &mut transition_buf);
 

--- a/crypto/stark/src/debug.rs
+++ b/crypto/stark/src/debug.rs
@@ -2,7 +2,7 @@ use super::domain::Domain;
 use super::lookup::BusPublicInputs;
 use super::trace::TraceTable;
 use super::traits::{AIR, TransitionEvaluationContext};
-use crate::lookup::{LOGUP_CHALLENGE_ALPHA, compute_alpha_powers};
+use crate::lookup::{LOGUP_CHALLENGE_ALPHA, PackingShifts, compute_alpha_powers};
 use crate::{frame::Frame, trace::LDETraceTable};
 use log::{error, info};
 use math::field::traits::IsSubFieldOf;
@@ -117,6 +117,7 @@ pub fn validate_trace<
     };
 
     // Iterate over trace and compute transitions
+    let packing_shifts = PackingShifts::<Field>::new();
     for step in 0..lde_trace.num_steps() {
         let frame = Frame::read_step_from_lde(&lde_trace, step, &air.context().transition_offsets);
         let periodic_values: Vec<_> = periodic_columns
@@ -129,6 +130,7 @@ pub fn validate_trace<
             rap_challenges,
             &logup_alpha_powers,
             &logup_table_offset,
+            &packing_shifts,
         );
         let evaluations = air.compute_transition(&transition_evaluation_context);
 

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -341,6 +341,111 @@ impl Packing {
         }
     }
 
+    /// Zero-allocation fingerprint accumulation from a `TableView` (constraint evaluation).
+    ///
+    /// Mirrors `accumulate_fingerprint` but reads from `step.get_main_evaluation_element`
+    /// instead of column-major `main_cols[col][row]`.
+    pub fn accumulate_fingerprint_step<A, B>(
+        &self,
+        step: &TableView<A, B>,
+        start_col: usize,
+        alpha_powers: &[FieldElement<B>],
+        alpha_offset: usize,
+        acc: &mut FieldElement<B>,
+    ) -> usize
+    where
+        A: IsSubFieldOf<B>,
+        B: IsField,
+    {
+        match self {
+            Packing::Direct => {
+                *acc += step.get_main_evaluation_element(0, start_col) * &alpha_powers[alpha_offset];
+                1
+            }
+            Packing::Word2L => {
+                let shift_16 = FieldElement::<A>::from(SHIFT_16);
+                let combined = step.get_main_evaluation_element(0, start_col)
+                    + step.get_main_evaluation_element(0, start_col + 1) * &shift_16;
+                *acc += &combined * &alpha_powers[alpha_offset];
+                1
+            }
+            Packing::Word4L => {
+                let shift_8 = FieldElement::<A>::from(SHIFT_8);
+                let shift_16 = FieldElement::<A>::from(SHIFT_16);
+                let shift_24 = &shift_8 * &shift_16;
+                let combined = step.get_main_evaluation_element(0, start_col)
+                    + step.get_main_evaluation_element(0, start_col + 1) * &shift_8
+                    + step.get_main_evaluation_element(0, start_col + 2) * &shift_16
+                    + step.get_main_evaluation_element(0, start_col + 3) * &shift_24;
+                *acc += &combined * &alpha_powers[alpha_offset];
+                1
+            }
+            Packing::DWordWL => {
+                *acc += step.get_main_evaluation_element(0, start_col) * &alpha_powers[alpha_offset];
+                *acc += step.get_main_evaluation_element(0, start_col + 1) * &alpha_powers[alpha_offset + 1];
+                2
+            }
+            Packing::DWordHHW => {
+                *acc += step.get_main_evaluation_element(0, start_col) * &alpha_powers[alpha_offset];
+                let shift_16 = FieldElement::<A>::from(SHIFT_16);
+                let w = step.get_main_evaluation_element(0, start_col + 1)
+                    + step.get_main_evaluation_element(0, start_col + 2) * &shift_16;
+                *acc += &w * &alpha_powers[alpha_offset + 1];
+                2
+            }
+            Packing::DWordWHH => {
+                let shift_16 = FieldElement::<A>::from(SHIFT_16);
+                let w = step.get_main_evaluation_element(0, start_col)
+                    + step.get_main_evaluation_element(0, start_col + 1) * &shift_16;
+                *acc += &w * &alpha_powers[alpha_offset];
+                *acc += step.get_main_evaluation_element(0, start_col + 2) * &alpha_powers[alpha_offset + 1];
+                2
+            }
+            Packing::DWordHL => {
+                let shift_16 = FieldElement::<A>::from(SHIFT_16);
+                let w0 = step.get_main_evaluation_element(0, start_col)
+                    + step.get_main_evaluation_element(0, start_col + 1) * &shift_16;
+                *acc += &w0 * &alpha_powers[alpha_offset];
+                let w1 = step.get_main_evaluation_element(0, start_col + 2)
+                    + step.get_main_evaluation_element(0, start_col + 3) * &shift_16;
+                *acc += &w1 * &alpha_powers[alpha_offset + 1];
+                2
+            }
+            Packing::DWordBL => {
+                let shift_8 = FieldElement::<A>::from(SHIFT_8);
+                let shift_16 = FieldElement::<A>::from(SHIFT_16);
+                let shift_24 = &shift_8 * &shift_16;
+                let w0 = step.get_main_evaluation_element(0, start_col)
+                    + step.get_main_evaluation_element(0, start_col + 1) * &shift_8
+                    + step.get_main_evaluation_element(0, start_col + 2) * &shift_16
+                    + step.get_main_evaluation_element(0, start_col + 3) * &shift_24;
+                *acc += &w0 * &alpha_powers[alpha_offset];
+                let w1 = step.get_main_evaluation_element(0, start_col + 4)
+                    + step.get_main_evaluation_element(0, start_col + 5) * &shift_8
+                    + step.get_main_evaluation_element(0, start_col + 6) * &shift_16
+                    + step.get_main_evaluation_element(0, start_col + 7) * &shift_24;
+                *acc += &w1 * &alpha_powers[alpha_offset + 1];
+                2
+            }
+            Packing::QuadHL => {
+                let shift_16 = FieldElement::<A>::from(SHIFT_16);
+                for i in 0..4 {
+                    let c = start_col + i * 2;
+                    let w = step.get_main_evaluation_element(0, c)
+                        + step.get_main_evaluation_element(0, c + 1) * &shift_16;
+                    *acc += &w * &alpha_powers[alpha_offset + i];
+                }
+                4
+            }
+            Packing::QuadWL => {
+                for i in 0..4 {
+                    *acc += step.get_main_evaluation_element(0, start_col + i) * &alpha_powers[alpha_offset + i];
+                }
+                4
+            }
+        }
+    }
+
     /// Combines column values into bus elements using powers of 2.
     ///
     /// Primitive packings define the combining formulas.
@@ -608,6 +713,61 @@ impl BusValue {
                         }
                         LinearTerm::Constant(value) => {
                             result += FieldElement::<F>::from(*value);
+                        }
+                    }
+                }
+                *acc += &result * &alpha_powers[alpha_offset];
+                1
+            }
+        }
+    }
+
+    /// Zero-allocation fingerprint accumulation from a `TableView` (constraint evaluation).
+    ///
+    /// Mirrors `accumulate_fingerprint` but reads from `step.get_main_evaluation_element`
+    /// instead of column-major `main_cols[col][row]`.
+    pub fn accumulate_fingerprint_step<A, B>(
+        &self,
+        step: &TableView<A, B>,
+        alpha_powers: &[FieldElement<B>],
+        alpha_offset: usize,
+        acc: &mut FieldElement<B>,
+    ) -> usize
+    where
+        A: IsSubFieldOf<B>,
+        B: IsField,
+    {
+        match self {
+            BusValue::Packed {
+                start_column,
+                packing,
+            } => packing.accumulate_fingerprint_step(
+                step,
+                *start_column,
+                alpha_powers,
+                alpha_offset,
+                acc,
+            ),
+            BusValue::Linear(terms) => {
+                let mut result = FieldElement::<A>::zero();
+                for term in terms {
+                    match term {
+                        LinearTerm::Column {
+                            coefficient,
+                            column,
+                        } => {
+                            let coeff = FieldElement::<A>::from(*coefficient);
+                            result += step.get_main_evaluation_element(0, *column) * coeff;
+                        }
+                        LinearTerm::ColumnUnsigned {
+                            coefficient,
+                            column,
+                        } => {
+                            let coeff = FieldElement::<A>::from(*coefficient);
+                            result += step.get_main_evaluation_element(0, *column) * coeff;
+                        }
+                        LinearTerm::Constant(value) => {
+                            result += FieldElement::<A>::from(*value);
                         }
                     }
                 }
@@ -1074,6 +1234,12 @@ pub enum Multiplicity {
     /// Useful for "all rows except those marked by this flag".
     Negated(usize),
 
+    /// Difference of two columns: `col_a - col_b`.
+    Diff(usize, usize),
+
+    /// Sum of three columns: `col_a + col_b + col_c`.
+    Sum3(usize, usize, usize),
+
     /// Arbitrary linear combination of columns and constants.
     /// Supports signed coefficients for subtraction.
     /// Example: `μ - read2 - read4 - read8` can be expressed as:
@@ -1279,6 +1445,24 @@ where
                 .collect();
             &multiplicities_owned
         }
+        Multiplicity::Diff(col_a, col_b) => {
+            multiplicities_owned = main_segment_cols[col_a]
+                .iter()
+                .zip(main_segment_cols[col_b].iter())
+                .map(|(a, b)| a - b)
+                .collect();
+            &multiplicities_owned
+        }
+        Multiplicity::Sum3(col_a, col_b, col_c) => {
+            multiplicities_owned = (0..trace_len)
+                .map(|row| {
+                    &main_segment_cols[col_a][row]
+                        + &main_segment_cols[col_b][row]
+                        + &main_segment_cols[col_c][row]
+                })
+                .collect();
+            &multiplicities_owned
+        }
         Multiplicity::Linear(ref terms) => {
             multiplicities_owned = (0..trace_len)
                 .map(|row| {
@@ -1425,6 +1609,18 @@ where
             Multiplicity::Negated(col) => main_segment_cols[*col]
                 .iter()
                 .map(|elem| FieldElement::<F>::one() - elem)
+                .collect(),
+            Multiplicity::Diff(col_a, col_b) => main_segment_cols[*col_a]
+                .iter()
+                .zip(main_segment_cols[*col_b].iter())
+                .map(|(a, b)| a - b)
+                .collect(),
+            Multiplicity::Sum3(col_a, col_b, col_c) => (0..trace_len)
+                .map(|row| {
+                    &main_segment_cols[*col_a][row]
+                        + &main_segment_cols[*col_b][row]
+                        + &main_segment_cols[*col_c][row]
+                })
                 .collect(),
             Multiplicity::Linear(terms) => (0..trace_len)
                 .map(|row| {
@@ -1636,6 +1832,15 @@ fn compute_multiplicity_from_step<A: IsSubFieldOf<B>, B: IsField>(
         Multiplicity::Negated(col) => {
             FieldElement::<A>::one() - step.get_main_evaluation_element(0, *col)
         }
+        Multiplicity::Diff(col_a, col_b) => {
+            step.get_main_evaluation_element(0, *col_a)
+                - step.get_main_evaluation_element(0, *col_b)
+        }
+        Multiplicity::Sum3(col_a, col_b, col_c) => {
+            step.get_main_evaluation_element(0, *col_a)
+                + step.get_main_evaluation_element(0, *col_b)
+                + step.get_main_evaluation_element(0, *col_c)
+        }
         Multiplicity::Linear(terms) => {
             let mut result = FieldElement::<A>::zero();
             for term in terms {
@@ -1673,18 +1878,12 @@ fn compute_fingerprint_from_step<A: IsSubFieldOf<B>, B: IsField>(
     z: &FieldElement<B>,
     alpha_powers: &[FieldElement<B>],
 ) -> FieldElement<B> {
-    let bus_id_ext: FieldElement<B> = FieldElement::from(interaction.bus_id);
-    let mut linear_combination = &bus_id_ext * &alpha_powers[0];
+    let bus_id_f = FieldElement::<A>::from(interaction.bus_id);
+    let mut linear_combination = &bus_id_f * &alpha_powers[0];
     let mut alpha_idx = 1;
     for bv in &interaction.values {
-        let combined: Vec<FieldElement<A>> =
-            bv.combine_from(|col| step.get_main_evaluation_element(0, col).clone());
-        for v in combined {
-            linear_combination += v * &alpha_powers[alpha_idx];
-            alpha_idx += 1;
-        }
+        alpha_idx += bv.accumulate_fingerprint_step(step, alpha_powers, alpha_idx, &mut linear_combination);
     }
-
     z - &linear_combination
 }
 

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1989,8 +1989,8 @@ where
             let m_a = compute_multiplicity_from_step(step, &interaction_a.multiplicity);
             let m_b = compute_multiplicity_from_step(step, &interaction_b.multiplicity);
 
-            let fp_a = compute_fingerprint_from_step(step, interaction_a, z, alpha_powers, &shifts);
-            let fp_b = compute_fingerprint_from_step(step, interaction_b, z, alpha_powers, &shifts);
+            let fp_a = compute_fingerprint_from_step(step, interaction_a, z, alpha_powers, shifts);
+            let fp_b = compute_fingerprint_from_step(step, interaction_b, z, alpha_powers, shifts);
 
             // c * fp_a * fp_b - sign_a * m_a * fp_b - sign_b * m_b * fp_a = 0
             // Use conditional negation instead of E×E sign multiplication
@@ -2144,7 +2144,7 @@ where
                         &absorbed[0],
                         z,
                         alpha_powers,
-                        &shifts,
+                        shifts,
                     );
                     let sign: FieldElement<B> = if absorbed[0].is_sender {
                         FieldElement::one()
@@ -2163,14 +2163,14 @@ where
                         &absorbed[0],
                         z,
                         alpha_powers,
-                        &shifts,
+                        shifts,
                     );
                     let f2 = compute_fingerprint_from_step(
                         second_step,
                         &absorbed[1],
                         z,
                         alpha_powers,
-                        &shifts,
+                        shifts,
                     );
                     let term1 = m1 * &f2;
                     let term1 = if absorbed[0].is_sender { term1 } else { -term1 };

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -1981,10 +1981,10 @@ where
             interaction_b: &BusInteraction,
             rap_challenges: &&[FieldElement<B>],
             alpha_powers: &[FieldElement<B>],
+            shifts: &PackingShifts<A>,
         ) -> FieldElement<B> {
             let c = step.get_aux_evaluation_element(0, term_column_idx);
             let z = &rap_challenges[LOGUP_CHALLENGE_Z];
-            let shifts = PackingShifts::<A>::new();
 
             let m_a = compute_multiplicity_from_step(step, &interaction_a.multiplicity);
             let m_b = compute_multiplicity_from_step(step, &interaction_b.multiplicity);
@@ -2014,6 +2014,7 @@ where
                 frame,
                 rap_challenges,
                 logup_alpha_powers,
+                packing_shifts,
                 ..
             } => evaluate_batched_term_constraint(
                 frame.get_evaluation_step(0),
@@ -2022,11 +2023,13 @@ where
                 &self.interaction_b,
                 rap_challenges,
                 logup_alpha_powers,
+                packing_shifts,
             ),
             TransitionEvaluationContext::Verifier {
                 frame,
                 rap_challenges,
                 logup_alpha_powers,
+                packing_shifts,
                 ..
             } => evaluate_batched_term_constraint(
                 frame.get_evaluation_step(0),
@@ -2035,6 +2038,7 @@ where
                 &self.interaction_b,
                 rap_challenges,
                 logup_alpha_powers,
+                packing_shifts,
             ),
         };
 
@@ -2111,6 +2115,7 @@ where
             absorbed: &[BusInteraction],
             rap_challenges: &&[FieldElement<B>],
             alpha_powers: &[FieldElement<B>],
+            shifts: &PackingShifts<A>,
         ) -> FieldElement<B> {
             // Accumulated column values
             let acc_curr = first_step.get_aux_evaluation_element(0, acc_column_idx);
@@ -2125,7 +2130,6 @@ where
             let delta = acc_next - acc_curr - terms_sum + logup_table_offset;
 
             let z = &rap_challenges[LOGUP_CHALLENGE_Z];
-            let shifts = PackingShifts::<A>::new();
 
             // Clear denominators of absorbed interactions
             debug_assert!(matches!(absorbed.len(), 1 | 2));
@@ -2184,6 +2188,7 @@ where
                 logup_table_offset,
                 rap_challenges,
                 logup_alpha_powers,
+                packing_shifts,
                 ..
             } => evaluate_accumulated_constraint(
                 frame.get_evaluation_step(0),
@@ -2194,12 +2199,14 @@ where
                 &self.absorbed,
                 rap_challenges,
                 logup_alpha_powers,
+                packing_shifts,
             ),
             TransitionEvaluationContext::Verifier {
                 frame,
                 logup_table_offset,
                 rap_challenges,
                 logup_alpha_powers,
+                packing_shifts,
                 ..
             } => evaluate_accumulated_constraint(
                 frame.get_evaluation_step(0),
@@ -2210,6 +2217,7 @@ where
                 &self.absorbed,
                 rap_challenges,
                 logup_alpha_powers,
+                packing_shifts,
             ),
         };
 

--- a/crypto/stark/src/traits.rs
+++ b/crypto/stark/src/traits.rs
@@ -10,7 +10,9 @@ use math::{
 };
 
 use crate::{
-    constraints::transition::TransitionConstraint, domain::Domain, lookup::BusPublicInputs,
+    constraints::transition::TransitionConstraint,
+    domain::Domain,
+    lookup::{BusPublicInputs, PackingShifts},
 };
 
 use super::{
@@ -78,6 +80,7 @@ where
         rap_challenges: &'a [FieldElement<E>],
         logup_alpha_powers: &'a [FieldElement<E>],
         logup_table_offset: &'a FieldElement<E>,
+        packing_shifts: &'a PackingShifts<F>,
     },
     Verifier {
         frame: &'a Frame<E, E>,
@@ -85,6 +88,7 @@ where
         rap_challenges: &'a [FieldElement<E>],
         logup_alpha_powers: &'a [FieldElement<E>],
         logup_table_offset: &'a FieldElement<E>,
+        packing_shifts: &'a PackingShifts<E>,
     },
 }
 
@@ -99,6 +103,7 @@ where
         rap_challenges: &'a [FieldElement<E>],
         logup_alpha_powers: &'a [FieldElement<E>],
         logup_table_offset: &'a FieldElement<E>,
+        packing_shifts: &'a PackingShifts<F>,
     ) -> Self {
         Self::Prover {
             frame,
@@ -106,6 +111,7 @@ where
             rap_challenges,
             logup_alpha_powers,
             logup_table_offset,
+            packing_shifts,
         }
     }
 
@@ -115,6 +121,7 @@ where
         rap_challenges: &'a [FieldElement<E>],
         logup_alpha_powers: &'a [FieldElement<E>],
         logup_table_offset: &'a FieldElement<E>,
+        packing_shifts: &'a PackingShifts<E>,
     ) -> Self {
         Self::Verifier {
             frame,
@@ -122,6 +129,7 @@ where
             rap_challenges,
             logup_alpha_powers,
             logup_table_offset,
+            packing_shifts,
         }
     }
 }

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     config::Commitment,
     domain::new_verifier_domain,
-    lookup::{LOGUP_CHALLENGE_ALPHA, LOGUP_NUM_CHALLENGES, compute_alpha_powers},
+    lookup::{LOGUP_CHALLENGE_ALPHA, LOGUP_NUM_CHALLENGES, PackingShifts, compute_alpha_powers},
     proof::stark::{DeepPolynomialOpening, MultiProof},
 };
 use crypto::{fiat_shamir::is_transcript::IsStarkTranscript, merkle_tree::proof::Proof};
@@ -331,12 +331,14 @@ pub trait IsStarkVerifier<
 
         let ood_frame =
             (proof.trace_ood_evaluations).into_frame(num_main_trace_columns, air.step_size());
+        let packing_shifts = PackingShifts::<FieldExtension>::new();
         let transition_evaluation_context = TransitionEvaluationContext::new_verifier(
             &ood_frame,
             &periodic_values,
             &challenges.rap_challenges,
             &logup_alpha_powers,
             &logup_table_offset,
+            &packing_shifts,
         );
         let transition_ood_frame_evaluations =
             air.compute_transition(&transition_evaluation_context);

--- a/prover/src/tables/commit.rs
+++ b/prover/src/tables/commit.rs
@@ -243,26 +243,8 @@ pub fn generate_commit_trace(
 /// - **Sends** to Memw for register/memory accesses (×5, mult varies)
 pub fn bus_interactions() -> Vec<BusInteraction> {
     // Reusable multiplicity expressions
-    let mu_minus_end = Multiplicity::Linear(vec![
-        LinearTerm::Column {
-            coefficient: 1,
-            column: cols::MU,
-        },
-        LinearTerm::Column {
-            coefficient: -1,
-            column: cols::END,
-        },
-    ]);
-    let mu_minus_first = Multiplicity::Linear(vec![
-        LinearTerm::Column {
-            coefficient: 1,
-            column: cols::MU,
-        },
-        LinearTerm::Column {
-            coefficient: -1,
-            column: cols::FIRST,
-        },
-    ]);
+    let mu_minus_end = Multiplicity::Diff(cols::MU, cols::END);
+    let mu_minus_first = Multiplicity::Diff(cols::MU, cols::FIRST);
 
     vec![
         // 1. Receive ECALL from CPU (mult = first)

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -1996,16 +1996,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
     // rv1 = value of a7 register (syscall number). For sys_exit, rv1 = 93.
     interactions.push(BusInteraction::sender(
         BusId::Ecall,
-        Multiplicity::Linear(vec![
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::ECALL,
-            },
-            LinearTerm::Column {
-                coefficient: -1,
-                column: cols::ECALL_COMMIT,
-            },
-        ]),
+        Multiplicity::Diff(cols::ECALL, cols::ECALL_COMMIT),
         vec![
             BusValue::Packed {
                 start_column: cols::TIMESTAMP,

--- a/prover/src/tables/memw.rs
+++ b/prover/src/tables/memw.rs
@@ -31,7 +31,7 @@
 use math::field::element::FieldElement;
 use math::field::traits::{IsField, IsSubFieldOf};
 use stark::constraints::transition::TransitionConstraint;
-use stark::lookup::{BusInteraction, BusValue, LinearTerm, Multiplicity, Packing};
+use stark::lookup::{BusInteraction, BusValue, Multiplicity, Packing};
 use stark::table::TableView;
 use stark::trace::TraceTable;
 use stark::traits::TransitionEvaluationContext;
@@ -91,7 +91,7 @@ pub mod cols {
     pub const MU_WRITE: usize = 69;
 
     /// Total number of columns
-    /// Note: w2, w4, μ_sum are now computed inline via Multiplicity::Linear/Sum
+    /// Note: w2, w4, μ_sum are now computed inline via Multiplicity::Sum3/Sum
     pub const NUM_COLUMNS: usize = 70;
 
     /// Helper to get address_add[i] column indices (4 halfwords each)
@@ -330,7 +330,7 @@ pub fn generate_memw_trace(
         // Multiplicity
         data[base + cols::MU_READ] = FE::from(op.is_read as u64);
         data[base + cols::MU_WRITE] = FE::from(!op.is_read as u64);
-        // Note: w2, w4, μ_sum are computed inline via Multiplicity::Linear/Sum
+        // Note: w2, w4, μ_sum are computed inline via Multiplicity::Sum3/Sum
     }
 
     TraceTable::new_main(data, cols::NUM_COLUMNS, 1)
@@ -483,20 +483,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
     // w2 = write2 + write4 + write8
     interactions.push(BusInteraction::sender(
         BusId::Memory,
-        Multiplicity::Linear(vec![
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::WRITE2,
-            },
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::WRITE4,
-            },
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::WRITE8,
-            },
-        ]),
+        Multiplicity::Sum3(cols::WRITE2, cols::WRITE4, cols::WRITE8),
         vec![
             BusValue::Packed {
                 start_column: cols::IS_REGISTER,
@@ -522,20 +509,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
     // CM19: memory[is_register, address_add[0], timestamp, value[1]] with -w2
     interactions.push(BusInteraction::receiver(
         BusId::Memory,
-        Multiplicity::Linear(vec![
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::WRITE2,
-            },
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::WRITE4,
-            },
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::WRITE8,
-            },
-        ]),
+        Multiplicity::Sum3(cols::WRITE2, cols::WRITE4, cols::WRITE8),
         vec![
             BusValue::Packed {
                 start_column: cols::IS_REGISTER,
@@ -572,16 +546,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         // CM22.i: send old token
         interactions.push(BusInteraction::sender(
             BusId::Memory,
-            Multiplicity::Linear(vec![
-                LinearTerm::Column {
-                    coefficient: 1,
-                    column: cols::WRITE4,
-                },
-                LinearTerm::Column {
-                    coefficient: 1,
-                    column: cols::WRITE8,
-                },
-            ]),
+            Multiplicity::Sum(cols::WRITE4, cols::WRITE8),
             vec![
                 BusValue::Packed {
                     start_column: cols::IS_REGISTER,
@@ -607,16 +572,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
         // CM23.i: receive new token
         interactions.push(BusInteraction::receiver(
             BusId::Memory,
-            Multiplicity::Linear(vec![
-                LinearTerm::Column {
-                    coefficient: 1,
-                    column: cols::WRITE4,
-                },
-                LinearTerm::Column {
-                    coefficient: 1,
-                    column: cols::WRITE8,
-                },
-            ]),
+            Multiplicity::Sum(cols::WRITE4, cols::WRITE8),
             vec![
                 BusValue::Packed {
                     start_column: cols::IS_REGISTER,
@@ -935,20 +891,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
     // Constraint 8: LT[1; old_timestamp[1], timestamp] with w2
     interactions.push(BusInteraction::sender(
         BusId::Lt,
-        Multiplicity::Linear(vec![
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::WRITE2,
-            },
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::WRITE4,
-            },
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::WRITE8,
-            },
-        ]),
+        Multiplicity::Sum3(cols::WRITE2, cols::WRITE4, cols::WRITE8),
         vec![
             BusValue::Packed {
                 start_column: cols::old_timestamp(1)[0],

--- a/prover/src/tables/shift.rs
+++ b/prover/src/tables/shift.rs
@@ -391,16 +391,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
     // SHIFT-C1: AND_BYTE[shift, 15] → bit_shift | left (= μ - direction)
     interactions.push(BusInteraction::sender(
         BusId::AndByte,
-        Multiplicity::Linear(vec![
-            LinearTerm::Column {
-                coefficient: 1,
-                column: cols::MU,
-            },
-            LinearTerm::Column {
-                coefficient: -1,
-                column: cols::DIRECTION,
-            },
-        ]),
+        Multiplicity::Diff(cols::MU, cols::DIRECTION),
         vec![
             BusValue::Packed {
                 start_column: cols::SHIFT_AMOUNT,
@@ -462,13 +453,7 @@ pub fn bus_interactions() -> Vec<BusInteraction> {
 
     // SHIFT-C4.i: HWSL[in[i], bit_shift] → X[i] for i∈[0,3] | 1 - zbs
     // HWSL receiver: [x + 256*y (halfword), z (shift amount), SLL (result)]
-    let one_minus_zbs = Multiplicity::Linear(vec![
-        LinearTerm::Constant(1),
-        LinearTerm::Column {
-            coefficient: -1,
-            column: cols::ZBS,
-        },
-    ]);
+    let one_minus_zbs = Multiplicity::Negated(cols::ZBS);
     for i in 0..4 {
         interactions.push(BusInteraction::sender(
             BusId::Hwsl,


### PR DESCRIPTION
- Add Multiplicity::Diff and Multiplicity::Sum3 variants to avoid Vec<LinearTerm> heap allocations for common patterns (a-b, a+b+c)
- Add Packing::accumulate_fingerprint_step and BusValue::accumulate_fingerprint_step for zero-allocation fingerprint computation from TableView (constraint evaluation context)
- Rewrite compute_fingerprint_from_step to use accumulate_fingerprint_step instead of combine_from, eliminating all Vec allocations per evaluation point per interaction in the constraint evaluation hot path
- Replace 8 Multiplicity::Linear usages across table files with allocation-free Diff/Sum3/Sum/Negated variants