### PR TITLE
fix(prover): compute arg2_sign_bit from rv2 instead of arg2

### DIFF
--- a/executor/programs/asm/test_addiw_neg.s
+++ b/executor/programs/asm/test_addiw_neg.s
@@ -1,0 +1,9 @@
+	.attribute	5, "rv64i2p1_m2p0"
+	.globl	main
+main:
+	li	t0, 0
+	li	t1, 1
+	addiw	a0, zero, -1
+	li	a0, 0
+	li	a7, 93
+	ecall

--- a/prover/src/tables/cpu.rs
+++ b/prover/src/tables/cpu.rs
@@ -201,7 +201,7 @@ pub mod cols {
     pub const ARG1_6: usize = 52;
     pub const ARG1_7: usize = 53;
 
-    /// arg2_sign_bit: Sign bit of arg2 as 32-bit word
+    /// arg2_sign_bit: Sign bit of rv2 as 32-bit word (bit 31 of rv2; used to define arg2's extension)
     pub const ARG2_SIGN_BIT: usize = 54;
 
     /// arg2[0..8]: Extended rv2/imm as DWordBL (8 bytes)
@@ -839,7 +839,7 @@ pub fn generate_cpu_trace(
 
         // Compute and store arg2
         let arg2 = op.compute_arg2();
-        let arg2_sign_bit = d.word_instr && CpuOperation::sign_bit_32(arg2);
+        let arg2_sign_bit = d.word_instr && CpuOperation::sign_bit_32(op.rv2);
         data[base + cols::ARG2_SIGN_BIT] = FE::from(arg2_sign_bit as u64);
         for i in 0..8 {
             data[base + cols::ARG2[i]] = FE::from((arg2 >> (i * 8)) & 0xFF);

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -1631,3 +1631,14 @@ fn test_verify_rejects_inflated_table_counts() {
         result
     );
 }
+
+/// Regression test: addiw with negative immediate must verify.
+/// Bug: arg2_sign_bit was computed from arg2 (sign-extended immediate)
+/// instead of rv2 (raw register value). The bus sends MSB16[rv2[1]] → arg2_sign_bit,
+/// so for I-type instructions (rs2=0, rv2=0), arg2_sign_bit must be 0.
+#[test]
+fn test_addiw_neg_immediate() {
+    let elf_bytes = crate::test_utils::asm_elf_bytes("test_addiw_neg");
+    let result = crate::prove_and_verify(&elf_bytes).expect("prove_and_verify failed");
+    assert!(result, "addiw with negative immediate should verify");
+}

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -1831,9 +1831,9 @@ fn test_verify_rejects_inflated_table_counts() {
 }
 
 /// Regression test: addiw with negative immediate must verify.
-/// Bug: arg2_sign_bit was computed from arg2 (sign-extended immediate)
-/// instead of rv2 (raw register value). The bus sends MSB16[rv2[1]] → arg2_sign_bit,
-/// so for I-type instructions (rs2=0, rv2=0), arg2_sign_bit must be 0.
+/// arg2_sign_bit is the sign bit of rv2 (bit 31), not of arg2, per spec
+/// constraint CPU-CE61: MSB16[arg2_sign_bit; rv2[1]].
+/// For I-type word instructions (rs2=x0, rv2=0), arg2_sign_bit must be 0.
 #[test]
 fn test_addiw_neg_immediate() {
     let elf_bytes = crate::test_utils::asm_elf_bytes("test_addiw_neg");


### PR DESCRIPTION
  - Fix arg2_sign_bit trace fill to use sign_bit_32(op.rv2) instead of sign_bit_32(arg2), matching spec constraint
  CPU-CE61: MSB16[arg2_sign_bit; rv2[1]]
  - For I-type word instructions like addiw a0, zero, -1, rs2=x0 so rv2=0, meaning arg2_sign_bit must be 0. The old code
  derived it from arg2 (the sign-extended immediate), incorrectly producing 1.
  - The bus interaction already correctly sent MSB16[rv2[1]], so only the trace column was wrong.
  - Adds a regression test (test_addiw_neg_immediate) that proves and verifies addiw with a negative immediate.
