### PR TITLE
perf: skip field multiplication for trivial coefficients in AddLinear…

### DIFF
--- a/prover/src/constraints/templates.rs
+++ b/prover/src/constraints/templates.rs
@@ -211,7 +211,11 @@ impl AddLinearTerm {
                 column,
             } => {
                 let col_val = step.get_main_evaluation_element(0, *column);
-                col_val * FieldElement::<F>::from(*coefficient)
+                match *coefficient {
+                    1 => col_val.clone(),
+                    -1 => -col_val.clone(),
+                    c => col_val * FieldElement::<F>::from(c),
+                }
             }
             AddLinearTerm::Constant(value) => FieldElement::<F>::from(*value),
         }


### PR DESCRIPTION
…Term

When coefficient is 1 (the most common case), clone the column value directly instead of multiplying by FieldElement::from(1). When coefficient is -1, use negation instead of multiplication.

This eliminates ~50 unnecessary field multiplications per CPU row evaluation. Each AddConstraint with DWordBL operands (8 terms, 2 with coefficient=1 per limb) was paying for multiply-by-1 on every term. With 4 AddConstraint pairs on the CPU table (~100K rows), this saves ~5M field multiplications per proof.