### PR TITLE
Add per-phase heap profiler

### DIFF
--- a/bin/cli/Cargo.toml
+++ b/bin/cli/Cargo.toml
@@ -14,4 +14,4 @@ tikv-jemalloc-ctl = { version = "0.6", features = ["stats"], optional = true }
 
 [features]
 jemalloc-stats = ["dep:tikv-jemalloc-ctl"]
-instruments = ["prover/instruments"]
+instruments = ["prover/instruments", "stark/instruments"]

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -262,6 +262,12 @@ fn cmd_prove(elf_path: PathBuf, output_path: PathBuf, blowup: Option<u8>, time: 
     #[cfg(feature = "jemalloc-stats")]
     let tracker = heap_tracker::HeapTracker::start();
 
+    #[cfg(all(feature = "jemalloc-stats", feature = "instruments"))]
+    stark::instruments::set_heap_reader(|| {
+        tikv_jemalloc_ctl::epoch::advance().ok();
+        tikv_jemalloc_ctl::stats::allocated::read().unwrap_or(0)
+    });
+
     let start = Instant::now();
     let proof = match blowup {
         Some(b) => {

--- a/crypto/stark/src/instruments.rs
+++ b/crypto/stark/src/instruments.rs
@@ -1,6 +1,33 @@
 use std::cell::RefCell;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+
+static HEAP_READER: OnceLock<fn() -> usize> = OnceLock::new();
+
+pub fn set_heap_reader(f: fn() -> usize) {
+    let _ = HEAP_READER.set(f);
+}
+
+pub fn heap_bytes() -> Option<usize> {
+    HEAP_READER.get().map(|f| f())
+}
+
+fn heap_mb() -> Option<usize> {
+    heap_bytes().map(|b| b / (1024 * 1024))
+}
+
+pub type HeapSnapshot = (&'static str, usize);
+
+pub fn snap(label: &'static str) -> Option<HeapSnapshot> {
+    heap_mb().map(|mb| (label, mb))
+}
+
+pub struct ProveHeapProfile {
+    pub after_execute: Option<usize>,
+    pub after_trace_build: Option<usize>,
+    pub after_air: Option<usize>,
+}
 
 /// Sub-operation timing breakdown for a single table in Rounds 2-4.
 #[derive(Clone, Debug, Default)]
@@ -49,6 +76,7 @@ pub struct MultiProveTiming {
     pub round1_sub: Round1SubOps,
     /// (name, rows, duration, sub_ops) per table for rounds 2-4.
     pub table_timings: Vec<(String, usize, Duration, TableSubOps)>,
+    pub heap_snapshots: Vec<HeapSnapshot>,
 }
 
 /// Round 1 sub-timings: atomics so parallel rayon workers can accumulate safely.

--- a/crypto/stark/src/instruments.rs
+++ b/crypto/stark/src/instruments.rs
@@ -13,14 +13,10 @@ pub fn heap_bytes() -> Option<usize> {
     HEAP_READER.get().map(|f| f())
 }
 
-fn heap_mb() -> Option<usize> {
-    heap_bytes().map(|b| b / (1024 * 1024))
-}
-
 pub type HeapSnapshot = (&'static str, usize);
 
 pub fn snap(label: &'static str) -> Option<HeapSnapshot> {
-    heap_mb().map(|mb| (label, mb))
+    heap_bytes().map(|b| (label, b))
 }
 
 pub struct ProveHeapProfile {

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1496,6 +1496,8 @@ pub trait IsStarkProver<
 
         #[cfg(feature = "instruments")]
         crate::instruments::reset_all();
+        #[cfg(feature = "instruments")]
+        let mut heap_snaps: Vec<crate::instruments::HeapSnapshot> = Vec::new();
 
         let num_airs = air_trace_pairs.len();
 
@@ -1547,6 +1549,10 @@ pub trait IsStarkProver<
 
         #[cfg(feature = "instruments")]
         let prepass_elapsed = phase_start.elapsed();
+        #[cfg(feature = "instruments")]
+        if let Some(s) = crate::instruments::snap("after pool alloc") {
+            heap_snaps.push(s);
+        }
 
         // =====================================================================
         // Round 1, Phase A: Commit all main traces (parallel in chunks of K)
@@ -1609,6 +1615,10 @@ pub trait IsStarkProver<
 
         #[cfg(feature = "instruments")]
         let main_commits_elapsed = phase_start.elapsed();
+        #[cfg(feature = "instruments")]
+        if let Some(s) = crate::instruments::snap("after main commits") {
+            heap_snaps.push(s);
+        }
 
         // =====================================================================
         // Round 1, Phase B: Sample shared LogUp challenges
@@ -1655,6 +1665,10 @@ pub trait IsStarkProver<
 
         #[cfg(feature = "instruments")]
         let aux_build_elapsed = phase_start.elapsed();
+        #[cfg(feature = "instruments")]
+        if let Some(s) = crate::instruments::snap("after aux build") {
+            heap_snaps.push(s);
+        }
 
         // Pass 2: Parallel fork transcript → extract → LDE → commit in chunks of K.
         // Each table gets its own transcript fork and pool set.
@@ -1755,6 +1769,10 @@ pub trait IsStarkProver<
 
         #[cfg(feature = "instruments")]
         let aux_commit_elapsed = phase_start.elapsed();
+        #[cfg(feature = "instruments")]
+        if let Some(s) = crate::instruments::snap("after aux commit") {
+            heap_snaps.push(s);
+        }
 
         #[cfg(feature = "debug-checks")]
         {
@@ -1897,6 +1915,7 @@ pub trait IsStarkProver<
                 rounds_2_4: phase_start.elapsed(),
                 round1_sub: crate::instruments::take_r1_sub(),
                 table_timings,
+                heap_snapshots: heap_snaps,
             });
         }
 

--- a/prover/src/instruments.rs
+++ b/prover/src/instruments.rs
@@ -232,12 +232,11 @@ pub fn print_report(
         print_row("After trace build", heap_profile.after_trace_build);
         print_row("After AIR construction", heap_profile.after_air);
         if let Some(ref mp_data) = mp {
-            for (label, snap_mb) in &mp_data.heap_snapshots {
-                let snap_bytes = snap_mb * (1024 * 1024);
-                let cur = *snap_mb;
+            for (label, bytes) in &mp_data.heap_snapshots {
+                let cur = mb(*bytes);
                 let delta = cur as isize - mb(prev) as isize;
                 eprintln!("  {:<36} {:>7} {:>+8}", label, cur, delta);
-                prev = snap_bytes;
+                prev = *bytes;
             }
         }
         eprintln!("  {}", "─".repeat(56));

--- a/prover/src/instruments.rs
+++ b/prover/src/instruments.rs
@@ -57,6 +57,8 @@ pub fn print_report(
     trace_build: Duration,
     air_construction: Duration,
     total: Duration,
+    heap_before: Option<usize>,
+    heap_profile: &stark::instruments::ProveHeapProfile,
 ) {
     let mp = stark::instruments::take();
 
@@ -69,7 +71,7 @@ pub fn print_report(
     row_top("Trace build", trace_build, total);
     row_top("AIR construction", air_construction, total);
 
-    if let Some(mp) = mp {
+    if let Some(ref mp) = mp {
         let round1 = mp.main_commits + mp.aux_build + mp.aux_commit;
 
         row_top("Pre-pass (domains/twiddles)", mp.prepass, total);
@@ -177,10 +179,7 @@ pub fn print_report(
                 ("R4  queries & openings", total_queries),
             ];
             sub_ops.sort_by(|a, b| b.1.cmp(&a.1));
-            eprintln!(
-                "  {}",
-                "    \u{2500}\u{2500} sub-operation totals (all tables) \u{2500}\u{2500}",
-            );
+            eprintln!("      \u{2500}\u{2500} sub-operation totals (all tables) \u{2500}\u{2500}",);
             for (label, dur) in &sub_ops {
                 row_sub(&format!("    {label}"), *dur, total);
             }
@@ -214,4 +213,34 @@ pub fn print_report(
     eprintln!("  {}", "─".repeat(58));
     eprintln!("  {:<36} {:>7.2}s", "TOTAL", total.as_secs_f64());
     eprintln!();
+
+    let mb = |b: usize| b / (1024 * 1024);
+    if let Some(before) = heap_before {
+        eprintln!("=== HEAP PROFILE (MB) ===");
+        eprintln!("  {:<36} {:>8} {:>8}", "Phase", "Heap", "Delta");
+        eprintln!("  {}", "─".repeat(56));
+        let mut prev = before;
+        let mut print_row = |label: &str, val: Option<usize>| {
+            if let Some(v) = val {
+                let cur = mb(v);
+                let delta = mb(v) as isize - mb(prev) as isize;
+                eprintln!("  {:<36} {:>7} {:>+8}", label, cur, delta);
+                prev = v;
+            }
+        };
+        print_row("After execute", heap_profile.after_execute);
+        print_row("After trace build", heap_profile.after_trace_build);
+        print_row("After AIR construction", heap_profile.after_air);
+        if let Some(ref mp_data) = mp {
+            for (label, snap_mb) in &mp_data.heap_snapshots {
+                let snap_bytes = snap_mb * (1024 * 1024);
+                let cur = *snap_mb;
+                let delta = cur as isize - mb(prev) as isize;
+                eprintln!("  {:<36} {:>7} {:>+8}", label, cur, delta);
+                prev = snap_bytes;
+            }
+        }
+        eprintln!("  {}", "─".repeat(56));
+        eprintln!();
+    }
 }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -476,6 +476,8 @@ pub fn prove_with_options(
 ) -> Result<VmProof, Error> {
     #[cfg(feature = "instruments")]
     let total_start = std::time::Instant::now();
+    #[cfg(feature = "instruments")]
+    let heap_before = stark::instruments::heap_bytes();
 
     // Phase 1: Execute (ELF load + run)
     #[cfg(feature = "instruments")]
@@ -489,6 +491,8 @@ pub fn prove_with_options(
 
     #[cfg(feature = "instruments")]
     let execute_elapsed = phase_start.elapsed();
+    #[cfg(feature = "instruments")]
+    let heap_after_execute = stark::instruments::heap_bytes();
 
     // Phase 2: Trace build
     #[cfg(feature = "instruments")]
@@ -500,6 +504,8 @@ pub fn prove_with_options(
 
     #[cfg(feature = "instruments")]
     let trace_build_elapsed = phase_start.elapsed();
+    #[cfg(feature = "instruments")]
+    let heap_after_trace = stark::instruments::heap_bytes();
 
     // Phase 3: AIR construction
     #[cfg(feature = "instruments")]
@@ -516,6 +522,8 @@ pub fn prove_with_options(
 
     #[cfg(feature = "instruments")]
     let air_elapsed = phase_start.elapsed();
+    #[cfg(feature = "instruments")]
+    let heap_after_air = stark::instruments::heap_bytes();
 
     let runtime_page_ranges = traces.runtime_page_ranges();
 
@@ -533,6 +541,12 @@ pub fn prove_with_options(
             trace_build_elapsed,
             air_elapsed,
             total_start.elapsed(),
+            heap_before,
+            &stark::instruments::ProveHeapProfile {
+                after_execute: heap_after_execute,
+                after_trace_build: heap_after_trace,
+                after_air: heap_after_air,
+            },
         );
     }
 

--- a/scripts/bench_heap_profile.sh
+++ b/scripts/bench_heap_profile.sh
@@ -180,7 +180,7 @@ for phase in $PHASES; do
             prev_val=$(grep "^${prev_phase_key}=" "$DATA" | cut -d= -f2)
             delta=$((cur - prev_val))
         fi
-        steps_m=$(awk "BEGIN {printf \"%.2f\", $steps / 1000000}")
+        steps_m=$(awk "BEGIN {printf \"%.6f\", $steps / 1000000}")
         PAIRS="$PAIRS $steps_m $delta"
     done
 
@@ -216,7 +216,7 @@ for size in $PROGRAMS; do
     steps=$(grep "^steps=" "$DATA" | cut -d= -f2)
     peak=$(grep "^peak=" "$DATA" | cut -d= -f2)
     [ -z "$peak" ] && continue
-    steps_m=$(awk "BEGIN {printf \"%.2f\", $steps / 1000000}")
+    steps_m=$(awk "BEGIN {printf \"%.6f\", $steps / 1000000}")
     PEAK_PAIRS="$PEAK_PAIRS $steps_m $peak"
 done
 

--- a/scripts/bench_heap_profile.sh
+++ b/scripts/bench_heap_profile.sh
@@ -63,15 +63,15 @@ for size in $PROGRAMS; do
     rm -f "$TMP_DIR/proof.bin"
 
     # Parse absolute heap values (second-to-last column) from HEAP PROFILE section
-    HEAP_VALS=$(awk '/^=== HEAP PROFILE/,/^  ─/{
-        if (/After execute/)       printf "execute=%s\n", $(NF-1)
-        if (/After trace build/)   printf "trace_build=%s\n", $(NF-1)
-        if (/After AIR/)           printf "air=%s\n", $(NF-1)
-        if (/after pool alloc/)    printf "pool_alloc=%s\n", $(NF-1)
-        if (/after main commits/)  printf "main_commits=%s\n", $(NF-1)
-        if (/after aux build/)     printf "aux_build=%s\n", $(NF-1)
-        if (/after aux commit/)    printf "aux_commit=%s\n", $(NF-1)
-    }' "$STDERR")
+    HEAP_VALS=$(awk '
+        /After execute/          { printf "execute=%s\n",      $(NF-1) }
+        /After trace build/      { printf "trace_build=%s\n",  $(NF-1) }
+        /After AIR/              { printf "air=%s\n",          $(NF-1) }
+        /after pool alloc/       { printf "pool_alloc=%s\n",   $(NF-1) }
+        /after main commits/     { printf "main_commits=%s\n", $(NF-1) }
+        /after aux build/        { printf "aux_build=%s\n",    $(NF-1) }
+        /after aux commit/       { printf "aux_commit=%s\n",   $(NF-1) }
+    ' "$STDERR")
 
     PEAK=$(grep -o 'Peak heap: [0-9]*' "$STDOUT" | awk '{print $3}')
     echo "steps=$steps" > "$TMP_DIR/${size}_data.txt"

--- a/scripts/bench_heap_profile.sh
+++ b/scripts/bench_heap_profile.sh
@@ -232,11 +232,17 @@ echo "$PEAK_PAIRS" | awk '{
     for (i=0;i<n;i++) { p=a+b*x[i]; ss_res+=(y[i]-p)^2; ss_tot+=(y[i]-ym)^2 }
     r2 = (ss_tot>0) ? 1 - ss_res/ss_tot : 1
     printf "  Model: peak = %.0f + %.0f * steps_M  (R²=%.4f)\n\n", a, b, r2
-    targets[0]=8; targets[1]=16; targets[2]=32; targets[3]=64
-    labels[0]="8M"; labels[1]="16M"; labels[2]="32M"; labels[3]="64M"
+    xmax = 0
+    for (i=0;i<n;i++) if (x[i] > xmax) xmax = x[i]
+    mults[0]=2; mults[1]=4; mults[2]=8; mults[3]=16
     for (t=0; t<4; t++) {
-        pred = a + b * targets[t]
-        printf "  fib_iterative_%-6s  ~%.0f MB  (~%.0f GB)\n", labels[t], pred, pred/1024
+        target_m = mults[t] * xmax
+        pred = a + b * target_m
+        abs = target_m * 1000000
+        if (abs >= 1000000)  lbl = sprintf("%gM", abs / 1000000)
+        else if (abs >= 1000) lbl = sprintf("%gk", abs / 1000)
+        else                  lbl = sprintf("%g", abs)
+        printf "  fib_iterative_%-6s  ~%.0f MB  (~%.0f GB)\n", lbl, pred, pred/1024
     }
 }'
 

--- a/scripts/bench_heap_profile.sh
+++ b/scripts/bench_heap_profile.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+# Per-phase heap profile across program sizes.
+# Shows where heap grows and how each phase scales with program size.
+#
+# Usage: bench_heap_profile.sh [--no-build] [--programs "500k 1M 2M 4M"]
+#
+# Requires: instruments + jemalloc-stats features.
+# Peak heap is deterministic, so 1 run per size is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_DIR="/tmp/bench_heap_profile"
+ELF_DIR="$ROOT_DIR/executor/program_artifacts/asm"
+
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+BUILD=true
+PROGRAMS="500k 1M 2M 4M"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --no-build) BUILD=false; shift ;;
+        --programs) PROGRAMS="$2"; shift 2 ;;
+        *) echo "Unknown arg: $1"; exit 1 ;;
+    esac
+done
+
+suffix_to_steps() {
+    case $1 in
+        160k) echo 160000 ;; 250k) echo 250000 ;; 372k) echo 372000 ;;
+        500k) echo 500000 ;; 1M) echo 1000000 ;; 1200k) echo 1200000 ;;
+        2M) echo 2000000 ;; 4M) echo 4000000 ;; 8M) echo 8000000 ;;
+        16M) echo 16000000 ;; 32M) echo 32000000 ;; 64M) echo 64000000 ;; 128M) echo 128000000 ;;
+        *) echo "Unknown: $1" >&2; exit 1 ;;
+    esac
+}
+
+rm -rf "$TMP_DIR" && mkdir -p "$TMP_DIR"
+
+if $BUILD; then
+    echo -e "${GREEN}Building CLI with instruments + jemalloc-stats...${NC}"
+    cargo build --release -p cli --features jemalloc-stats,instruments \
+        --manifest-path "$ROOT_DIR/Cargo.toml" 2>&1 | tail -1
+fi
+CLI="$ROOT_DIR/target/release/cli"
+
+# Phase labels we parse from stderr (order matters)
+PHASES="execute trace_build air pool_alloc main_commits aux_build aux_commit rounds_2_4"
+
+for size in $PROGRAMS; do
+    ELF="$ELF_DIR/fib_iterative_${size}.elf"
+    [ -f "$ELF" ] || { echo "Missing: $ELF"; continue; }
+    steps=$(suffix_to_steps "$size")
+    echo -e "${GREEN}Running fib_iterative_${size}...${NC}"
+
+    STDERR="$TMP_DIR/${size}_stderr.txt"
+    STDOUT="$TMP_DIR/${size}_stdout.txt"
+    "$CLI" prove "$ELF" -o "$TMP_DIR/proof.bin" --time >"$STDOUT" 2>"$STDERR"
+    rm -f "$TMP_DIR/proof.bin"
+
+    # Parse absolute heap values (second-to-last column) from HEAP PROFILE section
+    HEAP_VALS=$(awk '/^=== HEAP PROFILE/,/^──/{
+        if (/After execute/)       printf "execute=%s\n", $(NF-1)
+        if (/After trace build/)   printf "trace_build=%s\n", $(NF-1)
+        if (/After AIR/)           printf "air=%s\n", $(NF-1)
+        if (/after pool alloc/)    printf "pool_alloc=%s\n", $(NF-1)
+        if (/after main commits/)  printf "main_commits=%s\n", $(NF-1)
+        if (/after aux build/)     printf "aux_build=%s\n", $(NF-1)
+        if (/after aux commit/)    printf "aux_commit=%s\n", $(NF-1)
+        if (/after rounds 2-4/)    printf "rounds_2_4=%s\n", $(NF-1)
+    }' "$STDERR")
+
+    PEAK=$(grep -o 'Peak heap: [0-9]*' "$STDOUT" | awk '{print $3}')
+    echo "steps=$steps" > "$TMP_DIR/${size}_data.txt"
+    echo "peak=$PEAK" >> "$TMP_DIR/${size}_data.txt"
+    echo "$HEAP_VALS" >> "$TMP_DIR/${size}_data.txt"
+done
+
+echo ""
+echo -e "${BOLD}=== HEAP PROFILE ACROSS SIZES ===${NC}"
+echo ""
+
+# Print table: phases as rows, sizes as columns
+# Header
+printf "  %-22s" "Phase (delta MB)"
+for size in $PROGRAMS; do printf " %10s" "$size"; done
+echo ""
+printf "  %-22s" "──────────────────────"
+for size in $PROGRAMS; do printf " %10s" "──────────"; done
+echo ""
+
+# For each phase, print the delta
+prev_phase=""
+for phase in $PHASES; do
+    case $phase in
+        execute)      label="Execute" ;;
+        trace_build)  label="Trace build" ;;
+        air)          label="AIR construction" ;;
+        pool_alloc)   label="Pool allocation" ;;
+        main_commits) label="Main commits" ;;
+        aux_build)    label="Aux build" ;;
+        aux_commit)   label="Aux commit" ;;
+        rounds_2_4)   label="Rounds 2-4" ;;
+    esac
+
+    printf "  %-22s" "$label"
+    for size in $PROGRAMS; do
+        DATA="$TMP_DIR/${size}_data.txt"
+        [ -f "$DATA" ] || { printf " %10s" "N/A"; continue; }
+        cur=$(grep "^${phase}=" "$DATA" | cut -d= -f2)
+        if [ -z "$cur" ]; then
+            printf " %10s" "N/A"
+        else
+            # Get previous phase value to compute delta
+            if [ -z "$prev_phase" ]; then
+                delta="$cur"
+            else
+                prev_val=$(grep "^${prev_phase}=" "$DATA" | cut -d= -f2)
+                delta=$((cur - prev_val))
+            fi
+            printf " %+10d" "$delta"
+        fi
+    done
+    echo ""
+    prev_phase=$phase
+done
+
+# Total/peak row
+printf "  %-22s" "──────────────────────"
+for size in $PROGRAMS; do printf " %10s" "──────────"; done
+echo ""
+printf "  %-22s" "Peak heap"
+for size in $PROGRAMS; do
+    DATA="$TMP_DIR/${size}_data.txt"
+    peak=$(grep "^peak=" "$DATA" | cut -d= -f2)
+    printf " %10s" "${peak:-N/A}"
+done
+echo ""
+
+# Linear regression per phase
+echo ""
+echo -e "${BOLD}=== GROWTH RATE PER PHASE (MB per 1M steps) ===${NC}"
+echo ""
+
+for phase in $PHASES; do
+    case $phase in
+        execute)      label="Execute" ;;
+        trace_build)  label="Trace build" ;;
+        air)          label="AIR construction" ;;
+        pool_alloc)   label="Pool allocation" ;;
+        main_commits) label="Main commits" ;;
+        aux_build)    label="Aux build" ;;
+        aux_commit)   label="Aux commit" ;;
+        rounds_2_4)   label="Rounds 2-4" ;;
+    esac
+
+    # Collect (steps_M, delta) pairs
+    PAIRS=""
+    prev_phase_key=""
+    case $phase in
+        execute)      prev_phase_key="" ;;
+        trace_build)  prev_phase_key="execute" ;;
+        air)          prev_phase_key="trace_build" ;;
+        pool_alloc)   prev_phase_key="air" ;;
+        main_commits) prev_phase_key="pool_alloc" ;;
+        aux_build)    prev_phase_key="main_commits" ;;
+        aux_commit)   prev_phase_key="aux_build" ;;
+        rounds_2_4)   prev_phase_key="aux_commit" ;;
+    esac
+
+    for size in $PROGRAMS; do
+        DATA="$TMP_DIR/${size}_data.txt"
+        [ -f "$DATA" ] || continue
+        steps=$(grep "^steps=" "$DATA" | cut -d= -f2)
+        cur=$(grep "^${phase}=" "$DATA" | cut -d= -f2)
+        [ -z "$cur" ] && continue
+        if [ -z "$prev_phase_key" ]; then
+            delta="$cur"
+        else
+            prev_val=$(grep "^${prev_phase_key}=" "$DATA" | cut -d= -f2)
+            delta=$((cur - prev_val))
+        fi
+        steps_m=$(awk "BEGIN {printf \"%.2f\", $steps / 1000000}")
+        PAIRS="$PAIRS $steps_m $delta"
+    done
+
+    # Linear regression: delta = a + b * steps_M
+    echo "$PAIRS" | awk -v label="$label" '{
+        n = NF / 2
+        if (n < 2) { printf "  %-22s  (insufficient data)\n", label; next }
+        for (i = 0; i < n; i++) {
+            x[i] = $(2*i+1); y[i] = $(2*i+2)
+        }
+        sx=0; sy=0; sxx=0; sxy=0
+        for (i=0;i<n;i++) { sx+=x[i]; sy+=y[i]; sxx+=x[i]*x[i]; sxy+=x[i]*y[i] }
+        b = (n*sxy - sx*sy) / (n*sxx - sx*sx)
+        a = (sy - b*sx) / n
+        # R²
+        ym = sy/n; ss_tot=0; ss_res=0
+        for (i=0;i<n;i++) { p=a+b*x[i]; ss_res+=(y[i]-p)^2; ss_tot+=(y[i]-ym)^2 }
+        r2 = (ss_tot>0) ? 1 - ss_res/ss_tot : 1
+        printf "  %-22s  %+.0f MB/M steps  (base: %.0f MB, R²=%.3f)\n", label, b, a, r2
+    }'
+done
+
+# Extrapolation
+echo ""
+echo -e "${BOLD}=== EXTRAPOLATED PEAK HEAP ===${NC}"
+echo ""
+
+# Collect (steps_M, peak) for regression
+PEAK_PAIRS=""
+for size in $PROGRAMS; do
+    DATA="$TMP_DIR/${size}_data.txt"
+    [ -f "$DATA" ] || continue
+    steps=$(grep "^steps=" "$DATA" | cut -d= -f2)
+    peak=$(grep "^peak=" "$DATA" | cut -d= -f2)
+    [ -z "$peak" ] && continue
+    steps_m=$(awk "BEGIN {printf \"%.2f\", $steps / 1000000}")
+    PEAK_PAIRS="$PEAK_PAIRS $steps_m $peak"
+done
+
+echo "$PEAK_PAIRS" | awk '{
+    n = NF / 2
+    if (n < 2) { print "  (insufficient data)"; next }
+    for (i = 0; i < n; i++) { x[i] = $(2*i+1); y[i] = $(2*i+2) }
+    sx=0; sy=0; sxx=0; sxy=0
+    for (i=0;i<n;i++) { sx+=x[i]; sy+=y[i]; sxx+=x[i]*x[i]; sxy+=x[i]*y[i] }
+    b = (n*sxy - sx*sy) / (n*sxx - sx*sx)
+    a = (sy - b*sx) / n
+    ym = sy/n; ss_tot=0; ss_res=0
+    for (i=0;i<n;i++) { p=a+b*x[i]; ss_res+=(y[i]-p)^2; ss_tot+=(y[i]-ym)^2 }
+    r2 = (ss_tot>0) ? 1 - ss_res/ss_tot : 1
+    printf "  Model: peak = %.0f + %.0f * steps_M  (R²=%.4f)\n\n", a, b, r2
+    targets[0]=8; targets[1]=16; targets[2]=32; targets[3]=64
+    labels[0]="8M"; labels[1]="16M"; labels[2]="32M"; labels[3]="64M"
+    for (t=0; t<4; t++) {
+        pred = a + b * targets[t]
+        printf "  fib_iterative_%-6s  ~%.0f MB  (~%.0f GB)\n", labels[t], pred, pred/1024
+    }
+}'
+
+echo ""
+echo "Raw data: $TMP_DIR/"

--- a/scripts/bench_heap_profile.sh
+++ b/scripts/bench_heap_profile.sh
@@ -49,7 +49,7 @@ fi
 CLI="$ROOT_DIR/target/release/cli"
 
 # Phase labels we parse from stderr (order matters)
-PHASES="execute trace_build air pool_alloc main_commits aux_build aux_commit rounds_2_4"
+PHASES="execute trace_build air pool_alloc main_commits aux_build aux_commit"
 
 for size in $PROGRAMS; do
     ELF="$ELF_DIR/fib_iterative_${size}.elf"
@@ -63,7 +63,7 @@ for size in $PROGRAMS; do
     rm -f "$TMP_DIR/proof.bin"
 
     # Parse absolute heap values (second-to-last column) from HEAP PROFILE section
-    HEAP_VALS=$(awk '/^=== HEAP PROFILE/,/^──/{
+    HEAP_VALS=$(awk '/^=== HEAP PROFILE/,/^  ─/{
         if (/After execute/)       printf "execute=%s\n", $(NF-1)
         if (/After trace build/)   printf "trace_build=%s\n", $(NF-1)
         if (/After AIR/)           printf "air=%s\n", $(NF-1)
@@ -71,7 +71,6 @@ for size in $PROGRAMS; do
         if (/after main commits/)  printf "main_commits=%s\n", $(NF-1)
         if (/after aux build/)     printf "aux_build=%s\n", $(NF-1)
         if (/after aux commit/)    printf "aux_commit=%s\n", $(NF-1)
-        if (/after rounds 2-4/)    printf "rounds_2_4=%s\n", $(NF-1)
     }' "$STDERR")
 
     PEAK=$(grep -o 'Peak heap: [0-9]*' "$STDOUT" | awk '{print $3}')
@@ -104,7 +103,6 @@ for phase in $PHASES; do
         main_commits) label="Main commits" ;;
         aux_build)    label="Aux build" ;;
         aux_commit)   label="Aux commit" ;;
-        rounds_2_4)   label="Rounds 2-4" ;;
     esac
 
     printf "  %-22s" "$label"
@@ -155,7 +153,6 @@ for phase in $PHASES; do
         main_commits) label="Main commits" ;;
         aux_build)    label="Aux build" ;;
         aux_commit)   label="Aux commit" ;;
-        rounds_2_4)   label="Rounds 2-4" ;;
     esac
 
     # Collect (steps_M, delta) pairs
@@ -169,7 +166,6 @@ for phase in $PHASES; do
         main_commits) prev_phase_key="pool_alloc" ;;
         aux_build)    prev_phase_key="main_commits" ;;
         aux_commit)   prev_phase_key="aux_build" ;;
-        rounds_2_4)   prev_phase_key="aux_commit" ;;
     esac
 
     for size in $PROGRAMS; do


### PR DESCRIPTION
Adds heap profiling infrastructure behind the existing `instruments` + `jemalloc-stats` feature flags.

- `scripts/bench_heap_profile.sh` runs the prover across program sizes and prints a per-phase heap breakdown with growth rates and extrapolation
- `stark::instruments` gains `set_heap_reader`, `snap`, `HeapSnapshot`, `ProveHeapProfile` for phase-boundary heap readings
- `prover::instruments::print_report` prints a `=== HEAP PROFILE (MB) ===` table when a heap reader is registered

Usage: `scripts/bench_heap_profile.sh --programs "1M 2M 4M 8M"`