### PR TITLE
perf/port optimizations from Lambdaworks

### DIFF
--- a/crypto/math/fuzz/fuzz_targets/goldilocks_native.rs
+++ b/crypto/math/fuzz/fuzz_targets/goldilocks_native.rs
@@ -174,4 +174,38 @@ fuzz_target!(|input: FuzzInput| {
         mod_add(a_native, a_native),
         a_native
     );
+
+    // Test with raw (non-canonical) inputs to exercise double-overflow/underflow paths.
+    // These paths require inputs >= p and are not reached with canonical inputs above.
+    let a_raw = input.a;
+    let b_raw = input.b;
+    let a_canon = a_raw % GOLDILOCKS_PRIME;
+    let b_canon = b_raw % GOLDILOCKS_PRIME;
+
+    let sum_raw = GoldilocksField::add(&a_raw, &b_raw);
+    assert_eq!(
+        canonicalize(sum_raw),
+        mod_add(a_canon, b_canon),
+        "Non-canonical add mismatch: a={:#x}, b={:#x}",
+        a_raw,
+        b_raw
+    );
+
+    let diff_raw = GoldilocksField::sub(&a_raw, &b_raw);
+    assert_eq!(
+        canonicalize(diff_raw),
+        mod_sub(a_canon, b_canon),
+        "Non-canonical sub mismatch: a={:#x}, b={:#x}",
+        a_raw,
+        b_raw
+    );
+
+    let prod_raw = GoldilocksField::mul(&a_raw, &b_raw);
+    assert_eq!(
+        canonicalize(prod_raw),
+        mod_mul(a_canon, b_canon),
+        "Non-canonical mul mismatch: a={:#x}, b={:#x}",
+        a_raw,
+        b_raw
+    );
 });

--- a/crypto/math/src/field/extensions_goldilocks.rs
+++ b/crypto/math/src/field/extensions_goldilocks.rs
@@ -528,11 +528,12 @@ impl HasDefaultTranscript for Degree3GoldilocksExtensionField {
 // =====================================================
 
 /// Multiply a field element by 7 (the quadratic non-residue).
-/// Uses 7 = 1 + 2 + 4 for efficiency (2 doubles + 2 adds, saves one double vs 8-1).
+/// Uses 7 = 8 - 1 to break the dependency chain (3 serial doubles then 1 sub,
+/// vs 2 doubles + 2 dependent adds).
 #[inline(always)]
 fn mul_by_7(a: &FpE) -> FpE {
-    // 7 * a = a + 2a + 4a
     let a2 = a.double();
     let a4 = a2.double();
-    *a + a2 + a4
+    let a8 = a4.double();
+    a8 - *a
 }

--- a/crypto/math/src/field/extensions_goldilocks.rs
+++ b/crypto/math/src/field/extensions_goldilocks.rs
@@ -6,7 +6,7 @@
 use crate::field::{
     element::FieldElement,
     errors::FieldError,
-    goldilocks::{GOLDILOCKS_PRIME, GoldilocksField},
+    goldilocks::{GOLDILOCKS_PRIME, GoldilocksField, dot_product_2, dot_product_3, mul_by_7_raw},
     traits::{HasDefaultTranscript, IsField, IsSubFieldOf},
 };
 use crate::traits::{AsBytes, ByteConversion};
@@ -106,33 +106,39 @@ impl IsField for Degree2GoldilocksExtensionField {
         [a[0] + b[0], a[1] + b[1]]
     }
 
-    /// Returns the multiplication of `a` and `b`:
-    /// (a0 + a1*w) * (b0 + b1*w) = (a0*b0 + W*a1*b1) + (a0*b1 + a1*b0)*w
-    /// where w^2 = W = 7
+    /// Multiplication using fused dot products for fewer reductions.
+    /// (a0 + a1*w) * (b0 + b1*w) = (a0*b0 + 7*a1*b1) + (a0*b1 + a1*b0)*w
+    ///
+    /// Uses dot_product_2 to compute each output component with a single
+    /// reduce128 instead of separate mul + reduce per product.
     #[inline(always)]
     fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
-        let a0b0 = a[0] * b[0];
-        let a1b1 = a[1] * b[1];
-        let z = (a[0] + a[1]) * (b[0] + b[1]);
+        let (a0, a1) = (*a[0].value(), *a[1].value());
+        let (b0, b1) = (*b[0].value(), *b[1].value());
+        let b1_7 = mul_by_7_raw(b1);
 
-        // W * a1b1 = 7 * a1b1
-        let w_a1b1 = mul_by_7(&a1b1);
+        // c0 = a0*b0 + a1*(7*b1)
+        let c0 = dot_product_2(a0, b0, a1, b1_7);
+        // c1 = a0*b1 + a1*b0
+        let c1 = dot_product_2(a0, b1, a1, b0);
 
-        [a0b0 + w_a1b1, z - a0b0 - a1b1]
+        [FpE::from_raw(c0), FpE::from_raw(c1)]
     }
 
-    /// Returns the square of `a`:
-    /// (a0 + a1*w)^2 = (a0^2 + W*a1^2) + 2*a0*a1*w
+    /// Squaring using fused dot product for the first component.
+    /// (a0 + a1*w)^2 = (a0^2 + 7*a1^2) + 2*a0*a1*w
     #[inline(always)]
     fn square(a: &Self::BaseType) -> Self::BaseType {
-        let a0_sq = a[0].square();
-        let a1_sq = a[1].square();
-        let a0a1 = a[0] * a[1];
+        let (a0, a1) = (*a[0].value(), *a[1].value());
+        let a1_7 = mul_by_7_raw(a1);
 
-        // W * a1^2 = 7 * a1^2
-        let w_a1_sq = mul_by_7(&a1_sq);
+        // c0 = a0*a0 + a1*(7*a1) via single-reduction dot product
+        let c0 = dot_product_2(a0, a0, a1, a1_7);
+        // c1 = 2 * a0 * a1
+        let c1 = <GoldilocksField as IsField>::mul(&a0, &a1);
+        let c1 = GoldilocksField::double(&c1);
 
-        [a0_sq + w_a1_sq, a0a1.double()]
+        [FpE::from_raw(c0), FpE::from_raw(c1)]
     }
 
     /// Returns the component-wise subtraction of `a` and `b`
@@ -272,42 +278,57 @@ impl IsField for Degree3GoldilocksExtensionField {
         [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
     }
 
-    /// Returns the multiplication of `a` and `b`:
+    /// Multiplication using schoolbook with fused dot products.
     /// (a0 + a1*w + a2*w^2) * (b0 + b1*w + b2*w^2) mod (w^3 - 2)
+    ///
+    /// Expanding and applying w^3 = 2:
+    ///   c0 = a0*b0 + 2*(a1*b2 + a2*b1)
+    ///   c1 = a0*b1 + a1*b0 + 2*a2*b2
+    ///   c2 = a0*b2 + a1*b1 + a2*b0
+    ///
+    /// Each component is computed as a single dot_product_3 (9 raw muls,
+    /// 3 reduce128 calls) instead of Karatsuba (6 muls, 6 reduce128 + many
+    /// add/sub). The reduction savings outweigh the extra multiplications.
     #[inline(always)]
     fn mul(a: &Self::BaseType, b: &Self::BaseType) -> Self::BaseType {
-        let v0 = a[0] * b[0];
-        let v1 = a[1] * b[1];
-        let v2 = a[2] * b[2];
+        let (a0, a1, a2) = (*a[0].value(), *a[1].value(), *a[2].value());
+        let (b0, b1, b2) = (*b[0].value(), *b[1].value(), *b[2].value());
 
-        // c0 = v0 + 2 * ((a1 + a2)(b1 + b2) - v1 - v2)
-        // c1 = (a0 + a1)(b0 + b1) - v0 - v1 + 2 * v2
-        // c2 = (a0 + a2)(b0 + b2) - v0 + v1 - v2
-        let t0 = (a[1] + a[2]) * (b[1] + b[2]) - v1 - v2;
-        let t1 = (a[0] + a[1]) * (b[0] + b[1]) - v0 - v1;
-        let t2 = (a[0] + a[2]) * (b[0] + b[2]) - v0 - v2;
+        // Precompute 2*b1 and 2*b2 for the w^3 = 2 reduction
+        let b1_2 = GoldilocksField::double(&b1);
+        let b2_2 = GoldilocksField::double(&b2);
 
-        [v0 + t0.double(), t1 + v2.double(), t2 + v1]
+        // c0 = a0*b0 + a1*(2*b2) + a2*(2*b1)
+        let c0 = dot_product_3(a0, b0, a1, b2_2, a2, b1_2);
+        // c1 = a0*b1 + a1*b0 + a2*(2*b2)
+        let c1 = dot_product_3(a0, b1, a1, b0, a2, b2_2);
+        // c2 = a0*b2 + a1*b1 + a2*b0
+        let c2 = dot_product_3(a0, b2, a1, b1, a2, b0);
+
+        [FpE::from_raw(c0), FpE::from_raw(c1), FpE::from_raw(c2)]
     }
 
-    /// Returns the square of `a`
+    /// Squaring using fused dot products.
+    /// (a0 + a1*w + a2*w^2)^2 mod (w^3 - 2):
+    ///   c0 = a0^2 + 4*a1*a2
+    ///   c1 = 2*a0*a1 + 2*a2^2
+    ///   c2 = 2*a0*a2 + a1^2
     #[inline(always)]
     fn square(a: &Self::BaseType) -> Self::BaseType {
-        let s0 = a[0].square();
-        let s1 = a[1].square();
-        let s2 = a[2].square();
-        let a01 = a[0] * a[1];
-        let a02 = a[0] * a[2];
-        let a12 = a[1] * a[2];
+        let (a0, a1, a2) = (*a[0].value(), *a[1].value(), *a[2].value());
 
-        // c0 = s0 + 4 * a12
-        // c1 = 2 * a01 + 2 * s2
-        // c2 = 2 * a02 + s1
-        [
-            s0 + a12.double().double(),
-            a01.double() + s2.double(),
-            a02.double() + s1,
-        ]
+        let a0_2 = GoldilocksField::double(&a0);
+        let a2_4 = GoldilocksField::double(&GoldilocksField::double(&a2));
+
+        // c0 = a0*a0 + a1*(4*a2) — using dot_product_2
+        let c0 = dot_product_2(a0, a0, a1, a2_4);
+        // c1 = (2*a0)*a1 + (2*a2)*a2 — using dot_product_2
+        let a2_2 = GoldilocksField::double(&a2);
+        let c1 = dot_product_2(a0_2, a1, a2_2, a2);
+        // c2 = a1*a1 + (2*a0)*a2 — using dot_product_2
+        let c2 = dot_product_2(a1, a1, a0_2, a2);
+
+        [FpE::from_raw(c0), FpE::from_raw(c1), FpE::from_raw(c2)]
     }
 
     /// Returns the component-wise subtraction of `a` and `b`
@@ -528,12 +549,8 @@ impl HasDefaultTranscript for Degree3GoldilocksExtensionField {
 // =====================================================
 
 /// Multiply a field element by 7 (the quadratic non-residue).
-/// Uses 7 = 8 - 1 to break the dependency chain (3 serial doubles then 1 sub,
-/// vs 2 doubles + 2 dependent adds).
+/// Wraps the raw u64 implementation for use with FieldElement types.
 #[inline(always)]
 fn mul_by_7(a: &FpE) -> FpE {
-    let a2 = a.double();
-    let a4 = a2.double();
-    let a8 = a4.double();
-    a8 - *a
+    FpE::from_raw(mul_by_7_raw(*a.value()))
 }

--- a/crypto/math/src/field/goldilocks.rs
+++ b/crypto/math/src/field/goldilocks.rs
@@ -270,8 +270,8 @@ pub(crate) fn dot_product_2(a0: u64, b0: u64, a1: u64, b1: u64) -> u64 {
     if overflow {
         // True value is sum + 2^128. Since 2^128 mod p = EPSILON^2,
         // add EPSILON^2 = (2^32-1)^2 = 2^64 - 2^33 + 1.
-        // This value is < p, and reduced < 2p, so their sum < 3p < 2^64 + p,
-        // satisfying the precondition for add_no_canonicalize.
+        // Safety: reduced < 2^64 (it's a u64), EPSILON_SQ < p,
+        // so reduced + EPSILON_SQ < 2^64 + p, satisfying add_no_canonicalize's precondition.
         branch_hint();
         const EPSILON_SQ: u64 = EPSILON.wrapping_mul(EPSILON);
         unsafe { add_no_canonicalize_trashing_input(reduced, EPSILON_SQ) }

--- a/crypto/math/src/field/goldilocks.rs
+++ b/crypto/math/src/field/goldilocks.rs
@@ -80,12 +80,15 @@ impl IsField for GoldilocksField {
         let (sum, over) = a.overflowing_add(*b);
         let (mut sum, over) = sum.overflowing_add((over as u64) * EPSILON);
         if over {
-            // Double overflow requires both inputs > ORDER, which is exceedingly rare.
+            // Double overflow requires a + b >= 2^65 - EPSILON.
+            // If either input <= p, then a + b <= p + (2^64-1) = 2^65 - EPSILON - 1,
+            // which is below the threshold. Therefore both must exceed p.
             unsafe {
                 assume(*a > GOLDILOCKS_PRIME && *b > GOLDILOCKS_PRIME);
             }
             branch_hint();
-            sum += EPSILON; // Cannot overflow.
+            // After double overflow, sum < EPSILON, so sum + EPSILON < 2^64.
+            sum += EPSILON;
         }
         sum
     }
@@ -96,6 +99,10 @@ impl IsField for GoldilocksField {
         let (diff, under) = a.overflowing_sub(*b);
         let (mut diff, under) = diff.overflowing_sub((under as u64) * EPSILON);
         if under {
+            // Double underflow requires a - b + 2^64 < EPSILON, i.e., b > a + p.
+            // Since b < 2^64 = p + EPSILON, we get a < EPSILON - 1.
+            // At a = EPSILON - 1, the minimum b for first underflow already gives
+            // diff1 = EPSILON, so diff1 - EPSILON = 0 (no second underflow).
             unsafe {
                 assume(*a < EPSILON - 1 && *b > GOLDILOCKS_PRIME);
             }
@@ -238,6 +245,87 @@ unsafe fn add_no_canonicalize_trashing_input(x: u64, y: u64) -> u64 {
 unsafe fn add_no_canonicalize_trashing_input(x: u64, y: u64) -> u64 {
     let (res_wrapped, carry) = x.overflowing_add(y);
     res_wrapped.wrapping_add(EPSILON * (carry as u64))
+}
+
+// =====================================================
+// FUSED MULTIPLY-ACCUMULATE (inspired by Plonky3)
+// =====================================================
+
+/// Compute a0*b0 + a1*b1 mod p in a single reduction pass.
+///
+/// Instead of reducing each product separately (2 reduce128 calls),
+/// this sums the u128 products and reduces once. When the sum overflows u128,
+/// we correct by adding 2^128 mod p = EPSILON^2 = (2^32 - 1)^2.
+///
+/// This is the critical building block for extension field multiplication:
+/// each Fp2 mul needs two dot products instead of three separate mul+reduce.
+#[inline(always)]
+pub(crate) fn dot_product_2(a0: u64, b0: u64, a1: u64, b1: u64) -> u64 {
+    let prod0 = (a0 as u128) * (b0 as u128);
+    let prod1 = (a1 as u128) * (b1 as u128);
+    let (sum, overflow) = prod0.overflowing_add(prod1);
+
+    let reduced = reduce128(sum);
+
+    if overflow {
+        // True value is sum + 2^128. Since 2^128 mod p = EPSILON^2,
+        // add EPSILON^2 = (2^32-1)^2 = 2^64 - 2^33 + 1.
+        // This value is < p, and reduced < 2p, so their sum < 3p < 2^64 + p,
+        // satisfying the precondition for add_no_canonicalize.
+        branch_hint();
+        const EPSILON_SQ: u64 = EPSILON.wrapping_mul(EPSILON);
+        unsafe { add_no_canonicalize_trashing_input(reduced, EPSILON_SQ) }
+    } else {
+        reduced
+    }
+}
+
+/// Compute a0*b0 + a1*b1 + a2*b2 mod p in a single reduction pass.
+///
+/// Accumulates three u128 products, tracking overflow count (at most 2).
+/// Each overflow adds 2^128 mod p = EPSILON^2 to the result.
+/// This is the critical building block for Fp3 multiplication (the extension
+/// field used by the VM's STARK prover).
+#[inline(always)]
+pub(crate) fn dot_product_3(
+    a0: u64, b0: u64,
+    a1: u64, b1: u64,
+    a2: u64, b2: u64,
+) -> u64 {
+    let prod0 = (a0 as u128) * (b0 as u128);
+    let prod1 = (a1 as u128) * (b1 as u128);
+    let prod2 = (a2 as u128) * (b2 as u128);
+
+    let (sum01, over1) = prod0.overflowing_add(prod1);
+    let (sum012, over2) = sum01.overflowing_add(prod2);
+    let overflow_count = (over1 as u64) + (over2 as u64);
+
+    let mut reduced = reduce128(sum012);
+
+    if overflow_count > 0 {
+        // Each overflow represents +2^128 to the true sum.
+        // 2^128 mod p = EPSILON^2 = (2^32 - 1)^2 = 2^64 - 2^33 + 1.
+        // Safety: reduced < 2^64, EPSILON_SQ < p, so sum < 2^64 + p.
+        branch_hint();
+        const EPSILON_SQ: u64 = EPSILON.wrapping_mul(EPSILON);
+        reduced = unsafe { add_no_canonicalize_trashing_input(reduced, EPSILON_SQ) };
+        if overflow_count > 1 {
+            branch_hint();
+            reduced = unsafe { add_no_canonicalize_trashing_input(reduced, EPSILON_SQ) };
+        }
+    }
+
+    reduced
+}
+
+/// Multiply a raw u64 field element by 7 (the Fp2 non-residue).
+/// Uses 7 = 8 - 1 for a straight-line computation.
+#[inline(always)]
+pub(crate) fn mul_by_7_raw(a: u64) -> u64 {
+    let a2 = GoldilocksField::double(&a);
+    let a4 = GoldilocksField::double(&a2);
+    let a8 = GoldilocksField::double(&a4);
+    GoldilocksField::sub(&a8, &a)
 }
 
 /// Inversion using optimized addition chain for a^(p-2).

--- a/crypto/math/src/field/goldilocks.rs
+++ b/crypto/math/src/field/goldilocks.rs
@@ -14,9 +14,46 @@
 //! - Plonky2: <https://github.com/0xPolygonZero/plonky2>
 //! - Remco Bloemen: <https://xn--2-umb.com/23/gold-reduce/>
 
+use core::hint::unreachable_unchecked;
+
 use crate::field::traits::HasDefaultTranscript;
 use crate::field::{element::FieldElement, errors::FieldError, traits::IsField};
 use crate::traits::{AsBytes, ByteConversion};
+
+// =====================================================
+// COMPILER HINTS (inspired by Plonky3)
+// =====================================================
+
+/// Hint to the compiler that a branch is unlikely to be taken.
+/// The empty asm block acts as a barrier that prevents the compiler from
+/// converting the branch into a conditional move, which is slower when
+/// the branch is highly predictable.
+#[inline(always)]
+fn branch_hint() {
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "arm",
+        target_arch = "x86",
+        target_arch = "x86_64",
+    ))]
+    unsafe {
+        core::arch::asm!("", options(nomem, nostack, preserves_flags));
+    }
+}
+
+/// Inform the compiler that a condition is always true.
+///
+/// # Safety
+/// The caller must guarantee that `p` is true.
+#[inline(always)]
+const unsafe fn assume(p: bool) {
+    debug_assert!(p);
+    if !p {
+        unsafe {
+            unreachable_unchecked();
+        }
+    }
+}
 
 /// The Goldilocks prime: p = 2^64 - 2^32 + 1
 pub const GOLDILOCKS_PRIME: u64 = 0xFFFF_FFFF_0000_0001;
@@ -35,32 +72,37 @@ pub struct GoldilocksField;
 impl IsField for GoldilocksField {
     type BaseType = u64;
 
-    /// Addition with overflow handling.
-    /// If a + b overflows, we add EPSILON (since 2^64 ≡ EPSILON mod p)
+    /// Addition with branch hint for rare double-overflow.
+    /// Compiles to a 3-instruction common path (add + csel + adds on ARM)
+    /// with a predicted-not-taken branch for the exceedingly rare double overflow.
     #[inline(always)]
     fn add(a: &u64, b: &u64) -> u64 {
         let (sum, over) = a.overflowing_add(*b);
-        let (sum, over2) = sum.overflowing_add((over as u64) * EPSILON);
-        // Second overflow is rare but possible
-        if over2 {
-            sum.wrapping_add(EPSILON)
-        } else {
-            sum
+        let (mut sum, over) = sum.overflowing_add((over as u64) * EPSILON);
+        if over {
+            // Double overflow requires both inputs > ORDER, which is exceedingly rare.
+            unsafe {
+                assume(*a > GOLDILOCKS_PRIME && *b > GOLDILOCKS_PRIME);
+            }
+            branch_hint();
+            sum += EPSILON; // Cannot overflow.
         }
+        sum
     }
 
-    /// Subtraction with underflow handling.
-    /// If a - b underflows, we subtract EPSILON (since -2^64 ≡ -EPSILON mod p)
+    /// Subtraction with branch hint for rare double-underflow.
     #[inline(always)]
     fn sub(a: &u64, b: &u64) -> u64 {
         let (diff, under) = a.overflowing_sub(*b);
-        let (diff, under2) = diff.overflowing_sub((under as u64) * EPSILON);
-        // Second underflow is rare but possible
-        if under2 {
-            diff.wrapping_sub(EPSILON)
-        } else {
-            diff
+        let (mut diff, under) = diff.overflowing_sub((under as u64) * EPSILON);
+        if under {
+            unsafe {
+                assume(*a < EPSILON - 1 && *b > GOLDILOCKS_PRIME);
+            }
+            branch_hint();
+            diff -= EPSILON;
         }
+        diff
     }
 
     /// Multiplication using 128-bit intermediate and fast reduction.
@@ -142,37 +184,60 @@ impl IsField for GoldilocksField {
 
 /// Reduce a 128-bit value to a 64-bit Goldilocks field element.
 ///
-/// Uses the identity: 2^64 ≡ 2^32 - 1 (mod p)
-/// and: 2^96 ≡ -1 (mod p)
-///
-/// For x = x_lo + x_hi * 2^64, where x_hi = x_hi_hi * 2^32 + x_hi_lo:
-/// x ≡ x_lo + x_hi_lo * EPSILON - x_hi_hi (mod p)
-///
-/// **Optimization**: Uses shift instead of multiply for EPSILON computation:
-/// x_hi_lo * EPSILON = x_hi_lo * (2^32 - 1) = (x_hi_lo << 32) - x_hi_lo
-/// Benchmarks show this is ~10% faster than using multiply.
+/// Uses the identities: 2^64 ≡ 2^32 - 1 (mod p), 2^96 ≡ -1 (mod p).
+/// Branch hints mark rare borrow/carry paths for better branch prediction.
 #[inline(always)]
 fn reduce128(x: u128) -> u64 {
-    let x_lo = x as u64;
-    let x_hi = (x >> 64) as u64;
+    let (x_lo, x_hi) = (x as u64, (x >> 64) as u64);
     let x_hi_hi = x_hi >> 32;
     let x_hi_lo = x_hi & EPSILON;
 
-    // Step 1: t0 = x_lo - x_hi_hi
-    let (t0, borrow) = x_lo.overflowing_sub(x_hi_hi);
-    let t0 = if borrow { t0.wrapping_sub(EPSILON) } else { t0 };
+    // 2^96 ≡ -1 (mod p), so x_hi_hi * 2^96 becomes -x_hi_hi
+    let (mut t0, borrow) = x_lo.overflowing_sub(x_hi_hi);
+    if borrow {
+        branch_hint();
+        t0 -= EPSILON; // Cannot underflow
+    }
 
-    // Step 2: t1 = x_hi_lo * EPSILON = (x_hi_lo << 32) - x_hi_lo
-    // Using shift is ~10% faster than multiply
+    // 2^64 ≡ EPSILON (mod p), so x_hi_lo * 2^64 = x_hi_lo * EPSILON
+    // Compute as (x_hi_lo << 32) - x_hi_lo to avoid a multiply
     let t1 = (x_hi_lo << 32).wrapping_sub(x_hi_lo);
 
-    // Step 3: result = t0 + t1
-    let (result, carry) = t0.overflowing_add(t1);
-    if carry {
-        result.wrapping_add(EPSILON)
-    } else {
-        result
+    // Final addition with overflow correction
+    // Safety: t0 + t1 < 2^64 + ORDER
+    unsafe { add_no_canonicalize_trashing_input(t0, t1) }
+}
+
+/// Fast modular addition: returns (x + y) mod p, assuming x + y < 2^64 + ORDER.
+/// On x86_64, uses inline asm (add + sbb trick) for 2-instruction modular add.
+/// On other architectures, uses portable overflowing_add + conditional correction.
+///
+/// # Safety
+/// Caller must ensure x + y < 2^64 + ORDER.
+#[inline(always)]
+#[cfg(target_arch = "x86_64")]
+unsafe fn add_no_canonicalize_trashing_input(x: u64, y: u64) -> u64 {
+    let res_wrapped: u64;
+    let adjustment: u64;
+    unsafe {
+        core::arch::asm!(
+            "add {0}, {1}",
+            // sbb {1:e}, {1:e} sets the low 32 bits to 0xFFFFFFFF on carry (= NEG_ORDER),
+            // or 0 otherwise. The high 32 bits are zeroed by the 32-bit register write.
+            "sbb {1:e}, {1:e}",
+            inlateout(reg) x => res_wrapped,
+            inlateout(reg) y => adjustment,
+            options(pure, nomem, nostack),
+        );
     }
+    res_wrapped + adjustment
+}
+
+#[inline(always)]
+#[cfg(not(target_arch = "x86_64"))]
+unsafe fn add_no_canonicalize_trashing_input(x: u64, y: u64) -> u64 {
+    let (res_wrapped, carry) = x.overflowing_add(y);
+    res_wrapped.wrapping_add(EPSILON * (carry as u64))
 }
 
 /// Inversion using optimized addition chain for a^(p-2).

--- a/crypto/math/src/field/goldilocks.rs
+++ b/crypto/math/src/field/goldilocks.rs
@@ -287,11 +287,7 @@ pub(crate) fn dot_product_2(a0: u64, b0: u64, a1: u64, b1: u64) -> u64 {
 /// This is the critical building block for Fp3 multiplication (the extension
 /// field used by the VM's STARK prover).
 #[inline(always)]
-pub(crate) fn dot_product_3(
-    a0: u64, b0: u64,
-    a1: u64, b1: u64,
-    a2: u64, b2: u64,
-) -> u64 {
+pub(crate) fn dot_product_3(a0: u64, b0: u64, a1: u64, b1: u64, a2: u64, b2: u64) -> u64 {
     let prod0 = (a0 as u128) * (b0 as u128);
     let prod1 = (a1 as u128) * (b1 as u128);
     let prod2 = (a2 as u128) * (b2 as u128);

--- a/crypto/math/src/tests/fft_friendly_u64_goldilocks_tests.rs
+++ b/crypto/math/src/tests/fft_friendly_u64_goldilocks_tests.rs
@@ -5,6 +5,8 @@ use crate::field::goldilocks::{
 use crate::field::traits::{IsFFTField, IsField, IsPrimeField};
 use crate::traits::ByteConversion;
 
+const EPSILON: u64 = 0xFFFF_FFFF;
+
 type F = GoldilocksField;
 type FE = FieldElement<F>;
 
@@ -419,5 +421,168 @@ mod fft_tests {
             let (poly, new_poly) = gen_fft_interpolate_and_evaluate(poly);
             prop_assert_eq!(poly, new_poly);
         }
+    }
+}
+
+// =====================================================
+// NON-CANONICAL / EDGE-CASE TESTS
+// =====================================================
+//
+// These test the double-overflow and double-underflow paths in add/sub,
+// which are only reachable with non-canonical inputs (values >= p).
+
+/// Reference modular add using u128 to avoid overflow.
+/// Canonicalizes inputs first so non-canonical u64 values work correctly.
+fn ref_add(a: u64, b: u64) -> u64 {
+    let a = (a % GOLDILOCKS_PRIME) as u128;
+    let b = (b % GOLDILOCKS_PRIME) as u128;
+    ((a + b) % GOLDILOCKS_PRIME as u128) as u64
+}
+
+/// Reference modular sub using u128 to avoid underflow.
+/// Canonicalizes inputs first so non-canonical u64 values work correctly.
+fn ref_sub(a: u64, b: u64) -> u64 {
+    let a = (a % GOLDILOCKS_PRIME) as u128;
+    let b = (b % GOLDILOCKS_PRIME) as u128;
+    let p = GOLDILOCKS_PRIME as u128;
+    ((a + p - b) % p) as u64
+}
+
+#[test]
+fn add_double_overflow_both_max() {
+    // a = b = u64::MAX, the most extreme double-overflow case.
+    let a = u64::MAX;
+    let b = u64::MAX;
+    let result = F::add(&a, &b);
+    assert_eq!(F::canonical(&result), ref_add(a, b));
+}
+
+#[test]
+fn add_double_overflow_threshold() {
+    // Double overflow fires when a + b >= 2^65 - EPSILON.
+    // Minimum case: a = p + 1, b = u64::MAX.
+    let a = GOLDILOCKS_PRIME + 1;
+    let b = u64::MAX;
+    let result = F::add(&a, &b);
+    assert_eq!(F::canonical(&result), ref_add(a, b));
+}
+
+#[test]
+fn add_no_double_overflow_at_boundary() {
+    // a = p, b = u64::MAX should NOT trigger double overflow
+    // (a + b = 2^65 - EPSILON - 1, one below the threshold).
+    let a = GOLDILOCKS_PRIME;
+    let b = u64::MAX;
+    let result = F::add(&a, &b);
+    assert_eq!(F::canonical(&result), ref_add(a, b));
+}
+
+#[test]
+fn add_non_canonical_symmetric() {
+    // Both inputs just above p.
+    for offset in 1..=EPSILON {
+        let a = GOLDILOCKS_PRIME + offset;
+        let b = GOLDILOCKS_PRIME + offset;
+        let result = F::add(&a, &b);
+        assert_eq!(
+            F::canonical(&result),
+            ref_add(a, b),
+            "failed for offset={}",
+            offset
+        );
+        // Only test a few representative values, not all 2^32-1.
+        if offset > 16 {
+            break;
+        }
+    }
+}
+
+#[test]
+fn sub_double_underflow_extreme() {
+    // a = 0, b = u64::MAX: maximum underflow.
+    let a = 0u64;
+    let b = u64::MAX;
+    let result = F::sub(&a, &b);
+    assert_eq!(F::canonical(&result), ref_sub(a, b));
+}
+
+#[test]
+fn sub_double_underflow_small_a_large_b() {
+    // a just below EPSILON - 1, b well above p.
+    let a = EPSILON - 2; // 2^32 - 3
+    let b = u64::MAX;
+    let result = F::sub(&a, &b);
+    assert_eq!(F::canonical(&result), ref_sub(a, b));
+}
+
+#[test]
+fn sub_no_double_underflow_at_boundary() {
+    // a = EPSILON - 1 = 2^32 - 2, b = u64::MAX.
+    // diff1 = EPSILON, diff1 - EPSILON = 0 (no second underflow).
+    let a = EPSILON - 1;
+    let b = u64::MAX;
+    let result = F::sub(&a, &b);
+    assert_eq!(F::canonical(&result), ref_sub(a, b));
+}
+
+#[test]
+fn sub_non_canonical_b() {
+    // b values just above p, a = 0.
+    for offset in 1..=16u64 {
+        let a = 0u64;
+        let b = GOLDILOCKS_PRIME + offset;
+        let result = F::sub(&a, &b);
+        assert_eq!(
+            F::canonical(&result),
+            ref_sub(a, b),
+            "failed for b = p + {}",
+            offset
+        );
+    }
+}
+
+#[test]
+fn add_sub_roundtrip_non_canonical() {
+    // For non-canonical inputs, (a + b) - b should equal a (mod p).
+    let test_cases: Vec<(u64, u64)> = vec![
+        (u64::MAX, u64::MAX),
+        (u64::MAX, GOLDILOCKS_PRIME + 1),
+        (u64::MAX - 1, GOLDILOCKS_PRIME + 1),
+        (0, u64::MAX),
+        (1, u64::MAX - 1),
+    ];
+    for (a, b) in test_cases {
+        let sum = F::add(&a, &b);
+        let back = F::sub(&sum, &b);
+        assert_eq!(
+            F::canonical(&back),
+            F::canonical(&a),
+            "roundtrip failed for a={:#x}, b={:#x}",
+            a,
+            b
+        );
+    }
+}
+
+#[test]
+fn mul_non_canonical_inputs() {
+    // Multiplication should produce correct results even with non-canonical inputs.
+    let test_cases: Vec<(u64, u64)> = vec![
+        (u64::MAX, u64::MAX),
+        (GOLDILOCKS_PRIME, GOLDILOCKS_PRIME),
+        (GOLDILOCKS_PRIME + 1, u64::MAX),
+        (u64::MAX - 1, 2),
+    ];
+    let ref_mul =
+        |a: u64, b: u64| ((a as u128 * b as u128) % GOLDILOCKS_PRIME as u128) as u64;
+    for (a, b) in test_cases {
+        let result = F::mul(&a, &b);
+        assert_eq!(
+            F::canonical(&result),
+            ref_mul(a, b),
+            "mul failed for a={:#x}, b={:#x}",
+            a,
+            b
+        );
     }
 }

--- a/crypto/math/src/tests/fft_friendly_u64_goldilocks_tests.rs
+++ b/crypto/math/src/tests/fft_friendly_u64_goldilocks_tests.rs
@@ -573,8 +573,7 @@ fn mul_non_canonical_inputs() {
         (GOLDILOCKS_PRIME + 1, u64::MAX),
         (u64::MAX - 1, 2),
     ];
-    let ref_mul =
-        |a: u64, b: u64| ((a as u128 * b as u128) % GOLDILOCKS_PRIME as u128) as u64;
+    let ref_mul = |a: u64, b: u64| ((a as u128 * b as u128) % GOLDILOCKS_PRIME as u128) as u64;
     for (a, b) in test_cases {
         let result = F::mul(&a, &b);
         assert_eq!(


### PR DESCRIPTION

This PR ports the Goldilocks field arithmetic optimizations from Lambdaworks (compiler hints, branch prediction, and x86_64 inline assembly for the base field) and extends them with fused dot-product accumulation for extension field arithmetic.


#### Base field 
- **add/sub**: Uses `assume()` + `branch_hint()` for rare double overflow/underflow cases, avoiding `cmov` on predictable branches.  
- **reduce128**: Applies the same branch-hint pattern for rare borrow/carry scenarios.  
- **add_no_canonicalize_trashing_input**: Uses x86_64 `add` + `sbb reg32, reg32` for a 2-instruction modular addition, with a portable fallback.


#### Fused dot-product and Fp3 rewrite 

`dot_product_2` and `dot_product_3` accumulate multiple `u64 × u64` products as `u128` and perform a single reduction instead of reducing per product.

This enables a rewrite of **Fp3**

- **Fp3 multiplication**:  
  Karatsuba (`6 muls + 6 reduce128`) → schoolbook + `dot_product_3` (`9 muls + 3 reduce128`).  
  Extra multiplications are cheaper than the saved reductions.

- **Fp3 squaring**:  
  `6 → 3 reduce128` using `dot_product_2`.


#### Testing

- Edge-case tests for non-canonical inputs  
- Expanded fuzz target for raw `u64` coverage  
- Inline proofs for unsafe `assume` invariants  