### PR TITLE
feat: skip empty optional tables to reduce sub-proof count

### DIFF
--- a/crypto/stark/src/proof/mod.rs
+++ b/crypto/stark/src/proof/mod.rs
@@ -1,2 +1,3 @@
 pub mod options;
 pub mod stark;
+pub mod unified;

--- a/crypto/stark/src/proof/stark.rs
+++ b/crypto/stark/src/proof/stark.rs
@@ -73,8 +73,19 @@ pub struct StarkProof<F: IsSubFieldOf<E>, E: IsField, PI> {
 /// A collection of STARK proofs for multiple AIRs.
 /// Used for multi-table proving where tables are linked via bus (LogUp).
 /// Returned by `Prover::multi_prove` and verified by `Verifier::multi_verify`.
+///
+/// When `unified_proof` is present, the tables at `unified_indices` are proved
+/// collectively via batched commitment + single FRI. Their entries in `proofs`
+/// are absent — `proofs` only contains per-table proofs for non-unified tables.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(bound = "PI: serde::Serialize + serde::de::DeserializeOwned")]
 pub struct MultiProof<F: IsSubFieldOf<E>, E: IsField, PI> {
+    /// Per-table proofs for individually-proved tables.
     pub proofs: Vec<StarkProof<F, E, PI>>,
+    /// Batched proof for tables at `unified_indices` (if any).
+    #[serde(default)]
+    pub unified_proof: Option<Box<super::unified::UnifiedMultiProof<F, E>>>,
+    /// Indices (in the original AIR ordering) of tables covered by `unified_proof`.
+    #[serde(default)]
+    pub unified_indices: Vec<usize>,
 }

--- a/crypto/stark/src/proof/unified.rs
+++ b/crypto/stark/src/proof/unified.rs
@@ -1,0 +1,130 @@
+//! Unified multi-table proof with batched commitment and single FRI.
+//!
+//! Unlike [`StarkProof`](super::stark::StarkProof) which contains per-table FRI data,
+//! this structure separates per-table OOD evaluations from shared commitment/FRI data.
+//! All tables' columns are committed together in shared Merkle trees, and a single
+//! FRI proof covers the combined DEEP composition polynomial.
+
+use crypto::merkle_tree::proof::Proof;
+use math::field::{
+    element::FieldElement,
+    traits::{IsField, IsSubFieldOf},
+};
+
+use crate::{
+    config::Commitment,
+    fri::fri_decommit::FriDecommitment,
+    lookup::BusPublicInputs,
+    table::Table,
+};
+
+/// Per-table data in a unified proof: OOD evaluations and bus inputs.
+/// Does NOT contain Merkle trees or FRI data — those are shared.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(bound = "")]
+pub struct TableOodData<E: IsField> {
+    /// Length of this table's trace (before LDE).
+    pub trace_length: usize,
+    /// Number of main trace columns for this table.
+    pub num_main_cols: usize,
+    /// Number of aux trace columns (0 if no aux).
+    pub num_aux_cols: usize,
+    /// Whether this table has precomputed (preprocessed) columns.
+    pub num_precomputed_cols: usize,
+    /// Trace evaluations at the OOD point z: T(z) and T(gz).
+    pub trace_ood_evaluations: Table<E>,
+    /// Composition polynomial parts evaluated at z^N.
+    pub composition_poly_parts_ood_evaluation: Vec<FieldElement<E>>,
+    /// Bus interaction public inputs.
+    pub bus_public_inputs: Option<BusPublicInputs<E>>,
+}
+
+/// Openings at a queried FRI index for the unified commitment.
+///
+/// Each query opens the shared main, aux, and composition Merkle trees
+/// at the queried index and its symmetric partner.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(bound = "")]
+pub struct UnifiedQueryOpening<F: IsSubFieldOf<E>, E: IsField> {
+    /// Main trace opening: Merkle proof + evaluations at (index, sym_index).
+    pub main_proof: Proof<Commitment>,
+    pub main_proof_sym: Proof<Commitment>,
+    pub main_evaluations: Vec<FieldElement<F>>,
+    pub main_evaluations_sym: Vec<FieldElement<F>>,
+    /// Aux trace opening (if any tables have aux).
+    pub aux_proof: Option<Proof<Commitment>>,
+    pub aux_proof_sym: Option<Proof<Commitment>>,
+    pub aux_evaluations: Vec<FieldElement<E>>,
+    pub aux_evaluations_sym: Vec<FieldElement<E>>,
+    /// Composition polynomial opening.
+    pub composition_proof: Proof<Commitment>,
+    pub composition_proof_sym: Proof<Commitment>,
+    pub composition_evaluations: Vec<FieldElement<E>>,
+    pub composition_evaluations_sym: Vec<FieldElement<E>>,
+}
+
+/// A unified multi-table STARK proof with batched commitments and single FRI.
+///
+/// Key differences from [`MultiProof`](super::stark::MultiProof):
+/// - All main trace columns committed in ONE Merkle tree (not one per table)
+/// - All aux columns in ONE Merkle tree
+/// - All composition polynomial parts in ONE Merkle tree
+/// - ONE FRI proof covering the combined DEEP composition polynomial
+/// - Per-table data is limited to OOD evaluations and bus inputs
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(bound = "")]
+pub struct UnifiedMultiProof<F: IsSubFieldOf<E>, E: IsField> {
+    // ====== Shared commitments ======
+    /// Root of the batched main trace Merkle tree (all tables' main columns).
+    pub main_trace_root: Commitment,
+    /// Root of the batched auxiliary trace Merkle tree (all tables' aux columns).
+    /// None if no table has auxiliary trace.
+    pub aux_trace_root: Option<Commitment>,
+    /// Root of the batched composition polynomial Merkle tree.
+    pub composition_poly_root: Commitment,
+
+    /// Precomputed commitment roots per preprocessed table.
+    /// Vec of (table_index, commitment). Empty for non-preprocessed tables.
+    pub precomputed_roots: Vec<(usize, Commitment)>,
+
+    // ====== Per-table OOD data ======
+    /// Per-table out-of-domain evaluations and metadata.
+    pub table_data: Vec<TableOodData<E>>,
+
+    // ====== Shared FRI proof ======
+    /// FRI layer Merkle roots from the single FRI instance.
+    pub fri_layers_merkle_roots: Vec<Commitment>,
+    /// Final constant value from FRI folding.
+    pub fri_last_value: FieldElement<E>,
+    /// FRI decommitments (one per query).
+    pub fri_query_list: Vec<FriDecommitment<E>>,
+
+    // ====== Unified query openings ======
+    /// Openings of the batched Merkle trees at each queried index.
+    pub query_openings: Vec<UnifiedQueryOpening<F, E>>,
+
+    // ====== Grinding ======
+    pub nonce: Option<u64>,
+
+    // ====== Layout ======
+    /// Column layout: for each table, (start_main_col, num_main_cols, start_aux_col, num_aux_cols).
+    /// Used by the verifier to extract per-table columns from unified openings.
+    pub column_layout: Vec<ColumnRange>,
+}
+
+/// Describes where a table's columns live within the unified commitment.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ColumnRange {
+    /// Starting column index in the batched main trace.
+    pub main_start: usize,
+    /// Number of main columns for this table.
+    pub main_count: usize,
+    /// Starting column index in the batched aux trace.
+    pub aux_start: usize,
+    /// Number of aux columns for this table.
+    pub aux_count: usize,
+    /// Starting column index in the batched composition polynomial.
+    pub comp_start: usize,
+    /// Number of composition polynomial parts for this table.
+    pub comp_count: usize,
+}

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
-use crypto::merkle_tree::traits::IsMerkleTreeBackend;
 use math::fft::cpu::bit_reversing::{in_place_bit_reverse_permute, reverse_index};
 use math::fft::cpu::bowers_fft::LayerTwiddles;
 use math::fft::errors::FFTError;
@@ -32,7 +31,7 @@ use crate::proof::stark::{DeepPolynomialOpenings, PolynomialOpenings};
 use crate::table::Table;
 use crate::trace::LDETraceTable;
 
-use super::config::{BatchedMerkleTree, BatchedMerkleTreeBackend, Commitment};
+use super::config::{BatchedMerkleTree, Commitment};
 use super::constraints::evaluator::ConstraintEvaluator;
 use super::domain::Domain;
 use super::fri::fri_decommit::FriDecommitment;
@@ -375,6 +374,8 @@ pub trait IsStarkProver<
     /// where `br(i)` is the bit-reversal of `i`. This produces the same Merkle
     /// tree as the old clone + bit-reverse + columns2rows + batch_commit flow,
     /// but avoids allocating the cloned and transposed matrices entirely.
+    ///
+    /// The hasher feeds column bytes incrementally — no per-row Vec allocation.
     fn commit_columns_bit_reversed<E>(
         columns: &[Vec<FieldElement<E>>],
     ) -> Option<(BatchedMerkleTree<E>, Commitment)>
@@ -382,6 +383,8 @@ pub trait IsStarkProver<
         FieldElement<E>: AsBytes + Sync + Send,
         E: IsField,
     {
+        use sha3::Digest;
+
         if columns.is_empty() || columns[0].is_empty() {
             return None;
         }
@@ -397,10 +400,11 @@ pub trait IsStarkProver<
         let hashed_leaves: Vec<Commitment> = iter
             .map(|row_idx| {
                 let br_idx = reverse_index(row_idx, num_rows as u64);
-                let row: Vec<FieldElement<E>> = (0..num_cols)
-                    .map(|col_idx| columns[col_idx][br_idx].clone())
-                    .collect();
-                BatchedMerkleTreeBackend::<E>::hash_data(&row)
+                let mut hasher = sha3::Keccak256::new();
+                for col_idx in 0..num_cols {
+                    hasher.update(columns[col_idx][br_idx].as_bytes());
+                }
+                hasher.finalize().into()
             })
             .collect();
 
@@ -721,16 +725,17 @@ pub trait IsStarkProver<
 
         let hashed_leaves: Vec<Commitment> = iter
             .map(|leaf_idx| {
+                use sha3::Digest;
                 let br_0 = reverse_index(2 * leaf_idx, num_rows as u64);
                 let br_1 = reverse_index(2 * leaf_idx + 1, num_rows as u64);
-                let mut leaf = Vec::with_capacity(2 * num_parts);
+                let mut hasher = sha3::Keccak256::new();
                 for part in lde_composition_poly_parts_evaluations.iter() {
-                    leaf.push(part[br_0].clone());
+                    hasher.update(part[br_0].as_bytes());
                 }
                 for part in lde_composition_poly_parts_evaluations.iter() {
-                    leaf.push(part[br_1].clone());
+                    hasher.update(part[br_1].as_bytes());
                 }
-                BatchedMerkleTreeBackend::<FieldExtension>::hash_data(&leaf)
+                hasher.finalize().into()
             })
             .collect();
 

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1871,7 +1871,762 @@ pub trait IsStarkProver<
             });
         }
 
-        Ok(MultiProof { proofs })
+        Ok(MultiProof {
+            proofs,
+            unified_proof: None,
+            unified_indices: Vec::new(),
+        })
+    }
+
+    /// Hybrid proving: batches non-preprocessed same-height tables via unified
+    /// commitment + single FRI, while individually proving the rest.
+    ///
+    /// All tables share a single transcript through Phase A+B (main commitments
+    /// + LogUp challenges), then fork: individual tables get per-table forked
+    /// transcripts, batched tables get one shared forked transcript.
+    ///
+    /// Falls back to `multi_prove` if no tables can be batched.
+    fn multi_prove_hybrid(
+        mut air_trace_pairs: Vec<AirTracePair<'_, Field, FieldExtension, PI>>,
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone + Send),
+    ) -> Result<MultiProof<Field, FieldExtension, PI>, ProvingError>
+    where
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
+        PI: Send + Sync + Clone,
+    {
+        let num_airs = air_trace_pairs.len();
+        if num_airs == 0 {
+            return Ok(MultiProof {
+                proofs: Vec::new(),
+                unified_proof: None,
+                unified_indices: Vec::new(),
+            });
+        }
+
+        // Classify tables into batchable (non-preprocessed, same height) vs individual
+        let mut height_counts: std::collections::HashMap<usize, usize> =
+            std::collections::HashMap::new();
+        for (air, trace, _) in &air_trace_pairs {
+            if !air.is_preprocessed() {
+                *height_counts.entry(trace.num_rows()).or_insert(0) += 1;
+            }
+        }
+        // Target height = most common height among non-preprocessed tables
+        let target_height = height_counts
+            .into_iter()
+            .max_by_key(|(_, count)| *count)
+            .map(|(h, _)| h);
+
+        let mut batched_indices: Vec<usize> = Vec::new();
+        let mut individual_indices: Vec<usize> = Vec::new();
+
+        if let Some(th) = target_height {
+            for (idx, (air, trace, _)) in air_trace_pairs.iter().enumerate() {
+                if !air.is_preprocessed() && trace.num_rows() == th {
+                    batched_indices.push(idx);
+                } else {
+                    individual_indices.push(idx);
+                }
+            }
+        }
+
+        // Need at least 2 tables to batch; otherwise fall back to per-table
+        if batched_indices.len() < 2 {
+            return Self::multi_prove(air_trace_pairs, transcript);
+        }
+
+        info!(
+            "multi_prove_hybrid: {} batched (height={}), {} individual",
+            batched_indices.len(),
+            target_height.unwrap(),
+            individual_indices.len()
+        );
+
+        let needs_lookup = air_trace_pairs.iter().any(|(a, _, _)| a.has_aux_trace());
+
+        // =====================================================================
+        // Phase A: Commit all main traces to shared transcript
+        // =====================================================================
+
+        // Compute domains/twiddles per table
+        let mut domains = Vec::with_capacity(num_airs);
+        let mut twiddle_caches: Vec<LdeTwiddles<Field>> = Vec::with_capacity(num_airs);
+        for (air, trace, _) in &air_trace_pairs {
+            let domain = new_domain(*air, trace.num_rows());
+            let twiddles = LdeTwiddles::new(&domain);
+            domains.push(domain);
+            twiddle_caches.push(twiddles);
+        }
+
+        // Individual tables: commit per-table (same as multi_prove Phase A)
+        let mut individual_main_commits: Vec<(usize, MainCommitData<Field>)> = Vec::new();
+        let mut individual_main_ldes: Vec<(usize, Vec<Vec<FieldElement<Field>>>)> = Vec::new();
+
+        for &idx in &individual_indices {
+            let (air, trace, _) = &air_trace_pairs[idx];
+            let domain = &domains[idx];
+            let twiddles = &twiddle_caches[idx];
+
+            let (tree, root, pre_tree, pre_root, n_pre, cached_main) =
+                if air.is_preprocessed() {
+                    Self::commit_preprocessed_trace(
+                        *trace,
+                        domain,
+                        air.precomputed_commitment(),
+                        air.num_precomputed_columns(),
+                        twiddles,
+                    )?
+                } else {
+                    Self::commit_main_trace(*trace, domain, twiddles)?
+                };
+
+            if let Some(ref pr) = pre_root {
+                transcript.append_bytes(pr);
+            }
+            transcript.append_bytes(&root);
+
+            individual_main_commits.push((
+                idx,
+                MainCommitData {
+                    main_tree: Arc::new(tree),
+                    main_root: root,
+                    precomputed_tree: pre_tree.map(Arc::new),
+                    precomputed_root: pre_root,
+                    num_precomputed_cols: n_pre,
+                },
+            ));
+            individual_main_ldes.push((idx, cached_main));
+        }
+
+        // Batched tables: batch-commit all main LDE columns in one tree
+        let batched_domain = &domains[batched_indices[0]];
+        let batched_twiddles = &twiddle_caches[batched_indices[0]];
+        let batched_lde_size =
+            batched_domain.interpolation_domain_size * batched_domain.blowup_factor;
+
+        let mut per_batched_main_lde: Vec<Vec<Vec<FieldElement<Field>>>> =
+            Vec::with_capacity(batched_indices.len());
+
+        for &idx in &batched_indices {
+            let (_, trace, _) = &air_trace_pairs[idx];
+            let mut columns = trace.extract_columns_main(batched_lde_size);
+            Self::expand_columns_to_lde::<Field>(&mut columns, batched_domain, batched_twiddles);
+            per_batched_main_lde.push(columns);
+        }
+
+        // Batch commit main
+        let batched_main_tree = {
+            use sha3::Digest;
+            #[cfg(feature = "parallel")]
+            let iter = (0..batched_lde_size).into_par_iter();
+            #[cfg(not(feature = "parallel"))]
+            let iter = 0..batched_lde_size;
+
+            let leaves: Vec<Commitment> = iter
+                .map(|row_idx| {
+                    let br = reverse_index(row_idx, batched_lde_size as u64);
+                    let mut hasher = sha3::Keccak256::new();
+                    for table_cols in &per_batched_main_lde {
+                        for col in table_cols {
+                            hasher.update(col[br].as_bytes());
+                        }
+                    }
+                    hasher.finalize().into()
+                })
+                .collect();
+            Arc::new(
+                BatchedMerkleTree::<Field>::build_from_hashed_leaves(leaves)
+                    .ok_or(ProvingError::EmptyCommitment)?,
+            )
+        };
+        let batched_main_root = batched_main_tree.root;
+        transcript.append_bytes(&batched_main_root);
+
+        // =====================================================================
+        // Phase B: Sample shared LogUp challenges
+        // =====================================================================
+
+        let lookup_challenges: Vec<FieldElement<FieldExtension>> = if needs_lookup {
+            (0..LOGUP_NUM_CHALLENGES)
+                .map(|_| transcript.sample_field_element())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // =====================================================================
+        // Build all auxiliary traces (shared challenges)
+        // =====================================================================
+
+        #[cfg(feature = "parallel")]
+        let aux_iter = air_trace_pairs.par_iter_mut();
+        #[cfg(not(feature = "parallel"))]
+        let aux_iter = air_trace_pairs.iter_mut();
+        let bus_inputs_vec: Vec<Option<BusPublicInputs<FieldExtension>>> = aux_iter
+            .map(|(air, trace, _)| {
+                if air.has_aux_trace() {
+                    air.build_auxiliary_trace(*trace, &lookup_challenges)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // =====================================================================
+        // Fork transcripts: individual per-table + one for batched group
+        // =====================================================================
+        // Individual tables use indices 0..num_airs-1 as fork IDs (matching multi_prove).
+        // The batched group uses index num_airs as its fork ID.
+
+        let mut individual_transcripts: Vec<_> = individual_indices
+            .iter()
+            .map(|&idx| {
+                let mut t = transcript.clone();
+                t.append_bytes(&(idx as u64).to_le_bytes());
+                t
+            })
+            .collect();
+
+        let mut batched_transcript = transcript.clone();
+        batched_transcript.append_bytes(&(num_airs as u64).to_le_bytes());
+
+        // =====================================================================
+        // Individual tables: Phase C + Rounds 2-4 (per-table, same as multi_prove)
+        // =====================================================================
+
+        let mut individual_proofs: Vec<(usize, StarkProof<Field, FieldExtension, PI>)> =
+            Vec::with_capacity(individual_indices.len());
+
+        for (pos, &idx) in individual_indices.iter().enumerate() {
+            let (air, trace, pub_inputs) = &air_trace_pairs[idx];
+            let domain = &domains[idx];
+            let twiddles = &twiddle_caches[idx];
+            let t = &mut individual_transcripts[pos];
+
+            // Aux commit
+            let (aux_tree, aux_root, cached_aux) = if air.has_aux_trace() {
+                let mut columns = trace.extract_columns_aux(
+                    domain.interpolation_domain_size * domain.blowup_factor,
+                );
+                Self::expand_columns_to_lde::<FieldExtension>(&mut columns, domain, twiddles);
+                let (tree, root) = Self::commit_columns_bit_reversed(&columns)
+                    .ok_or(ProvingError::EmptyCommitment)?;
+                (Some(Arc::new(tree)), Some(root), columns)
+            } else {
+                (None, None, Vec::new())
+            };
+
+            if let Some(ref root) = aux_root {
+                t.append_bytes(root);
+            }
+
+            // Build Round1
+            let (_, main_commit) = individual_main_commits
+                .iter()
+                .find(|(i, _)| *i == idx)
+                .unwrap();
+            let (_, main_lde) = individual_main_ldes
+                .iter()
+                .find(|(i, _)| *i == idx)
+                .unwrap();
+
+            let commitments = Round1Commitments {
+                main_merkle_tree: Arc::clone(&main_commit.main_tree),
+                main_merkle_root: main_commit.main_root,
+                precomputed_merkle_tree: main_commit.precomputed_tree.as_ref().map(Arc::clone),
+                precomputed_merkle_root: main_commit.precomputed_root,
+                num_precomputed_cols: main_commit.num_precomputed_cols,
+                aux_merkle_tree: aux_tree,
+                aux_merkle_root: aux_root,
+                rap_challenges: lookup_challenges.clone(),
+                bus_public_inputs: bus_inputs_vec[idx].clone(),
+            };
+
+            let lde = Lde {
+                main: main_lde.clone(),
+                aux: cached_aux,
+            };
+            let round_1 = commitments.build_round1(
+                lde,
+                air.step_size(),
+                domain.blowup_factor,
+                air.has_aux_trace(),
+            );
+
+            if let Some(ref bpi) = round_1.bus_public_inputs {
+                t.append_field_element(&bpi.table_contribution);
+            }
+
+            let proof = Self::prove_rounds_2_to_4(*air, *pub_inputs, &round_1, t, domain)?;
+            individual_proofs.push((idx, proof));
+        }
+
+        // =====================================================================
+        // Batched tables: unified Phase C + Rounds 2-4
+        // =====================================================================
+
+        // Extract batched air_trace_pairs (borrow references)
+        let batched_bus_inputs: Vec<Option<BusPublicInputs<FieldExtension>>> =
+            batched_indices.iter().map(|&idx| bus_inputs_vec[idx].clone()).collect();
+
+        // Call multi_prove_unified's logic: Phase C through Round 4
+        // We manually inline the unified path here since we already did Phase A+B.
+        let unified_proof = Self::unified_phase_c_through_round4(
+            &air_trace_pairs,
+            &batched_indices,
+            &mut per_batched_main_lde,
+            &batched_bus_inputs,
+            &lookup_challenges,
+            batched_domain,
+            batched_twiddles,
+            batched_main_tree,
+            batched_main_root,
+            batched_lde_size,
+            &mut batched_transcript,
+        )?;
+
+        // =====================================================================
+        // Assemble result
+        // =====================================================================
+
+        // Sort individual proofs by original index
+        individual_proofs.sort_by_key(|(idx, _)| *idx);
+        let proofs: Vec<StarkProof<Field, FieldExtension, PI>> =
+            individual_proofs.into_iter().map(|(_, p)| p).collect();
+
+        Ok(MultiProof {
+            proofs,
+            unified_proof: Some(Box::new(unified_proof)),
+            unified_indices: batched_indices,
+        })
+    }
+
+    /// Phase C through Round 4 for the unified (batched) path.
+    /// Called by `multi_prove_hybrid` after Phase A+B are complete.
+    #[allow(clippy::too_many_arguments)]
+    fn unified_phase_c_through_round4(
+        air_trace_pairs: &[AirTracePair<'_, Field, FieldExtension, PI>],
+        batched_indices: &[usize],
+        per_batched_main_lde: &mut [Vec<Vec<FieldElement<Field>>>],
+        batched_bus_inputs: &[Option<BusPublicInputs<FieldExtension>>],
+        lookup_challenges: &[FieldElement<FieldExtension>],
+        domain: &Domain<Field>,
+        twiddles: &LdeTwiddles<Field>,
+        main_tree: Arc<BatchedMerkleTree<Field>>,
+        main_root: Commitment,
+        lde_size: usize,
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Send),
+    ) -> Result<
+        crate::proof::unified::UnifiedMultiProof<Field, FieldExtension>,
+        ProvingError,
+    >
+    where
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
+        PI: Send + Sync + Clone,
+    {
+        use crate::proof::unified::{
+            ColumnRange, TableOodData, UnifiedMultiProof, UnifiedQueryOpening,
+        };
+        use sha3::Digest;
+
+        let num_batched = batched_indices.len();
+        let blowup_factor = domain.blowup_factor;
+        let domain_size = domain.interpolation_domain_size;
+        let trace_length = domain_size;
+
+        // Build column layout for main
+        let mut layout: Vec<ColumnRange> = Vec::with_capacity(num_batched);
+        let mut main_col_offset = 0usize;
+        for lde in per_batched_main_lde.iter() {
+            let count = lde.len();
+            layout.push(ColumnRange {
+                main_start: main_col_offset,
+                main_count: count,
+                aux_start: 0,
+                aux_count: 0,
+                comp_start: 0,
+                comp_count: 0,
+            });
+            main_col_offset += count;
+        }
+        let total_main_cols = main_col_offset;
+
+        // Phase C: aux LDE + batch commit
+        let mut per_batched_aux_lde: Vec<Vec<Vec<FieldElement<FieldExtension>>>> =
+            Vec::with_capacity(num_batched);
+        let mut aux_col_offset = 0usize;
+
+        for (pos, &idx) in batched_indices.iter().enumerate() {
+            let (air, trace, _) = &air_trace_pairs[idx];
+            if air.has_aux_trace() {
+                let mut columns = trace.extract_columns_aux(lde_size);
+                Self::expand_columns_to_lde::<FieldExtension>(&mut columns, domain, twiddles);
+                let count = columns.len();
+                layout[pos].aux_start = aux_col_offset;
+                layout[pos].aux_count = count;
+                aux_col_offset += count;
+                per_batched_aux_lde.push(columns);
+            } else {
+                per_batched_aux_lde.push(Vec::new());
+            }
+        }
+
+        let total_aux_cols = aux_col_offset;
+        let (aux_tree, aux_root) = if total_aux_cols > 0 {
+            #[cfg(feature = "parallel")]
+            let iter = (0..lde_size).into_par_iter();
+            #[cfg(not(feature = "parallel"))]
+            let iter = 0..lde_size;
+
+            let leaves: Vec<Commitment> = iter
+                .map(|row_idx| {
+                    let br = reverse_index(row_idx, lde_size as u64);
+                    let mut hasher = sha3::Keccak256::new();
+                    for table_cols in &per_batched_aux_lde {
+                        for col in table_cols {
+                            hasher.update(col[br].as_bytes());
+                        }
+                    }
+                    hasher.finalize().into()
+                })
+                .collect();
+            let tree = BatchedMerkleTree::<FieldExtension>::build_from_hashed_leaves(leaves)
+                .ok_or(ProvingError::EmptyCommitment)?;
+            let root = tree.root;
+            (Some(Arc::new(tree)), Some(root))
+        } else {
+            (None, None)
+        };
+
+        if let Some(ref root) = aux_root {
+            transcript.append_bytes(root);
+        }
+        for bus in batched_bus_inputs {
+            if let Some(bpi) = bus {
+                transcript.append_field_element(&bpi.table_contribution);
+            }
+        }
+
+        // Round 2: constraint eval + batch comp commit
+        let beta: FieldElement<FieldExtension> = transcript.sample_field_element();
+        let mut per_batched_comp_lde: Vec<Vec<Vec<FieldElement<FieldExtension>>>> =
+            Vec::with_capacity(num_batched);
+        let mut comp_col_offset = 0usize;
+
+        for (pos, &idx) in batched_indices.iter().enumerate() {
+            let (air, _, pub_inputs) = &air_trace_pairs[idx];
+            let main_cols = std::mem::take(&mut per_batched_main_lde[pos]);
+            let aux_cols = std::mem::take(&mut per_batched_aux_lde[pos]);
+            let lde_trace =
+                LDETraceTable::from_columns(main_cols, aux_cols, air.step_size(), blowup_factor);
+
+            let evaluator = ConstraintEvaluator::new(
+                *air, *pub_inputs, lookup_challenges,
+                batched_bus_inputs[pos].as_ref(), trace_length,
+            );
+            let num_boundary = air
+                .boundary_constraints(
+                    *pub_inputs, lookup_challenges,
+                    batched_bus_inputs[pos].as_ref(), trace_length,
+                )
+                .constraints.len();
+            let num_transition = air.context().num_transition_constraints;
+            let mut coefficients: Vec<FieldElement<FieldExtension>> =
+                core::iter::successors(Some(FieldElement::one()), |x| Some(x * &beta))
+                    .take(num_boundary + num_transition)
+                    .collect();
+            let transition_coefficients: Vec<_> = coefficients.drain(..num_transition).collect();
+            let boundary_coefficients = coefficients;
+
+            let constraint_evaluations = evaluator.evaluate(
+                *air, &lde_trace, domain,
+                &transition_coefficients, &boundary_coefficients, lookup_challenges,
+            );
+            let number_of_parts = air.composition_poly_degree_bound(trace_length) / trace_length;
+            let comp_evals = if number_of_parts == 2 {
+                Self::decompose_and_extend_d2(&constraint_evaluations, domain)
+            } else if number_of_parts == 1 {
+                vec![constraint_evaluations]
+            } else {
+                let p = Polynomial::interpolate_offset_fft(
+                    &constraint_evaluations, &domain.coset_offset,
+                ).unwrap();
+                p.break_in_parts(number_of_parts).iter().map(|part| {
+                    evaluate_polynomial_on_lde_domain(part, blowup_factor, domain_size, &domain.coset_offset).unwrap()
+                }).collect()
+            };
+            let count = comp_evals.len();
+            layout[pos].comp_start = comp_col_offset;
+            layout[pos].comp_count = count;
+            comp_col_offset += count;
+            per_batched_comp_lde.push(comp_evals);
+
+            let (main_back, aux_back) = lde_trace.into_columns();
+            per_batched_main_lde[pos] = main_back;
+            per_batched_aux_lde[pos] = aux_back;
+        }
+
+        // Batch comp commit (pair-merged leaves)
+        let total_comp_cols = comp_col_offset;
+        let comp_lde_size = per_batched_comp_lde[0][0].len();
+        let num_comp_leaves = comp_lde_size / 2;
+        let comp_tree = {
+            #[cfg(feature = "parallel")]
+            let iter = (0..num_comp_leaves).into_par_iter();
+            #[cfg(not(feature = "parallel"))]
+            let iter = 0..num_comp_leaves;
+            let leaves: Vec<Commitment> = iter
+                .map(|leaf_idx| {
+                    let br_0 = reverse_index(2 * leaf_idx, comp_lde_size as u64);
+                    let br_1 = reverse_index(2 * leaf_idx + 1, comp_lde_size as u64);
+                    let mut hasher = sha3::Keccak256::new();
+                    for parts in &per_batched_comp_lde {
+                        for part in parts { hasher.update(part[br_0].as_bytes()); }
+                    }
+                    for parts in &per_batched_comp_lde {
+                        for part in parts { hasher.update(part[br_1].as_bytes()); }
+                    }
+                    hasher.finalize().into()
+                })
+                .collect();
+            BatchedMerkleTree::<FieldExtension>::build_from_hashed_leaves(leaves)
+                .ok_or(ProvingError::EmptyCommitment)?
+        };
+        let comp_root = comp_tree.root;
+        transcript.append_bytes(&comp_root);
+
+        // Round 3: shared z
+        let z: FieldElement<FieldExtension> = transcript.sample_z_ood(
+            &domain.lde_roots_of_unity_coset,
+            &domain.trace_roots_of_unity,
+        );
+
+        let coset_points: Vec<FieldElement<Field>> = (0..domain_size)
+            .map(|i| domain.lde_roots_of_unity_coset[i * blowup_factor].clone())
+            .collect();
+        let coset_offset_pow_n: FieldElement<Field> = domain.coset_offset.pow(domain_size);
+        let domain_size_inv: FieldElement<Field> =
+            FieldElement::<Field>::from(domain_size as u64).inv().expect("power of two");
+        let g_n_inv: FieldElement<Field> = coset_offset_pow_n.inv().expect("non-zero");
+
+        let mut table_data: Vec<TableOodData<FieldExtension>> = Vec::with_capacity(num_batched);
+
+        for (pos, &idx) in batched_indices.iter().enumerate() {
+            let (air, _, _) = &air_trace_pairs[idx];
+            let main_cols = std::mem::take(&mut per_batched_main_lde[pos]);
+            let aux_cols = std::mem::take(&mut per_batched_aux_lde[pos]);
+            let lde_trace =
+                LDETraceTable::from_columns(main_cols, aux_cols, air.step_size(), blowup_factor);
+
+            let trace_ood = crate::trace::get_trace_evaluations_from_lde(
+                &lde_trace, domain, &z, &air.context().transition_offsets, air.step_size(),
+            );
+
+            let num_parts = layout[pos].comp_count;
+            let z_power = z.pow(num_parts);
+            let comp_z_pow_n = z_power.pow(domain_size);
+            let comp_inv_denoms = math::polynomial::barycentric_inv_denoms(&z_power, &coset_points);
+            let comp_ood: Vec<_> = per_batched_comp_lde[pos].iter().map(|lde_evals| {
+                let evals: Vec<_> = (0..domain_size).map(|i| lde_evals[i * blowup_factor].clone()).collect();
+                math::polynomial::interpolate_coset_eval_ext_with_g_n_inv(
+                    &comp_z_pow_n, &coset_offset_pow_n, &domain_size_inv, &g_n_inv,
+                    &coset_points, &evals, &comp_inv_denoms,
+                )
+            }).collect();
+
+            for col in trace_ood.columns().iter() {
+                for elem in col.iter() { transcript.append_field_element(elem); }
+            }
+            for elem in &comp_ood { transcript.append_field_element(elem); }
+
+            let num_main = lde_trace.num_main_cols();
+            let num_aux = lde_trace.num_aux_cols();
+            let (main_back, aux_back) = lde_trace.into_columns();
+            per_batched_main_lde[pos] = main_back;
+            per_batched_aux_lde[pos] = aux_back;
+
+            table_data.push(TableOodData {
+                trace_length,
+                num_main_cols: num_main,
+                num_aux_cols: num_aux,
+                num_precomputed_cols: 0,
+                trace_ood_evaluations: trace_ood,
+                composition_poly_parts_ood_evaluation: comp_ood,
+                bus_public_inputs: batched_bus_inputs[pos].clone(),
+            });
+        }
+
+        // Round 4: unified DEEP + single FRI
+        let gamma: FieldElement<FieldExtension> = transcript.sample_field_element();
+        let num_eval_points = 2;
+        let primitive_root = &domain.trace_primitive_root;
+        let z_shifted = [z.clone(), primitive_root * &z];
+
+        let per_table_z_power_k: Vec<FieldElement<FieldExtension>> =
+            layout.iter().map(|l| z.pow(l.comp_count)).collect();
+        let unique_z_powers: Vec<FieldElement<FieldExtension>> = {
+            let mut seen = Vec::new();
+            for zk in &per_table_z_power_k {
+                if !seen.contains(zk) { seen.push(zk.clone()); }
+            }
+            seen
+        };
+
+        let mut total_terms = 0usize;
+        for l in &layout {
+            total_terms += (l.main_count + l.aux_count) * num_eval_points + l.comp_count;
+        }
+        let gamma_powers: Vec<FieldElement<FieldExtension>> =
+            core::iter::successors(Some(FieldElement::one()), |x| Some(x * &gamma))
+                .take(total_terms).collect();
+
+        let num_denom_groups = 2 + unique_z_powers.len();
+        let mut denoms: Vec<FieldElement<FieldExtension>> =
+            Vec::with_capacity(domain_size * num_denom_groups);
+        for i in 0..domain_size {
+            let x_i = &domain.lde_roots_of_unity_coset[i * blowup_factor];
+            denoms.push(x_i - &z_shifted[0]);
+        }
+        for i in 0..domain_size {
+            let x_i = &domain.lde_roots_of_unity_coset[i * blowup_factor];
+            denoms.push(x_i - &z_shifted[1]);
+        }
+        for zk in &unique_z_powers {
+            for i in 0..domain_size {
+                let x_i = &domain.lde_roots_of_unity_coset[i * blowup_factor];
+                denoms.push(x_i - zk);
+            }
+        }
+        FieldElement::inplace_batch_inverse(&mut denoms).expect("non-zero");
+        let inv_t0 = &denoms[0..domain_size];
+        let inv_t1 = &denoms[domain_size..2 * domain_size];
+        let per_table_inv_h_idx: Vec<usize> = per_table_z_power_k.iter()
+            .map(|zk| unique_z_powers.iter().position(|u| u == zk).unwrap()).collect();
+        let inv_h_slices: Vec<&[FieldElement<FieldExtension>]> = (0..unique_z_powers.len())
+            .map(|g| &denoms[(2 + g) * domain_size..(3 + g) * domain_size]).collect();
+
+        #[cfg(feature = "parallel")]
+        let deep_iter = (0..domain_size).into_par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let deep_iter = 0..domain_size;
+
+        let deep_evals: Vec<FieldElement<FieldExtension>> = deep_iter.map(|i| {
+            let row_idx = i * blowup_factor;
+            let mut result = FieldElement::<FieldExtension>::zero();
+            let mut term_idx = 0usize;
+            for pos in 0..num_batched {
+                let ood_cols = table_data[pos].trace_ood_evaluations.columns();
+                let main_lde = &per_batched_main_lde[pos];
+                let aux_lde = &per_batched_aux_lde[pos];
+                for j in 0..main_lde.len() {
+                    let t_val = &main_lde[j][row_idx];
+                    result += &gamma_powers[term_idx] * &(t_val - &ood_cols[j][0]) * &inv_t0[i];
+                    term_idx += 1;
+                    result += &gamma_powers[term_idx] * &(t_val - &ood_cols[j][1]) * &inv_t1[i];
+                    term_idx += 1;
+                }
+                let mc = main_lde.len();
+                for j in 0..aux_lde.len() {
+                    let t_val = &aux_lde[j][row_idx];
+                    result += &gamma_powers[term_idx] * &(t_val - &ood_cols[mc + j][0]) * &inv_t0[i];
+                    term_idx += 1;
+                    result += &gamma_powers[term_idx] * &(t_val - &ood_cols[mc + j][1]) * &inv_t1[i];
+                    term_idx += 1;
+                }
+                let inv_h_t = inv_h_slices[per_table_inv_h_idx[pos]];
+                let comp = &per_batched_comp_lde[pos];
+                let comp_ood = &table_data[pos].composition_poly_parts_ood_evaluation;
+                for p in 0..comp.len() {
+                    result += &gamma_powers[term_idx] * &(&comp[p][row_idx] - &comp_ood[p]) * &inv_h_t[i];
+                    term_idx += 1;
+                }
+            }
+            result
+        }).collect();
+
+        let deep_poly = Polynomial::interpolate_fft::<Field>(&deep_evals).expect("iFFT");
+        let mut lde_deep = Polynomial::evaluate_fft::<Field>(&deep_poly, 1, Some(lde_size)).expect("FFT");
+        in_place_bit_reverse_permute(&mut lde_deep);
+
+        let coset_offset_u64 = air_trace_pairs[batched_indices[0]].0.context().proof_options.coset_offset;
+        let coset_offset = FieldElement::<Field>::from(coset_offset_u64);
+        let (fri_last_value, fri_layers) = fri::commit_phase_from_evaluations::<Field, FieldExtension>(
+            domain.root_order as usize, lde_deep, transcript, &coset_offset, lde_size,
+        );
+
+        let security_bits = air_trace_pairs[batched_indices[0]].0.context().proof_options.grinding_factor;
+        let mut nonce = None;
+        if security_bits > 0 {
+            let nonce_value = grinding::generate_nonce(&transcript.state(), security_bits).expect("nonce");
+            transcript.append_bytes(&nonce_value.to_be_bytes());
+            nonce = Some(nonce_value);
+        }
+
+        let number_of_queries = air_trace_pairs[batched_indices[0]].0.options().fri_number_of_queries;
+        let iotas = Self::sample_query_indexes(number_of_queries, domain, transcript);
+        let query_list = fri::query_phase(&fri_layers, &iotas);
+        let fri_layers_merkle_roots: Vec<Commitment> = fri_layers.iter().map(|l| l.merkle_tree.root).collect();
+
+        let query_openings: Vec<UnifiedQueryOpening<Field, FieldExtension>> = iotas.iter().map(|&iota| {
+            let index = iota * 2;
+            let index_sym = iota * 2 + 1;
+            let br = reverse_index(index, lde_size as u64);
+            let br_sym = reverse_index(index_sym, lde_size as u64);
+
+            let main_proof = main_tree.get_proof_by_pos(index).unwrap();
+            let main_proof_sym = main_tree.get_proof_by_pos(index_sym).unwrap();
+            let mut main_evals = Vec::with_capacity(total_main_cols);
+            let mut main_evals_sym = Vec::with_capacity(total_main_cols);
+            for tc in per_batched_main_lde.iter() {
+                for col in tc { main_evals.push(col[br].clone()); main_evals_sym.push(col[br_sym].clone()); }
+            }
+
+            let (aux_proof, aux_proof_sym, aux_evals, aux_evals_sym) = if let Some(ref tree) = aux_tree {
+                let p = tree.get_proof_by_pos(index).unwrap();
+                let ps = tree.get_proof_by_pos(index_sym).unwrap();
+                let mut e = Vec::with_capacity(total_aux_cols);
+                let mut es = Vec::with_capacity(total_aux_cols);
+                for tc in &per_batched_aux_lde {
+                    for col in tc { e.push(col[br].clone()); es.push(col[br_sym].clone()); }
+                }
+                (Some(p), Some(ps), e, es)
+            } else { (None, None, Vec::new(), Vec::new()) };
+
+            let comp_proof = comp_tree.get_proof_by_pos(iota).unwrap();
+            let comp_proof_sym = comp_proof.clone();
+            let cbr0 = reverse_index(iota * 2, comp_lde_size as u64);
+            let cbr1 = reverse_index(iota * 2 + 1, comp_lde_size as u64);
+            let mut ce = Vec::with_capacity(total_comp_cols);
+            let mut ces = Vec::with_capacity(total_comp_cols);
+            for parts in &per_batched_comp_lde {
+                for part in parts { ce.push(part[cbr0].clone()); ces.push(part[cbr1].clone()); }
+            }
+
+            UnifiedQueryOpening {
+                main_proof, main_proof_sym,
+                main_evaluations: main_evals, main_evaluations_sym: main_evals_sym,
+                aux_proof, aux_proof_sym,
+                aux_evaluations: aux_evals, aux_evaluations_sym: aux_evals_sym,
+                composition_proof: comp_proof, composition_proof_sym: comp_proof_sym,
+                composition_evaluations: ce, composition_evaluations_sym: ces,
+            }
+        }).collect();
+
+        Ok(UnifiedMultiProof {
+            main_trace_root: main_root,
+            aux_trace_root: aux_root,
+            composition_poly_root: comp_root,
+            precomputed_roots: Vec::new(),
+            table_data,
+            fri_layers_merkle_roots,
+            fri_last_value,
+            fri_query_list: query_list,
+            query_openings,
+            nonce,
+            column_layout: layout,
+        })
     }
 
     /// Generate a STARK proof for a single AIR/trace.

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -2054,6 +2054,700 @@ pub trait IsStarkProver<
             trace_length: domain.interpolation_domain_size,
         })
     }
+
+    /// Generates a unified multi-table STARK proof with batched commitments and single FRI.
+    ///
+    /// All tables in `air_trace_pairs` MUST have the same trace length and MUST NOT be
+    /// preprocessed. This batches all tables' columns into shared Merkle trees (one for
+    /// main, one for aux, one for composition) and runs a single FRI proof covering the
+    /// combined DEEP composition polynomial.
+    ///
+    /// For preprocessed/fixed-size tables, use the standard `multi_prove` instead.
+    fn multi_prove_unified(
+        mut air_trace_pairs: Vec<AirTracePair<'_, Field, FieldExtension, PI>>,
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Send),
+    ) -> Result<
+        crate::proof::unified::UnifiedMultiProof<Field, FieldExtension>,
+        ProvingError,
+    >
+    where
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
+        PI: Send + Sync + Clone,
+    {
+        use crate::proof::unified::{
+            ColumnRange, TableOodData, UnifiedMultiProof, UnifiedQueryOpening,
+        };
+        use sha3::Digest;
+
+        let num_airs = air_trace_pairs.len();
+        assert!(num_airs > 0, "multi_prove_unified requires at least one AIR");
+
+        let needs_lookup = air_trace_pairs.iter().any(|(a, _, _)| a.has_aux_trace());
+
+        // Pre-pass: shared domain + twiddles (all tables must have same trace length)
+        let trace_length = air_trace_pairs[0].1.num_rows();
+        let domain = new_domain(air_trace_pairs[0].0, trace_length);
+        let twiddles = LdeTwiddles::new(&domain);
+        let lde_size = domain.interpolation_domain_size * domain.blowup_factor;
+        let blowup_factor = domain.blowup_factor;
+        let domain_size = domain.interpolation_domain_size;
+
+        for (idx, (air, trace, _)) in air_trace_pairs.iter().enumerate() {
+            debug_assert_eq!(
+                trace.num_rows(),
+                trace_length,
+                "table {idx} ({}) has trace_length {} != expected {}",
+                air.name(),
+                trace.num_rows(),
+                trace_length
+            );
+            debug_assert!(
+                !air.is_preprocessed(),
+                "preprocessed table {} must not be in unified batch",
+                air.name()
+            );
+        }
+
+        info!("multi_prove_unified: {} tables, trace_length={}", num_airs, trace_length);
+
+        // =====================================================================
+        // Phase A: Main trace LDE → batched commitment
+        // =====================================================================
+
+        let mut per_table_main_lde: Vec<Vec<Vec<FieldElement<Field>>>> =
+            Vec::with_capacity(num_airs);
+        let mut layout: Vec<ColumnRange> = Vec::with_capacity(num_airs);
+        let mut main_col_offset = 0usize;
+
+        for idx in 0..num_airs {
+            let (air, trace, _) = &air_trace_pairs[idx];
+            let _ = air;
+            let mut columns = trace.extract_columns_main(lde_size);
+            Self::expand_columns_to_lde::<Field>(&mut columns, &domain, &twiddles);
+            let count = columns.len();
+            layout.push(ColumnRange {
+                main_start: main_col_offset,
+                main_count: count,
+                aux_start: 0,
+                aux_count: 0,
+                comp_start: 0,
+                comp_count: 0,
+            });
+            main_col_offset += count;
+            per_table_main_lde.push(columns);
+        }
+
+        // Batch-commit all main columns in ONE Merkle tree.
+        // Each leaf = Keccak256(table0_col0[br] || table0_col1[br] || ... || tableN_colM[br])
+        let total_main_cols = main_col_offset;
+        let main_tree = {
+            #[cfg(feature = "parallel")]
+            let iter = (0..lde_size).into_par_iter();
+            #[cfg(not(feature = "parallel"))]
+            let iter = 0..lde_size;
+
+            let hashed_leaves: Vec<Commitment> = iter
+                .map(|row_idx| {
+                    let br = reverse_index(row_idx, lde_size as u64);
+                    let mut hasher = sha3::Keccak256::new();
+                    for table_cols in &per_table_main_lde {
+                        for col in table_cols {
+                            hasher.update(col[br].as_bytes());
+                        }
+                    }
+                    hasher.finalize().into()
+                })
+                .collect();
+
+            Arc::new(
+                BatchedMerkleTree::<Field>::build_from_hashed_leaves(hashed_leaves)
+                    .ok_or(ProvingError::EmptyCommitment)?,
+            )
+        };
+        let main_root = main_tree.root;
+        transcript.append_bytes(&main_root);
+
+        // =====================================================================
+        // Phase B: Sample shared LogUp challenges
+        // =====================================================================
+
+        let lookup_challenges: Vec<FieldElement<FieldExtension>> = if needs_lookup {
+            (0..LOGUP_NUM_CHALLENGES)
+                .map(|_| transcript.sample_field_element())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // =====================================================================
+        // Phase C: Build aux traces → batched aux commitment
+        // =====================================================================
+
+        #[cfg(feature = "parallel")]
+        let aux_iter = air_trace_pairs.par_iter_mut();
+        #[cfg(not(feature = "parallel"))]
+        let aux_iter = air_trace_pairs.iter_mut();
+        let bus_inputs_vec: Vec<Option<BusPublicInputs<FieldExtension>>> = aux_iter
+            .map(|(air, trace, _)| {
+                if air.has_aux_trace() {
+                    air.build_auxiliary_trace(*trace, &lookup_challenges)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let mut per_table_aux_lde: Vec<Vec<Vec<FieldElement<FieldExtension>>>> =
+            Vec::with_capacity(num_airs);
+        let mut aux_col_offset = 0usize;
+
+        for idx in 0..num_airs {
+            let (air, trace, _) = &air_trace_pairs[idx];
+            if air.has_aux_trace() {
+                let mut columns = trace.extract_columns_aux(lde_size);
+                Self::expand_columns_to_lde::<FieldExtension>(&mut columns, &domain, &twiddles);
+                let count = columns.len();
+                layout[idx].aux_start = aux_col_offset;
+                layout[idx].aux_count = count;
+                aux_col_offset += count;
+                per_table_aux_lde.push(columns);
+            } else {
+                per_table_aux_lde.push(Vec::new());
+            }
+        }
+
+        // Batch-commit all aux columns in ONE Merkle tree
+        let total_aux_cols = aux_col_offset;
+        let (aux_tree, aux_root) = if total_aux_cols > 0 {
+            #[cfg(feature = "parallel")]
+            let iter = (0..lde_size).into_par_iter();
+            #[cfg(not(feature = "parallel"))]
+            let iter = 0..lde_size;
+
+            let hashed_leaves: Vec<Commitment> = iter
+                .map(|row_idx| {
+                    let br = reverse_index(row_idx, lde_size as u64);
+                    let mut hasher = sha3::Keccak256::new();
+                    for table_cols in &per_table_aux_lde {
+                        for col in table_cols {
+                            hasher.update(col[br].as_bytes());
+                        }
+                    }
+                    hasher.finalize().into()
+                })
+                .collect();
+
+            let tree =
+                BatchedMerkleTree::<FieldExtension>::build_from_hashed_leaves(hashed_leaves)
+                    .ok_or(ProvingError::EmptyCommitment)?;
+            let root = tree.root;
+            (Some(Arc::new(tree)), Some(root))
+        } else {
+            (None, None)
+        };
+
+        // Observe aux root, then bus_public_inputs for all tables
+        if let Some(ref root) = aux_root {
+            transcript.append_bytes(root);
+        }
+        for bus_inputs in &bus_inputs_vec {
+            if let Some(bpi) = bus_inputs {
+                transcript.append_field_element(&bpi.table_contribution);
+            }
+        }
+
+        // =====================================================================
+        // Round 2: Constraint evaluation → batched composition commitment
+        // =====================================================================
+
+        let beta: FieldElement<FieldExtension> = transcript.sample_field_element();
+
+        let mut per_table_comp_lde: Vec<Vec<Vec<FieldElement<FieldExtension>>>> =
+            Vec::with_capacity(num_airs);
+        let mut comp_col_offset = 0usize;
+
+        for idx in 0..num_airs {
+            let (air, _, pub_inputs) = &air_trace_pairs[idx];
+
+            // Move columns into temporary LDETraceTable (zero-copy)
+            let main_cols = std::mem::take(&mut per_table_main_lde[idx]);
+            let aux_cols = std::mem::take(&mut per_table_aux_lde[idx]);
+            let lde_trace = LDETraceTable::from_columns(
+                main_cols,
+                aux_cols,
+                air.step_size(),
+                blowup_factor,
+            );
+
+            // Evaluate constraints
+            let evaluator = ConstraintEvaluator::new(
+                *air,
+                *pub_inputs,
+                &lookup_challenges,
+                bus_inputs_vec[idx].as_ref(),
+                trace_length,
+            );
+
+            let num_boundary = air
+                .boundary_constraints(
+                    *pub_inputs,
+                    &lookup_challenges,
+                    bus_inputs_vec[idx].as_ref(),
+                    trace_length,
+                )
+                .constraints
+                .len();
+            let num_transition = air.context().num_transition_constraints;
+
+            let mut coefficients: Vec<FieldElement<FieldExtension>> =
+                core::iter::successors(Some(FieldElement::one()), |x| Some(x * &beta))
+                    .take(num_boundary + num_transition)
+                    .collect();
+            let transition_coefficients: Vec<_> =
+                coefficients.drain(..num_transition).collect();
+            let boundary_coefficients = coefficients;
+
+            let constraint_evaluations = evaluator.evaluate(
+                *air,
+                &lde_trace,
+                &domain,
+                &transition_coefficients,
+                &boundary_coefficients,
+                &lookup_challenges,
+            );
+
+            let number_of_parts =
+                air.composition_poly_degree_bound(trace_length) / trace_length;
+            let comp_evals = if number_of_parts == 2 {
+                Self::decompose_and_extend_d2(&constraint_evaluations, &domain)
+            } else if number_of_parts == 1 {
+                vec![constraint_evaluations]
+            } else {
+                let p = Polynomial::interpolate_offset_fft(
+                    &constraint_evaluations,
+                    &domain.coset_offset,
+                )
+                .unwrap();
+                let parts = p.break_in_parts(number_of_parts);
+                parts
+                    .iter()
+                    .map(|part| {
+                        evaluate_polynomial_on_lde_domain(
+                            part,
+                            blowup_factor,
+                            domain_size,
+                            &domain.coset_offset,
+                        )
+                        .unwrap()
+                    })
+                    .collect()
+            };
+
+            let count = comp_evals.len();
+            layout[idx].comp_start = comp_col_offset;
+            layout[idx].comp_count = count;
+            comp_col_offset += count;
+            per_table_comp_lde.push(comp_evals);
+
+            // Move columns back (zero-copy)
+            let (main_back, aux_back) = lde_trace.into_columns();
+            per_table_main_lde[idx] = main_back;
+            per_table_aux_lde[idx] = aux_back;
+        }
+
+        // Batch-commit all composition columns in ONE Merkle tree (pair-merged leaves)
+        let total_comp_cols = comp_col_offset;
+        let comp_lde_size = per_table_comp_lde[0][0].len();
+        let num_comp_leaves = comp_lde_size / 2;
+
+        let comp_tree = {
+            #[cfg(feature = "parallel")]
+            let iter = (0..num_comp_leaves).into_par_iter();
+            #[cfg(not(feature = "parallel"))]
+            let iter = 0..num_comp_leaves;
+
+            let hashed_leaves: Vec<Commitment> = iter
+                .map(|leaf_idx| {
+                    let br_0 = reverse_index(2 * leaf_idx, comp_lde_size as u64);
+                    let br_1 = reverse_index(2 * leaf_idx + 1, comp_lde_size as u64);
+                    let mut hasher = sha3::Keccak256::new();
+                    for table_parts in &per_table_comp_lde {
+                        for part in table_parts {
+                            hasher.update(part[br_0].as_bytes());
+                        }
+                    }
+                    for table_parts in &per_table_comp_lde {
+                        for part in table_parts {
+                            hasher.update(part[br_1].as_bytes());
+                        }
+                    }
+                    hasher.finalize().into()
+                })
+                .collect();
+
+            BatchedMerkleTree::<FieldExtension>::build_from_hashed_leaves(hashed_leaves)
+                .ok_or(ProvingError::EmptyCommitment)?
+        };
+        let comp_root = comp_tree.root;
+        transcript.append_bytes(&comp_root);
+
+        // =====================================================================
+        // Round 3: Shared OOD point z → per-table evaluations
+        // =====================================================================
+
+        let z: FieldElement<FieldExtension> = transcript.sample_z_ood(
+            &domain.lde_roots_of_unity_coset,
+            &domain.trace_roots_of_unity,
+        );
+
+        // Precompute barycentric helpers (shared across tables)
+        let coset_points: Vec<FieldElement<Field>> = (0..domain_size)
+            .map(|i| domain.lde_roots_of_unity_coset[i * blowup_factor].clone())
+            .collect();
+        let coset_offset_pow_n: FieldElement<Field> = domain.coset_offset.pow(domain_size);
+        let domain_size_inv: FieldElement<Field> =
+            FieldElement::<Field>::from(domain_size as u64)
+                .inv()
+                .expect("domain_size is power of two");
+        let g_n_inv: FieldElement<Field> = coset_offset_pow_n
+            .inv()
+            .expect("coset_offset_pow_n non-zero");
+
+        let mut table_data: Vec<TableOodData<FieldExtension>> =
+            Vec::with_capacity(num_airs);
+
+        for idx in 0..num_airs {
+            let (air, _, _) = &air_trace_pairs[idx];
+
+            // Build temporary LDETraceTable for OOD evaluation
+            let main_cols = std::mem::take(&mut per_table_main_lde[idx]);
+            let aux_cols = std::mem::take(&mut per_table_aux_lde[idx]);
+            let lde_trace = LDETraceTable::from_columns(
+                main_cols,
+                aux_cols,
+                air.step_size(),
+                blowup_factor,
+            );
+
+            // Trace OOD evaluations via barycentric interpolation on LDE
+            let trace_ood = crate::trace::get_trace_evaluations_from_lde(
+                &lde_trace,
+                &domain,
+                &z,
+                &air.context().transition_offsets,
+                air.step_size(),
+            );
+
+            // Composition polynomial OOD evaluations
+            let num_parts = layout[idx].comp_count;
+            let z_power = z.pow(num_parts);
+            let comp_z_pow_n = z_power.pow(domain_size);
+            let comp_inv_denoms =
+                math::polynomial::barycentric_inv_denoms(&z_power, &coset_points);
+
+            let comp_ood: Vec<FieldElement<FieldExtension>> = per_table_comp_lde[idx]
+                .iter()
+                .map(|lde_evals| {
+                    let evals: Vec<FieldElement<FieldExtension>> = (0..domain_size)
+                        .map(|i| lde_evals[i * blowup_factor].clone())
+                        .collect();
+                    math::polynomial::interpolate_coset_eval_ext_with_g_n_inv(
+                        &comp_z_pow_n,
+                        &coset_offset_pow_n,
+                        &domain_size_inv,
+                        &g_n_inv,
+                        &coset_points,
+                        &evals,
+                        &comp_inv_denoms,
+                    )
+                })
+                .collect();
+
+            // Append OOD to transcript (trace first, then composition)
+            for col in trace_ood.columns().iter() {
+                for elem in col.iter() {
+                    transcript.append_field_element(elem);
+                }
+            }
+            for elem in &comp_ood {
+                transcript.append_field_element(elem);
+            }
+
+            let num_main = lde_trace.num_main_cols();
+            let num_aux = lde_trace.num_aux_cols();
+
+            // Move columns back
+            let (main_back, aux_back) = lde_trace.into_columns();
+            per_table_main_lde[idx] = main_back;
+            per_table_aux_lde[idx] = aux_back;
+
+            table_data.push(TableOodData {
+                trace_length,
+                num_main_cols: num_main,
+                num_aux_cols: num_aux,
+                num_precomputed_cols: 0,
+                trace_ood_evaluations: trace_ood,
+                composition_poly_parts_ood_evaluation: comp_ood,
+                bus_public_inputs: bus_inputs_vec[idx].clone(),
+            });
+        }
+
+        // =====================================================================
+        // Round 4: Unified DEEP composition → single FRI
+        // =====================================================================
+
+        let gamma: FieldElement<FieldExtension> = transcript.sample_field_element();
+
+        // All tables have step_size=1, offsets=[0,1] → 2 trace poles: z and z·g
+        let num_eval_points = 2;
+        let primitive_root = &domain.trace_primitive_root;
+        let z_shifted = [z.clone(), primitive_root * &z];
+
+        // Collect unique composition-pole z^K values (tables may have different K)
+        let per_table_z_power_k: Vec<FieldElement<FieldExtension>> = layout
+            .iter()
+            .map(|l| z.pow(l.comp_count))
+            .collect();
+        let unique_z_powers: Vec<FieldElement<FieldExtension>> = {
+            let mut seen = Vec::new();
+            for zk in &per_table_z_power_k {
+                if !seen.contains(zk) {
+                    seen.push(zk.clone());
+                }
+            }
+            seen
+        };
+
+        // Precompute total DEEP terms for γ powers
+        let mut total_terms = 0usize;
+        for idx in 0..num_airs {
+            let num_cols = layout[idx].main_count + layout[idx].aux_count;
+            total_terms += num_cols * num_eval_points + layout[idx].comp_count;
+        }
+
+        let gamma_powers: Vec<FieldElement<FieldExtension>> =
+            core::iter::successors(Some(FieldElement::one()), |x| Some(x * &gamma))
+                .take(total_terms)
+                .collect();
+
+        // Batch-invert all denominators:
+        //   2 trace poles (z, z·g) + N_unique composition poles (z^K for each unique K)
+        let num_denom_groups = 2 + unique_z_powers.len();
+        let mut denoms: Vec<FieldElement<FieldExtension>> =
+            Vec::with_capacity(domain_size * num_denom_groups);
+        // Trace pole 0: x - z
+        for i in 0..domain_size {
+            let x_i = &domain.lde_roots_of_unity_coset[i * blowup_factor];
+            denoms.push(x_i - &z_shifted[0]);
+        }
+        // Trace pole 1: x - z·g
+        for i in 0..domain_size {
+            let x_i = &domain.lde_roots_of_unity_coset[i * blowup_factor];
+            denoms.push(x_i - &z_shifted[1]);
+        }
+        // Composition poles: x - z^K for each unique K
+        for zk in &unique_z_powers {
+            for i in 0..domain_size {
+                let x_i = &domain.lde_roots_of_unity_coset[i * blowup_factor];
+                denoms.push(x_i - zk);
+            }
+        }
+        FieldElement::inplace_batch_inverse(&mut denoms).expect(
+            "DEEP denominators non-zero: coset points are base field, poles are extension",
+        );
+        let inv_t0 = &denoms[0..domain_size];
+        let inv_t1 = &denoms[domain_size..2 * domain_size];
+        // Map each table to its composition inv_denom slice
+        let per_table_inv_h_idx: Vec<usize> = per_table_z_power_k
+            .iter()
+            .map(|zk| unique_z_powers.iter().position(|u| u == zk).unwrap())
+            .collect();
+        let inv_h_slices: Vec<&[FieldElement<FieldExtension>]> = (0..unique_z_powers.len())
+            .map(|g| &denoms[(2 + g) * domain_size..(3 + g) * domain_size])
+            .collect();
+
+        // Compute unified DEEP polynomial on trace-size coset
+        #[cfg(feature = "parallel")]
+        let deep_iter = (0..domain_size).into_par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let deep_iter = 0..domain_size;
+
+        let deep_evals: Vec<FieldElement<FieldExtension>> = deep_iter
+            .map(|i| {
+                let row_idx = i * blowup_factor;
+                let mut result = FieldElement::<FieldExtension>::zero();
+                let mut term_idx = 0usize;
+
+                for table_idx in 0..num_airs {
+                    let ood_cols = table_data[table_idx].trace_ood_evaluations.columns();
+                    let main_lde = &per_table_main_lde[table_idx];
+                    let aux_lde = &per_table_aux_lde[table_idx];
+
+                    // Main trace terms: γ^k * (t_j(x) - t_j(z·w^k)) / (x - z·w^k)
+                    for j in 0..main_lde.len() {
+                        let t_val = &main_lde[j][row_idx];
+                        let num_0 = t_val - &ood_cols[j][0];
+                        result += &gamma_powers[term_idx] * &num_0 * &inv_t0[i];
+                        term_idx += 1;
+                        let num_1 = t_val - &ood_cols[j][1];
+                        result += &gamma_powers[term_idx] * &num_1 * &inv_t1[i];
+                        term_idx += 1;
+                    }
+
+                    // Aux trace terms
+                    let main_count = main_lde.len();
+                    for j in 0..aux_lde.len() {
+                        let t_val = &aux_lde[j][row_idx];
+                        let ood_idx = main_count + j;
+                        let num_0 = t_val - &ood_cols[ood_idx][0];
+                        result += &gamma_powers[term_idx] * &num_0 * &inv_t0[i];
+                        term_idx += 1;
+                        let num_1 = t_val - &ood_cols[ood_idx][1];
+                        result += &gamma_powers[term_idx] * &num_1 * &inv_t1[i];
+                        term_idx += 1;
+                    }
+
+                    // Composition polynomial terms: γ^k * (H_p(x) - H_p(z^K)) / (x - z^K)
+                    let comp_lde = &per_table_comp_lde[table_idx];
+                    let comp_ood =
+                        &table_data[table_idx].composition_poly_parts_ood_evaluation;
+                    let inv_h_table = inv_h_slices[per_table_inv_h_idx[table_idx]];
+                    for p in 0..comp_lde.len() {
+                        let h_val = &comp_lde[p][row_idx];
+                        let num = h_val - &comp_ood[p];
+                        result += &gamma_powers[term_idx] * &num * &inv_h_table[i];
+                        term_idx += 1;
+                    }
+                }
+                result
+            })
+            .collect();
+
+        // Extend DEEP evaluations from N trace-coset points to 2N LDE-coset points
+        let deep_poly =
+            Polynomial::interpolate_fft::<Field>(&deep_evals).expect("iFFT should succeed");
+        let mut lde_deep =
+            Polynomial::evaluate_fft::<Field>(&deep_poly, 1, Some(lde_size))
+                .expect("FFT should succeed");
+        in_place_bit_reverse_permute(&mut lde_deep);
+
+        // FRI commit phase
+        let coset_offset_u64 = air_trace_pairs[0].0.context().proof_options.coset_offset;
+        let coset_offset = FieldElement::<Field>::from(coset_offset_u64);
+
+        let (fri_last_value, fri_layers) =
+            fri::commit_phase_from_evaluations::<Field, FieldExtension>(
+                domain.root_order as usize,
+                lde_deep,
+                transcript,
+                &coset_offset,
+                lde_size,
+            );
+
+        // Grinding
+        let security_bits = air_trace_pairs[0].0.context().proof_options.grinding_factor;
+        let mut nonce = None;
+        if security_bits > 0 {
+            let nonce_value = grinding::generate_nonce(&transcript.state(), security_bits)
+                .expect("nonce not found");
+            transcript.append_bytes(&nonce_value.to_be_bytes());
+            nonce = Some(nonce_value);
+        }
+
+        // FRI query phase
+        let number_of_queries = air_trace_pairs[0].0.options().fri_number_of_queries;
+        let iotas = Self::sample_query_indexes(number_of_queries, &domain, transcript);
+        let query_list = fri::query_phase(&fri_layers, &iotas);
+        let fri_layers_merkle_roots: Vec<Commitment> =
+            fri_layers.iter().map(|l| l.merkle_tree.root).collect();
+
+        // Open unified trees at each query index
+        let query_openings: Vec<UnifiedQueryOpening<Field, FieldExtension>> = iotas
+            .iter()
+            .map(|&iota| {
+                let index = iota * 2;
+                let index_sym = iota * 2 + 1;
+                let br = reverse_index(index, lde_size as u64);
+                let br_sym = reverse_index(index_sym, lde_size as u64);
+
+                // Main tree: one proof per index/sym
+                let main_proof = main_tree.get_proof_by_pos(index).unwrap();
+                let main_proof_sym = main_tree.get_proof_by_pos(index_sym).unwrap();
+                let mut main_evals = Vec::with_capacity(total_main_cols);
+                let mut main_evals_sym = Vec::with_capacity(total_main_cols);
+                for table_cols in &per_table_main_lde {
+                    for col in table_cols {
+                        main_evals.push(col[br].clone());
+                        main_evals_sym.push(col[br_sym].clone());
+                    }
+                }
+
+                // Aux tree: one proof per index/sym (if exists)
+                let (aux_proof, aux_proof_sym, aux_evals, aux_evals_sym) =
+                    if let Some(ref tree) = aux_tree {
+                        let p = tree.get_proof_by_pos(index).unwrap();
+                        let p_sym = tree.get_proof_by_pos(index_sym).unwrap();
+                        let mut evals = Vec::with_capacity(total_aux_cols);
+                        let mut evals_sym = Vec::with_capacity(total_aux_cols);
+                        for table_cols in &per_table_aux_lde {
+                            for col in table_cols {
+                                evals.push(col[br].clone());
+                                evals_sym.push(col[br_sym].clone());
+                            }
+                        }
+                        (Some(p), Some(p_sym), evals, evals_sym)
+                    } else {
+                        (None, None, Vec::new(), Vec::new())
+                    };
+
+                // Composition tree: pair-merged (one proof, both values in same leaf)
+                let comp_proof = comp_tree.get_proof_by_pos(iota).unwrap();
+                let comp_proof_sym = comp_proof.clone();
+                let comp_br_0 = reverse_index(iota * 2, comp_lde_size as u64);
+                let comp_br_1 = reverse_index(iota * 2 + 1, comp_lde_size as u64);
+                let mut comp_evals = Vec::with_capacity(total_comp_cols);
+                let mut comp_evals_sym = Vec::with_capacity(total_comp_cols);
+                for table_parts in &per_table_comp_lde {
+                    for part in table_parts {
+                        comp_evals.push(part[comp_br_0].clone());
+                        comp_evals_sym.push(part[comp_br_1].clone());
+                    }
+                }
+
+                UnifiedQueryOpening {
+                    main_proof,
+                    main_proof_sym,
+                    main_evaluations: main_evals,
+                    main_evaluations_sym: main_evals_sym,
+                    aux_proof,
+                    aux_proof_sym,
+                    aux_evaluations: aux_evals,
+                    aux_evaluations_sym: aux_evals_sym,
+                    composition_proof: comp_proof,
+                    composition_proof_sym: comp_proof_sym,
+                    composition_evaluations: comp_evals,
+                    composition_evaluations_sym: comp_evals_sym,
+                }
+            })
+            .collect();
+
+        info!("multi_prove_unified: proof generation complete");
+
+        Ok(UnifiedMultiProof {
+            main_trace_root: main_root,
+            aux_trace_root: aux_root,
+            composition_poly_root: comp_root,
+            precomputed_roots: Vec::new(),
+            table_data,
+            fri_layers_merkle_roots,
+            fri_last_value,
+            fri_query_list: query_list,
+            query_openings,
+            nonce,
+            column_layout: layout,
+        })
+    }
 }
 
 /// Print a global bus balance report aggregating per-bus sums across all tables.

--- a/crypto/stark/src/tests/mod.rs
+++ b/crypto/stark/src/tests/mod.rs
@@ -6,3 +6,4 @@ pub mod proof_options_tests;
 pub mod prove_verify_roundtrip_tests;
 pub mod prover_tests;
 pub mod small_trace_tests;
+pub mod unified_prover_tests;

--- a/crypto/stark/src/tests/unified_prover_tests.rs
+++ b/crypto/stark/src/tests/unified_prover_tests.rs
@@ -1,0 +1,281 @@
+//! Tests for `multi_prove_unified` — batched commitment + single FRI.
+//!
+//! Uses the same synthetic multi-table AIRs as bus_tests/completeness_tests
+//! (CPU dispatching to ADD and MUL tables via LogUp bus).
+
+use crypto::fiat_shamir::default_transcript::DefaultTranscript;
+use math::field::element::FieldElement;
+use math::field::{
+    extensions_goldilocks::Degree3GoldilocksExtensionField, goldilocks::GoldilocksField,
+};
+
+use crate::examples::multi_table_lookup::{
+    new_add_air_with_lookup, new_cpu_air_with_lookup, new_mul_air_with_lookup,
+};
+use crate::proof::options::ProofOptions;
+use crate::prover::{IsStarkProver, Prover};
+use crate::trace::TraceTable;
+use crate::traits::AIR;
+
+type F = GoldilocksField;
+type E = Degree3GoldilocksExtensionField;
+type FE = FieldElement<F>;
+
+/// Test multi_prove_unified with the standard CPU+ADD+MUL synthetic tables.
+///
+/// All three tables have the same trace length (8 rows padded to 8) and are
+/// non-preprocessed, making them valid candidates for unified proving.
+#[test_log::test]
+fn test_unified_prove_basic() {
+    // CPU Trace (8 rows)
+    let mut cpu_trace = TraceTable::from_columns_main(
+        vec![
+            vec![
+                FE::one(),
+                FE::zero(),
+                FE::one(),
+                FE::zero(),
+                FE::one(),
+                FE::one(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::zero(),
+                FE::one(),
+                FE::zero(),
+                FE::one(),
+                FE::zero(),
+                FE::zero(),
+                FE::one(),
+                FE::one(),
+            ],
+            vec![
+                FE::from(1),
+                FE::from(2),
+                FE::from(3),
+                FE::from(4),
+                FE::from(5),
+                FE::from(6),
+                FE::from(7),
+                FE::from(8),
+            ],
+            vec![
+                FE::from(10),
+                FE::from(20),
+                FE::from(30),
+                FE::from(40),
+                FE::from(50),
+                FE::from(60),
+                FE::from(70),
+                FE::from(80),
+            ],
+            vec![
+                FE::from(11),
+                FE::from(40),
+                FE::from(33),
+                FE::from(160),
+                FE::from(55),
+                FE::from(66),
+                FE::from(490),
+                FE::from(640),
+            ],
+        ],
+        1,
+    );
+
+    // ADD Trace (4 rows, padded to 8 to match CPU trace length)
+    let mut add_trace = TraceTable::from_columns_main(
+        vec![
+            vec![
+                FE::from(1),
+                FE::from(3),
+                FE::from(5),
+                FE::from(6),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::from(10),
+                FE::from(30),
+                FE::from(50),
+                FE::from(60),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::from(11),
+                FE::from(33),
+                FE::from(55),
+                FE::from(66),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::one(),
+                FE::one(),
+                FE::one(),
+                FE::one(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+        ],
+        1,
+    );
+
+    // MUL Trace (4 rows, padded to 8)
+    let mut mul_trace = TraceTable::from_columns_main(
+        vec![
+            vec![
+                FE::from(2),
+                FE::from(4),
+                FE::from(7),
+                FE::from(8),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::from(20),
+                FE::from(40),
+                FE::from(70),
+                FE::from(80),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::from(40),
+                FE::from(160),
+                FE::from(490),
+                FE::from(640),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::one(),
+                FE::one(),
+                FE::one(),
+                FE::one(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+        ],
+        1,
+    );
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = new_cpu_air_with_lookup(&proof_options);
+    let add_air = new_add_air_with_lookup(&proof_options);
+    let mul_air = new_mul_air_with_lookup(&proof_options);
+
+    // Verify all tables have same trace length and are non-preprocessed
+    assert_eq!(cpu_trace.num_rows(), add_trace.num_rows());
+    assert_eq!(cpu_trace.num_rows(), mul_trace.num_rows());
+    assert!(!cpu_air.is_preprocessed());
+    assert!(!add_air.is_preprocessed());
+    assert!(!mul_air.is_preprocessed());
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut cpu_trace, &()),
+        (&add_air, &mut add_trace, &()),
+        (&mul_air, &mut mul_trace, &()),
+    ];
+
+    let unified_proof = Prover::multi_prove_unified(
+        air_trace_pairs,
+        &mut DefaultTranscript::<E>::new(&[]),
+    )
+    .expect("multi_prove_unified failed");
+
+    // Structural assertions
+    assert_eq!(unified_proof.table_data.len(), 3, "should have 3 table OOD entries");
+    assert_eq!(unified_proof.column_layout.len(), 3, "should have 3 column ranges");
+    assert!(unified_proof.aux_trace_root.is_some(), "all tables have aux traces");
+    assert!(!unified_proof.fri_layers_merkle_roots.is_empty(), "FRI should produce layers");
+    assert!(!unified_proof.query_openings.is_empty(), "should have query openings");
+    assert!(unified_proof.precomputed_roots.is_empty(), "no preprocessed tables");
+
+    // Check column layout is consistent
+    let layout = &unified_proof.column_layout;
+    // CPU: 5 main cols, ADD: 4 main cols, MUL: 4 main cols → total 13
+    assert_eq!(layout[0].main_start, 0);
+    assert_eq!(layout[0].main_count, 5);
+    assert_eq!(layout[1].main_start, 5);
+    assert_eq!(layout[1].main_count, 4);
+    assert_eq!(layout[2].main_start, 9);
+    assert_eq!(layout[2].main_count, 4);
+
+    // Verify each table's OOD data has correct dimensions
+    for (idx, td) in unified_proof.table_data.iter().enumerate() {
+        assert_eq!(td.trace_length, 8, "table {idx} trace_length");
+        assert!(!td.composition_poly_parts_ood_evaluation.is_empty());
+        assert!(td.bus_public_inputs.is_some(), "table {idx} should have bus inputs");
+    }
+
+    println!(
+        "Unified proof OK: {} tables, {} FRI layers, {} queries, {} query openings",
+        unified_proof.table_data.len(),
+        unified_proof.fri_layers_merkle_roots.len(),
+        unified_proof.fri_query_list.len(),
+        unified_proof.query_openings.len(),
+    );
+}
+
+/// All-padding variant: every multiplicity is 0.
+#[test_log::test]
+fn test_unified_prove_all_padding() {
+    let mut cpu_trace = TraceTable::from_columns_main(
+        vec![vec![FE::zero(); 4]; 5],
+        1,
+    );
+    let mut add_trace = TraceTable::from_columns_main(
+        vec![vec![FE::zero(); 4]; 4],
+        1,
+    );
+    let mut mul_trace = TraceTable::from_columns_main(
+        vec![vec![FE::zero(); 4]; 4],
+        1,
+    );
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = new_cpu_air_with_lookup(&proof_options);
+    let add_air = new_add_air_with_lookup(&proof_options);
+    let mul_air = new_mul_air_with_lookup(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut cpu_trace, &()),
+        (&add_air, &mut add_trace, &()),
+        (&mul_air, &mut mul_trace, &()),
+    ];
+
+    let unified_proof = Prover::multi_prove_unified(
+        air_trace_pairs,
+        &mut DefaultTranscript::<E>::new(&[]),
+    )
+    .expect("multi_prove_unified with all-padding should succeed");
+
+    assert_eq!(unified_proof.table_data.len(), 3);
+}

--- a/crypto/stark/src/tests/unified_prover_tests.rs
+++ b/crypto/stark/src/tests/unified_prover_tests.rs
@@ -16,186 +16,51 @@ use crate::proof::options::ProofOptions;
 use crate::prover::{IsStarkProver, Prover};
 use crate::trace::TraceTable;
 use crate::traits::AIR;
+use crate::verifier::{IsStarkVerifier, Verifier};
 
 type F = GoldilocksField;
 type E = Degree3GoldilocksExtensionField;
 type FE = FieldElement<F>;
 
-/// Test multi_prove_unified with the standard CPU+ADD+MUL synthetic tables.
+/// Test unified prove + verify with ADD and MUL tables (same height = 4).
 ///
-/// All three tables have the same trace length (8 rows padded to 8) and are
-/// non-preprocessed, making them valid candidates for unified proving.
+/// Uses the exact same trace data as completeness_tests but only batches
+/// the same-height tables (ADD + MUL, both 4 rows).
 #[test_log::test]
-fn test_unified_prove_basic() {
-    // CPU Trace (8 rows)
-    let mut cpu_trace = TraceTable::from_columns_main(
-        vec![
-            vec![
-                FE::one(),
-                FE::zero(),
-                FE::one(),
-                FE::zero(),
-                FE::one(),
-                FE::one(),
-                FE::zero(),
-                FE::zero(),
-            ],
-            vec![
-                FE::zero(),
-                FE::one(),
-                FE::zero(),
-                FE::one(),
-                FE::zero(),
-                FE::zero(),
-                FE::one(),
-                FE::one(),
-            ],
-            vec![
-                FE::from(1),
-                FE::from(2),
-                FE::from(3),
-                FE::from(4),
-                FE::from(5),
-                FE::from(6),
-                FE::from(7),
-                FE::from(8),
-            ],
-            vec![
-                FE::from(10),
-                FE::from(20),
-                FE::from(30),
-                FE::from(40),
-                FE::from(50),
-                FE::from(60),
-                FE::from(70),
-                FE::from(80),
-            ],
-            vec![
-                FE::from(11),
-                FE::from(40),
-                FE::from(33),
-                FE::from(160),
-                FE::from(55),
-                FE::from(66),
-                FE::from(490),
-                FE::from(640),
-            ],
-        ],
-        1,
-    );
-
-    // ADD Trace (4 rows, padded to 8 to match CPU trace length)
+fn test_unified_prove_verify_same_height() {
+    // ADD Trace (4 rows)
     let mut add_trace = TraceTable::from_columns_main(
         vec![
-            vec![
-                FE::from(1),
-                FE::from(3),
-                FE::from(5),
-                FE::from(6),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-            ],
-            vec![
-                FE::from(10),
-                FE::from(30),
-                FE::from(50),
-                FE::from(60),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-            ],
-            vec![
-                FE::from(11),
-                FE::from(33),
-                FE::from(55),
-                FE::from(66),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-            ],
-            vec![
-                FE::one(),
-                FE::one(),
-                FE::one(),
-                FE::one(),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-            ],
+            vec![FE::from(1), FE::from(3), FE::from(5), FE::from(6)],
+            vec![FE::from(10), FE::from(30), FE::from(50), FE::from(60)],
+            vec![FE::from(11), FE::from(33), FE::from(55), FE::from(66)],
+            vec![FE::one(), FE::one(), FE::one(), FE::one()],
         ],
         1,
     );
 
-    // MUL Trace (4 rows, padded to 8)
+    // MUL Trace (4 rows)
     let mut mul_trace = TraceTable::from_columns_main(
         vec![
-            vec![
-                FE::from(2),
-                FE::from(4),
-                FE::from(7),
-                FE::from(8),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-            ],
-            vec![
-                FE::from(20),
-                FE::from(40),
-                FE::from(70),
-                FE::from(80),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-            ],
-            vec![
-                FE::from(40),
-                FE::from(160),
-                FE::from(490),
-                FE::from(640),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-            ],
-            vec![
-                FE::one(),
-                FE::one(),
-                FE::one(),
-                FE::one(),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-                FE::zero(),
-            ],
+            vec![FE::from(2), FE::from(4), FE::from(7), FE::from(8)],
+            vec![FE::from(20), FE::from(40), FE::from(70), FE::from(80)],
+            vec![FE::from(40), FE::from(160), FE::from(490), FE::from(640)],
+            vec![FE::one(), FE::one(), FE::one(), FE::one()],
         ],
         1,
     );
 
     let proof_options = ProofOptions::default_test_options();
-    let cpu_air = new_cpu_air_with_lookup(&proof_options);
     let add_air = new_add_air_with_lookup(&proof_options);
     let mul_air = new_mul_air_with_lookup(&proof_options);
 
-    // Verify all tables have same trace length and are non-preprocessed
-    assert_eq!(cpu_trace.num_rows(), add_trace.num_rows());
-    assert_eq!(cpu_trace.num_rows(), mul_trace.num_rows());
-    assert!(!cpu_air.is_preprocessed());
-    assert!(!add_air.is_preprocessed());
-    assert!(!mul_air.is_preprocessed());
+    assert_eq!(add_trace.num_rows(), mul_trace.num_rows());
 
     let air_trace_pairs: Vec<(
         &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
         _,
         _,
     )> = vec![
-        (&cpu_air, &mut cpu_trace, &()),
         (&add_air, &mut add_trace, &()),
         (&mul_air, &mut mul_trace, &()),
     ];
@@ -206,43 +71,45 @@ fn test_unified_prove_basic() {
     )
     .expect("multi_prove_unified failed");
 
-    // Structural assertions
-    assert_eq!(unified_proof.table_data.len(), 3, "should have 3 table OOD entries");
-    assert_eq!(unified_proof.column_layout.len(), 3, "should have 3 column ranges");
-    assert!(unified_proof.aux_trace_root.is_some(), "all tables have aux traces");
-    assert!(!unified_proof.fri_layers_merkle_roots.is_empty(), "FRI should produce layers");
-    assert!(!unified_proof.query_openings.is_empty(), "should have query openings");
-    assert!(unified_proof.precomputed_roots.is_empty(), "no preprocessed tables");
+    assert_eq!(unified_proof.table_data.len(), 2);
+    assert_eq!(unified_proof.column_layout.len(), 2);
 
-    // Check column layout is consistent
-    let layout = &unified_proof.column_layout;
-    // CPU: 5 main cols, ADD: 4 main cols, MUL: 4 main cols → total 13
-    assert_eq!(layout[0].main_start, 0);
-    assert_eq!(layout[0].main_count, 5);
-    assert_eq!(layout[1].main_start, 5);
-    assert_eq!(layout[1].main_count, 4);
-    assert_eq!(layout[2].main_start, 9);
-    assert_eq!(layout[2].main_count, 4);
+    // Verify the unified proof
+    let airs_refs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&add_air, &mul_air];
+    let pub_inputs: Vec<&()> = vec![&(), &()];
 
-    // Verify each table's OOD data has correct dimensions
-    for (idx, td) in unified_proof.table_data.iter().enumerate() {
-        assert_eq!(td.trace_length, 8, "table {idx} trace_length");
-        assert!(!td.composition_poly_parts_ood_evaluation.is_empty());
-        assert!(td.bus_public_inputs.is_some(), "table {idx} should have bus inputs");
-    }
+    // Compute the actual bus balance from the proof (no CPU sender, so non-zero)
+    let actual_bus_balance: FieldElement<E> = unified_proof
+        .table_data
+        .iter()
+        .filter_map(|td| td.bus_public_inputs.as_ref())
+        .map(|bpi| &bpi.table_contribution)
+        .fold(FieldElement::zero(), |acc, c| acc + c);
+
+    assert!(
+        Verifier::multi_verify_unified(
+            &airs_refs,
+            &pub_inputs,
+            &unified_proof,
+            &mut DefaultTranscript::<E>::new(&[]),
+            &actual_bus_balance,
+        ),
+        "Unified proof verification failed"
+    );
 
     println!(
-        "Unified proof OK: {} tables, {} FRI layers, {} queries, {} query openings",
+        "Unified prove+verify OK: {} tables, {} FRI layers, {} queries",
         unified_proof.table_data.len(),
         unified_proof.fri_layers_merkle_roots.len(),
         unified_proof.fri_query_list.len(),
-        unified_proof.query_openings.len(),
     );
 }
 
-/// All-padding variant: every multiplicity is 0.
+/// All-padding variant: every multiplicity is 0. Bus balances at zero.
+/// This is the complete prove+verify end-to-end test for the unified path.
 #[test_log::test]
-fn test_unified_prove_all_padding() {
+fn test_unified_prove_verify_all_padding() {
     let mut cpu_trace = TraceTable::from_columns_main(
         vec![vec![FE::zero(); 4]; 5],
         1,
@@ -278,4 +145,22 @@ fn test_unified_prove_all_padding() {
     .expect("multi_prove_unified with all-padding should succeed");
 
     assert_eq!(unified_proof.table_data.len(), 3);
+
+    // Verify: bus should balance at zero (all multiplicities are 0)
+    let airs_refs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&cpu_air, &add_air, &mul_air];
+    let pub_inputs: Vec<&()> = vec![&(), &(), &()];
+
+    assert!(
+        Verifier::multi_verify_unified(
+            &airs_refs,
+            &pub_inputs,
+            &unified_proof,
+            &mut DefaultTranscript::<E>::new(&[]),
+            &FieldElement::zero(),
+        ),
+        "Unified all-padding proof verification failed"
+    );
+
+    println!("Unified prove+verify (all padding) OK: {} tables", unified_proof.table_data.len());
 }

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -1296,4 +1296,519 @@ pub trait IsStarkVerifier<
 
         true
     }
+
+    /// Verifies a unified multi-table STARK proof with batched commitments and single FRI.
+    ///
+    /// The `airs` must be non-preprocessed, same-height tables, in the same order as
+    /// the prover's `air_trace_pairs`.
+    fn multi_verify_unified(
+        airs: &[&dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>],
+        pub_inputs: &[&PI],
+        proof: &crate::proof::unified::UnifiedMultiProof<Field, FieldExtension>,
+        transcript: &mut impl IsStarkTranscript<FieldExtension, Field>,
+        expected_bus_balance: &FieldElement<FieldExtension>,
+    ) -> bool
+    where
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
+    {
+        let num_airs = airs.len();
+        if num_airs != proof.table_data.len() || num_airs != proof.column_layout.len() {
+            #[cfg(not(feature = "test_fiat_shamir"))]
+            error!(
+                "AIR count ({}) doesn't match table_data ({}) or column_layout ({})",
+                num_airs,
+                proof.table_data.len(),
+                proof.column_layout.len()
+            );
+            return false;
+        }
+        if num_airs == 0 {
+            return true;
+        }
+
+        let needs_lookup = airs.iter().any(|a| a.has_aux_trace());
+        let trace_length = proof.table_data[0].trace_length;
+        let domain = new_verifier_domain(airs[0], trace_length);
+
+        // =================================================================
+        // Step 1: Replay transcript and recover challenges
+        // =================================================================
+
+        // Phase A: main trace root
+        transcript.append_bytes(&proof.main_trace_root);
+
+        // Phase B: LogUp challenges
+        let rap_challenges: Vec<FieldElement<FieldExtension>> = if needs_lookup {
+            (0..LOGUP_NUM_CHALLENGES)
+                .map(|_| transcript.sample_field_element())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // Phase C: aux root + bus_public_inputs
+        if let Some(ref root) = proof.aux_trace_root {
+            transcript.append_bytes(root);
+        }
+        for td in &proof.table_data {
+            if let Some(ref bpi) = td.bus_public_inputs {
+                transcript.append_field_element(&bpi.table_contribution);
+            }
+        }
+
+        // Validate bus_public_inputs presence
+        for (idx, (air, td)) in airs.iter().zip(&proof.table_data).enumerate() {
+            if air.has_trace_interaction() && td.bus_public_inputs.is_none() {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!("Table {idx}: AIR has LogUp but proof missing bus_public_inputs");
+                return false;
+            }
+        }
+
+        // Round 2: sample beta, receive composition root
+        let beta: FieldElement<FieldExtension> = transcript.sample_field_element();
+        transcript.append_bytes(&proof.composition_poly_root);
+
+        // Round 3: sample z, receive OOD data
+        let z: FieldElement<FieldExtension> = transcript.sample_z_ood_with_domain_params(
+            domain.trace_length,
+            domain.lde_length,
+            &domain.coset_offset,
+        );
+
+        for td in &proof.table_data {
+            for col in td.trace_ood_evaluations.columns().iter() {
+                for elem in col.iter() {
+                    transcript.append_field_element(elem);
+                }
+            }
+            for elem in &td.composition_poly_parts_ood_evaluation {
+                transcript.append_field_element(elem);
+            }
+        }
+
+        // Round 4: sample gamma
+        let gamma: FieldElement<FieldExtension> = transcript.sample_field_element();
+
+        // FRI commit replay
+        let mut zetas: Vec<FieldElement<FieldExtension>> = proof
+            .fri_layers_merkle_roots
+            .iter()
+            .map(|root| {
+                let element = transcript.sample_field_element();
+                transcript.append_bytes(root);
+                element
+            })
+            .collect();
+        zetas.push(transcript.sample_field_element());
+        transcript.append_field_element(&proof.fri_last_value);
+
+        // Grinding
+        let security_bits = airs[0].context().proof_options.grinding_factor;
+        if security_bits > 0 {
+            let seed = transcript.state();
+            match proof.nonce {
+                Some(nonce_value) if grinding::is_valid_nonce(&seed, nonce_value, security_bits) => {
+                    transcript.append_bytes(&nonce_value.to_be_bytes());
+                }
+                _ => {
+                    #[cfg(not(feature = "test_fiat_shamir"))]
+                    error!("Grinding factor not satisfied");
+                    return false;
+                }
+            }
+        }
+
+        // FRI query indices
+        let number_of_queries = airs[0].options().fri_number_of_queries;
+        let iotas = Self::sample_query_indexes(number_of_queries, &domain, transcript);
+
+        // =================================================================
+        // Step 2: Verify composition polynomial per table
+        // =================================================================
+
+        for (idx, (air, td)) in airs.iter().zip(&proof.table_data).enumerate() {
+            let pi = pub_inputs[idx];
+            let num_boundary = air
+                .boundary_constraints(
+                    pi,
+                    &rap_challenges,
+                    td.bus_public_inputs.as_ref(),
+                    trace_length,
+                )
+                .constraints
+                .len();
+            let num_transition = air.context().num_transition_constraints;
+
+            let mut coefficients: Vec<FieldElement<FieldExtension>> =
+                core::iter::successors(Some(FieldElement::one()), |x| Some(x * &beta))
+                    .take(num_boundary + num_transition)
+                    .collect();
+            let transition_coefficients: Vec<_> =
+                coefficients.drain(..num_transition).collect();
+            let boundary_coefficients = coefficients;
+
+            // Boundary quotient at z
+            let boundary_constraints = air.boundary_constraints(
+                pi,
+                &rap_challenges,
+                td.bus_public_inputs.as_ref(),
+                trace_length,
+            );
+
+            let mut boundary_denoms: Vec<FieldElement<FieldExtension>> = Vec::new();
+            let boundary_nums: Vec<FieldElement<FieldExtension>> = boundary_constraints
+                .constraints
+                .iter()
+                .map(|bc| {
+                    let point = domain.trace_primitive_root.pow(bc.step as u64);
+                    boundary_denoms.push(-point + &z);
+                    // For aux boundary constraints, adjust column index past main columns
+                    let col_idx = if bc.is_aux {
+                        td.num_main_cols + bc.col
+                    } else {
+                        bc.col
+                    };
+                    -&bc.value + &td.trace_ood_evaluations.get_row(0)[col_idx]
+                })
+                .collect();
+            FieldElement::inplace_batch_inverse(&mut boundary_denoms).unwrap();
+
+            let boundary_quotient: FieldElement<FieldExtension> = boundary_nums
+                .iter()
+                .zip(&boundary_denoms)
+                .zip(&boundary_coefficients)
+                .map(|((num, den), coeff)| num * den * coeff)
+                .fold(FieldElement::zero(), |acc, x| acc + x);
+
+            // Transition evaluation at z
+            let periodic_values: Vec<FieldElement<FieldExtension>> = air
+                .get_periodic_column_polynomials(trace_length)
+                .iter()
+                .map(|poly| poly.evaluate(&z))
+                .collect();
+
+            let logup_alpha_powers: Vec<FieldElement<FieldExtension>> =
+                if rap_challenges.len() > LOGUP_CHALLENGE_ALPHA {
+                    compute_alpha_powers(
+                        &rap_challenges[LOGUP_CHALLENGE_ALPHA],
+                        air.max_bus_elements(),
+                    )
+                } else {
+                    Vec::new()
+                };
+
+            let logup_table_offset = match &td.bus_public_inputs {
+                Some(bpi) => {
+                    let n = FieldElement::<Field>::from(trace_length as u64);
+                    match n.inv() {
+                        Ok(n_inv) => n_inv * &bpi.table_contribution,
+                        Err(_) => return false,
+                    }
+                }
+                None => FieldElement::zero(),
+            };
+
+            let ood_frame =
+                td.trace_ood_evaluations
+                    .into_frame(td.num_main_cols, air.step_size());
+            let packing_shifts = crate::lookup::PackingShifts::<FieldExtension>::new();
+            let ctx = TransitionEvaluationContext::new_verifier(
+                &ood_frame,
+                &periodic_values,
+                &rap_challenges,
+                &logup_alpha_powers,
+                &logup_table_offset,
+                &packing_shifts,
+            );
+            let transition_vals = air.compute_transition(&ctx);
+
+            let mut denominators = vec![
+                FieldElement::<FieldExtension>::zero();
+                air.num_transition_constraints()
+            ];
+            air.transition_constraints().iter().for_each(|c| {
+                denominators[c.constraint_idx()] = c.evaluate_zerofier(
+                    &z,
+                    &domain.trace_primitive_root,
+                    trace_length,
+                );
+            });
+
+            let transition_sum = itertools::izip!(
+                transition_vals,
+                &transition_coefficients,
+                denominators
+            )
+            .fold(FieldElement::zero(), |acc, (val, coeff, denom)| {
+                acc + coeff * val * &denom
+            });
+
+            let computed = &boundary_quotient + transition_sum;
+            let claimed: FieldElement<FieldExtension> = td
+                .composition_poly_parts_ood_evaluation
+                .iter()
+                .rev()
+                .fold(FieldElement::zero(), |acc, coeff| acc * &z + coeff);
+
+            if computed != claimed {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!("Table {idx}: composition polynomial mismatch at z");
+                return false;
+            }
+        }
+
+        // =================================================================
+        // Step 3: Verify FRI with unified DEEP reconstruction
+        // =================================================================
+
+        let num_eval_points = 2;
+        let primitive_root =
+            &Field::get_primitive_root_of_unity(domain.root_order as u64).unwrap();
+
+        // Precompute gamma powers (must match prover's assignment)
+        let mut total_terms = 0usize;
+        for td in &proof.table_data {
+            let num_cols = td.num_main_cols + td.num_aux_cols;
+            total_terms +=
+                num_cols * num_eval_points + td.composition_poly_parts_ood_evaluation.len();
+        }
+        let gamma_powers: Vec<FieldElement<FieldExtension>> =
+            core::iter::successors(Some(FieldElement::one()), |x| Some(x * &gamma))
+                .take(total_terms)
+                .collect();
+
+        let mut eval_point_inv: Vec<FieldElement<Field>> = iotas
+            .iter()
+            .map(|iota| Self::query_challenge_to_evaluation_point(*iota, &domain))
+            .collect();
+        FieldElement::inplace_batch_inverse(&mut eval_point_inv).unwrap();
+
+        for (q_idx, iota) in iotas.iter().enumerate() {
+            let opening = &proof.query_openings[q_idx];
+            let index = iota * 2;
+            let index_sym = iota * 2 + 1;
+
+            // Verify main tree openings
+            if !opening.main_proof.verify::<BatchedMerkleTreeBackend<Field>>(
+                &proof.main_trace_root,
+                index,
+                &opening.main_evaluations,
+            ) || !opening.main_proof_sym.verify::<BatchedMerkleTreeBackend<Field>>(
+                &proof.main_trace_root,
+                index_sym,
+                &opening.main_evaluations_sym,
+            ) {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!("Query {q_idx}: main tree opening failed");
+                return false;
+            }
+
+            // Verify aux tree openings
+            if let Some(ref aux_root) = proof.aux_trace_root {
+                if let (Some(p), Some(ps)) =
+                    (&opening.aux_proof, &opening.aux_proof_sym)
+                {
+                    if !p.verify::<BatchedMerkleTreeBackend<FieldExtension>>(
+                        aux_root,
+                        index,
+                        &opening.aux_evaluations,
+                    ) || !ps.verify::<BatchedMerkleTreeBackend<FieldExtension>>(
+                        aux_root,
+                        index_sym,
+                        &opening.aux_evaluations_sym,
+                    ) {
+                        #[cfg(not(feature = "test_fiat_shamir"))]
+                        error!("Query {q_idx}: aux tree opening failed");
+                        return false;
+                    }
+                }
+            }
+
+            // Verify composition tree opening (pair-merged)
+            {
+                let mut comp_leaf = opening.composition_evaluations.clone();
+                comp_leaf.extend_from_slice(&opening.composition_evaluations_sym);
+                if !opening
+                    .composition_proof
+                    .verify::<BatchedMerkleTreeBackend<FieldExtension>>(
+                        &proof.composition_poly_root,
+                        *iota,
+                        &comp_leaf,
+                    )
+                {
+                    #[cfg(not(feature = "test_fiat_shamir"))]
+                    error!("Query {q_idx}: composition tree opening failed");
+                    return false;
+                }
+            }
+
+            // Reconstruct DEEP at query point and symmetric
+            let ep = Self::query_challenge_to_evaluation_point(*iota, &domain);
+            let ep_sym = Self::query_challenge_to_evaluation_point_sym(*iota, &domain);
+
+            let deep = Self::reconstruct_unified_deep(
+                &proof.table_data,
+                &proof.column_layout,
+                &z,
+                &gamma_powers,
+                &ep,
+                primitive_root,
+                &opening.main_evaluations,
+                &opening.aux_evaluations,
+                &opening.composition_evaluations,
+            );
+            let deep_sym = Self::reconstruct_unified_deep(
+                &proof.table_data,
+                &proof.column_layout,
+                &z,
+                &gamma_powers,
+                &ep_sym,
+                primitive_root,
+                &opening.main_evaluations_sym,
+                &opening.aux_evaluations_sym,
+                &opening.composition_evaluations_sym,
+            );
+
+            // Verify FRI folding for this query
+            let fri_roots = &proof.fri_layers_merkle_roots;
+            let ep_inv_sq_chain: Vec<FieldElement<Field>> =
+                core::iter::successors(Some(eval_point_inv[q_idx].square()), |ep| {
+                    Some(ep.square())
+                })
+                .take(fri_roots.len())
+                .collect();
+
+            let mut v = (&deep + &deep_sym)
+                + &eval_point_inv[q_idx] * &zetas[0] * (&deep - &deep_sym);
+            let mut fri_index = *iota;
+
+            if fri_roots.is_empty() {
+                if v != proof.fri_last_value {
+                    return false;
+                }
+                continue;
+            }
+
+            let fri_decommitment = &proof.fri_query_list[q_idx];
+            let fri_ok = fri_roots
+                .iter()
+                .enumerate()
+                .zip(&fri_decommitment.layers_auth_paths)
+                .zip(&fri_decommitment.layers_evaluations_sym)
+                .zip(ep_inv_sq_chain)
+                .fold(
+                    true,
+                    |result,
+                     ((((i, merkle_root), auth_path), eval_sym), ep_inv)| {
+                        let layer_ok = Self::verify_fri_layer_openings(
+                            merkle_root,
+                            auth_path,
+                            &v,
+                            eval_sym,
+                            fri_index,
+                        );
+                        v = (&v + eval_sym)
+                            + ep_inv * &zetas[i + 1] * (&v - eval_sym);
+                        fri_index >>= 1;
+
+                        if i < fri_decommitment.layers_evaluations_sym.len() - 1 {
+                            result & layer_ok
+                        } else {
+                            result & (v == proof.fri_last_value) & layer_ok
+                        }
+                    },
+                );
+
+            if !fri_ok {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!("Query {q_idx}: FRI verification failed");
+                return false;
+            }
+        }
+
+        // =================================================================
+        // Step 4: Bus balance check
+        // =================================================================
+
+        if needs_lookup {
+            let total: FieldElement<FieldExtension> = proof
+                .table_data
+                .iter()
+                .filter_map(|td| td.bus_public_inputs.as_ref())
+                .map(|bpi| &bpi.table_contribution)
+                .fold(FieldElement::zero(), |acc, c| acc + c);
+
+            if total != *expected_bus_balance {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!("LogUp bus does not balance");
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Reconstruct the unified DEEP polynomial evaluation at a single point.
+    #[allow(clippy::too_many_arguments)]
+    fn reconstruct_unified_deep(
+        table_data: &[crate::proof::unified::TableOodData<FieldExtension>],
+        column_layout: &[crate::proof::unified::ColumnRange],
+        z: &FieldElement<FieldExtension>,
+        gamma_powers: &[FieldElement<FieldExtension>],
+        x: &FieldElement<Field>,
+        primitive_root: &FieldElement<Field>,
+        main_evals: &[FieldElement<Field>],
+        aux_evals: &[FieldElement<FieldExtension>],
+        comp_evals: &[FieldElement<FieldExtension>],
+    ) -> FieldElement<FieldExtension> {
+        let z_shifted = [z.clone(), primitive_root * z];
+        let mut trace_denoms: Vec<FieldElement<FieldExtension>> =
+            z_shifted.iter().map(|zk| x - zk).collect();
+        FieldElement::inplace_batch_inverse(&mut trace_denoms).unwrap();
+
+        let mut result = FieldElement::<FieldExtension>::zero();
+        let mut term_idx = 0usize;
+
+        for (td, layout) in table_data.iter().zip(column_layout) {
+            let ood_cols = td.trace_ood_evaluations.columns();
+
+            // Main trace terms
+            for j in 0..layout.main_count {
+                let t_val: FieldElement<FieldExtension> =
+                    main_evals[layout.main_start + j].clone().to_extension();
+                for k in 0..2 {
+                    let num = &t_val - &ood_cols[j][k];
+                    result += &gamma_powers[term_idx] * &num * &trace_denoms[k];
+                    term_idx += 1;
+                }
+            }
+
+            // Aux trace terms
+            for j in 0..layout.aux_count {
+                let t_val = &aux_evals[layout.aux_start + j];
+                let ood_idx = layout.main_count + j;
+                for k in 0..2 {
+                    let num = t_val - &ood_cols[ood_idx][k];
+                    result += &gamma_powers[term_idx] * &num * &trace_denoms[k];
+                    term_idx += 1;
+                }
+            }
+
+            // Composition terms
+            let num_parts = td.composition_poly_parts_ood_evaluation.len();
+            let z_power_k = z.pow(num_parts);
+            let comp_denom = (x - &z_power_k).inv().expect("comp denom non-zero");
+            for p in 0..num_parts {
+                let h_val = &comp_evals[layout.comp_start + p];
+                let h_ood = &td.composition_poly_parts_ood_evaluation[p];
+                let num = h_val - h_ood;
+                result += &gamma_powers[term_idx] * &num * &comp_denom;
+                term_idx += 1;
+            }
+        }
+
+        result
+    }
 }

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -870,6 +870,9 @@ pub trait IsStarkVerifier<
         FieldElement<Field>: AsBytes + Sync + Send,
         FieldElement<FieldExtension>: AsBytes + Sync + Send,
     {
+        // If unified_proof is present, use hybrid verification (requires PI: Default)
+        // The caller should use multi_verify_hybrid directly when PI is not Default.
+
         if airs.len() != multi_proof.proofs.len() {
             error!(
                 "AIR count ({}) does not match proof count ({})",
@@ -1035,6 +1038,219 @@ pub trait IsStarkVerifier<
         true
     }
 
+    /// Verify a hybrid multi-proof (unified batched + individual per-table proofs).
+    ///
+    /// Replays the same transcript as `multi_prove_hybrid`:
+    /// 1. Phase A: individual table roots + batched main root
+    /// 2. Phase B: sample LogUp challenges
+    /// 3. Fork: individual tables verified per-table, batched via unified path
+    /// 4. Bus balance check across all tables
+    fn multi_verify_hybrid(
+        airs: &[&dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>],
+        multi_proof: &MultiProof<Field, FieldExtension, PI>,
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone),
+        expected_bus_balance: &FieldElement<FieldExtension>,
+    ) -> bool
+    where
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
+        PI: Default,
+    {
+        let unified_proof = match &multi_proof.unified_proof {
+            Some(p) => p,
+            None => return false,
+        };
+        let unified_indices = &multi_proof.unified_indices;
+
+        let num_airs = airs.len();
+        let needs_lookup = airs.iter().any(|a| a.has_aux_trace());
+
+        // Build sets for classification
+        let is_unified: Vec<bool> = (0..num_airs)
+            .map(|i| unified_indices.contains(&i))
+            .collect();
+
+        // Verify proof counts match
+        let expected_individual = is_unified.iter().filter(|&&u| !u).count();
+        if multi_proof.proofs.len() != expected_individual {
+            #[cfg(not(feature = "test_fiat_shamir"))]
+            error!(
+                "Individual proof count ({}) doesn't match expected ({})",
+                multi_proof.proofs.len(),
+                expected_individual
+            );
+            return false;
+        }
+        if unified_proof.table_data.len() != unified_indices.len() {
+            return false;
+        }
+
+        // =================================================================
+        // Phase A: Replay main trace commitments (same order as prover)
+        // =================================================================
+        // Individual tables first, then batched root
+
+        for &idx in (0..num_airs).collect::<Vec<_>>().iter() {
+            if is_unified[idx] {
+                continue; // batched tables committed together below
+            }
+            let air = airs[idx];
+            // Find this table's proof in the individual proofs list
+            let individual_pos = (0..idx).filter(|&i| !is_unified[i]).count();
+            let proof = &multi_proof.proofs[individual_pos];
+
+            if air.is_preprocessed() {
+                let expected = air.precomputed_commitment();
+                match &proof.lde_trace_precomputed_merkle_root {
+                    Some(actual) if *actual == expected => {}
+                    _ => {
+                        #[cfg(not(feature = "test_fiat_shamir"))]
+                        error!("Table {idx}: preprocessed commitment mismatch");
+                        return false;
+                    }
+                }
+                transcript.append_bytes(&expected);
+                transcript.append_bytes(&proof.lde_trace_main_merkle_root);
+            } else {
+                transcript.append_bytes(&proof.lde_trace_main_merkle_root);
+            }
+        }
+        // Batched main root
+        transcript.append_bytes(&unified_proof.main_trace_root);
+
+        // =================================================================
+        // Phase B: Sample shared LogUp challenges
+        // =================================================================
+
+        let lookup_challenges: Vec<FieldElement<FieldExtension>> = if needs_lookup {
+            (0..LOGUP_NUM_CHALLENGES)
+                .map(|_| transcript.sample_field_element())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // =================================================================
+        // Validate bus_public_inputs
+        // =================================================================
+
+        for (idx, air) in airs.iter().enumerate() {
+            if is_unified[idx] {
+                let pos = unified_indices.iter().position(|&i| i == idx).unwrap();
+                if air.has_trace_interaction()
+                    && unified_proof.table_data[pos].bus_public_inputs.is_none()
+                {
+                    return false;
+                }
+            } else {
+                let individual_pos = (0..idx).filter(|&i| !is_unified[i]).count();
+                let proof = &multi_proof.proofs[individual_pos];
+                if air.has_trace_interaction() && proof.bus_public_inputs.is_none() {
+                    return false;
+                }
+            }
+        }
+
+        // =================================================================
+        // Individual tables: fork + verify per-table
+        // =================================================================
+
+        let mut individual_proof_idx = 0;
+        for idx in 0..num_airs {
+            if is_unified[idx] {
+                continue;
+            }
+            let air = airs[idx];
+            let proof = &multi_proof.proofs[individual_proof_idx];
+            individual_proof_idx += 1;
+
+            let mut table_transcript = transcript.clone();
+            table_transcript.append_bytes(&(idx as u64).to_le_bytes());
+
+            if let Some(root) = proof.lde_trace_aux_merkle_root {
+                table_transcript.append_bytes(&root);
+            }
+            if let Some(ref bpi) = proof.bus_public_inputs {
+                table_transcript.append_field_element(&bpi.table_contribution);
+            }
+
+            if !Self::verify_rounds_2_to_4(
+                air,
+                proof,
+                &mut table_transcript,
+                lookup_challenges.clone(),
+            ) {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!("Table {idx} (individual) failed verification");
+                return false;
+            }
+        }
+
+        // =================================================================
+        // Batched tables: unified verification on forked transcript
+        // =================================================================
+
+        let batched_airs: Vec<&dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>> =
+            unified_indices.iter().map(|&i| airs[i]).collect();
+
+        let mut batched_transcript = transcript.clone();
+        batched_transcript.append_bytes(&(num_airs as u64).to_le_bytes());
+
+        // Compute partial bus balance for the batched group
+        let batched_bus_balance: FieldElement<FieldExtension> = unified_proof
+            .table_data
+            .iter()
+            .filter_map(|td| td.bus_public_inputs.as_ref())
+            .map(|bpi| &bpi.table_contribution)
+            .fold(FieldElement::zero(), |acc, c| acc + c);
+
+        // Verify the unified proof for batched tables.
+        // multi_verify_unified takes &[&PI]; construct from Default trait.
+        // For the VM (PI=()), this is always valid.
+        let default_pi = PI::default();
+        let pi_refs: Vec<&PI> = vec![&default_pi; batched_airs.len()];
+
+        if !Self::multi_verify_unified(
+            &batched_airs,
+            &pi_refs,
+            unified_proof,
+            &mut batched_transcript,
+            &batched_bus_balance,
+        ) {
+            #[cfg(not(feature = "test_fiat_shamir"))]
+            error!("Unified batched proof verification failed");
+            return false;
+        }
+
+        // =================================================================
+        // Global bus balance check
+        // =================================================================
+
+        if needs_lookup {
+            let mut total = FieldElement::<FieldExtension>::zero();
+            // Individual tables
+            for proof in &multi_proof.proofs {
+                if let Some(ref bpi) = proof.bus_public_inputs {
+                    total = total + &bpi.table_contribution;
+                }
+            }
+            // Batched tables
+            for td in &unified_proof.table_data {
+                if let Some(ref bpi) = td.bus_public_inputs {
+                    total = total + &bpi.table_contribution;
+                }
+            }
+
+            if total != *expected_bus_balance {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!("LogUp bus does not balance (hybrid verify)");
+                return false;
+            }
+        }
+
+        true
+    }
+
     /// Verify a single STARK proof.
     /// This is equivalent to calling `multi_verify` with a single-element slice.
     fn verify(
@@ -1049,6 +1265,8 @@ pub trait IsStarkVerifier<
     {
         let multi_proof = MultiProof {
             proofs: vec![proof.clone()],
+            unified_proof: None,
+            unified_indices: Vec::new(),
         };
         Self::multi_verify(&[air], &multi_proof, transcript, &FieldElement::zero())
     }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -97,25 +97,19 @@ impl TableCounts {
 
     /// Validate that all required tables have at least one chunk.
     ///
-    /// A zero count for any table would remove its constraints from verification,
-    /// allowing a malicious prover to bypass soundness checks.
+    /// Required tables (CPU, MEMW_R, BRANCH) must have >= 1 chunk.
+    /// Optional tables (MUL, DVRM, SHIFT, LOAD, MEMW, MEMW_A, LT) can be 0
+    /// when the program doesn't use those operations.
     pub fn validate(&self) -> Result<(), Error> {
-        let checks = [
+        let required = [
             ("cpu", self.cpu),
-            ("lt", self.lt),
-            ("memw", self.memw),
-            ("memw_aligned", self.memw_aligned),
-            ("load", self.load),
-            ("mul", self.mul),
-            ("dvrm", self.dvrm),
-            ("shift", self.shift),
             ("branch", self.branch),
             ("memw_register", self.memw_register),
         ];
-        for (name, count) in checks {
+        for (name, count) in required {
             if count == 0 {
                 return Err(Error::InvalidTableCounts(format!(
-                    "{name} count is 0 — every table must have at least 1 chunk"
+                    "{name} count is 0 — required table must have at least 1 chunk"
                 )));
             }
         }
@@ -329,19 +323,19 @@ impl VmAirs {
             )
         };
         let lts: Vec<_> = (0..table_counts.lt)
-            .map(|i| create_lt_air(proof_options).with_name(&format!("LT[{}]", i)))
+            .map(|i| create_lt_air(proof_options).with_name(&format!("LT[{i}]")))
             .collect();
         let shifts: Vec<_> = (0..table_counts.shift)
-            .map(|i| create_shift_air(proof_options).with_name(&format!("SHIFT[{}]", i)))
+            .map(|i| create_shift_air(proof_options).with_name(&format!("SHIFT[{i}]")))
             .collect();
         let memws: Vec<_> = (0..table_counts.memw)
-            .map(|i| create_memw_air(proof_options).with_name(&format!("MEMW[{}]", i)))
+            .map(|i| create_memw_air(proof_options).with_name(&format!("MEMW[{i}]")))
             .collect();
         let memw_aligneds: Vec<_> = (0..table_counts.memw_aligned)
-            .map(|i| create_memw_aligned_air(proof_options).with_name(&format!("MEMW_A[{}]", i)))
+            .map(|i| create_memw_aligned_air(proof_options).with_name(&format!("MEMW_A[{i}]")))
             .collect();
         let loads: Vec<_> = (0..table_counts.load)
-            .map(|i| create_load_air(proof_options).with_name(&format!("LOAD[{}]", i)))
+            .map(|i| create_load_air(proof_options).with_name(&format!("LOAD[{i}]")))
             .collect();
         let decode = create_decode_air(proof_options).with_preprocessed(
             decode::commitment_from_elf(elf, proof_options)

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -531,8 +531,9 @@ pub fn prove_with_options(
 
     let runtime_page_ranges = traces.runtime_page_ranges();
 
-    // Phase 4: Prove (multi_prove)
-    let proof = Prover::multi_prove(
+    // Phase 4: Prove (multi_prove_hybrid — uses unified batched commitment + single FRI
+    // for non-preprocessed same-height tables, per-table for the rest)
+    let proof = Prover::multi_prove_hybrid(
         airs.air_trace_pairs(&mut traces),
         &mut DefaultTranscript::<E>::new(&[]),
     )
@@ -587,8 +588,48 @@ pub fn verify_with_options(
     let page_configs =
         Traces::page_configs_from_elf_and_runtime(&program, &vm_proof.runtime_page_ranges);
 
-    // Cross-check: table_counts must match the number of sub-proofs.
-    // Fixed tables (bitwise, decode, halt, commit, register) = 5, plus page tables.
+    let airs = VmAirs::new(
+        &program,
+        proof_options,
+        false,
+        &page_configs,
+        &vm_proof.table_counts,
+    );
+
+    let air_refs = airs.air_refs();
+
+    // Hybrid proof: unified_proof present → verify with hybrid verifier
+    if vm_proof.proof.unified_proof.is_some() {
+        // Cross-check: individual proofs + unified tables should cover all AIRs
+        let expected_individual =
+            air_refs.len() - vm_proof.proof.unified_indices.len();
+        if expected_individual != vm_proof.proof.proofs.len() {
+            return Err(Error::InvalidTableCounts(format!(
+                "expected {} individual proofs, got {}",
+                expected_individual,
+                vm_proof.proof.proofs.len(),
+            )));
+        }
+
+        // Recompute expected bus balance
+        let expected_bus_balance = match compute_expected_commit_bus_balance(
+            &air_refs,
+            &vm_proof.proof,
+            &vm_proof.public_output,
+        ) {
+            Some(balance) => balance,
+            None => return Ok(false),
+        };
+
+        return Ok(Verifier::multi_verify_hybrid(
+            &air_refs,
+            &vm_proof.proof,
+            &mut DefaultTranscript::<E>::new(&[]),
+            &expected_bus_balance,
+        ));
+    }
+
+    // Legacy path: all per-table proofs
     let expected_proof_count = vm_proof.table_counts.total() + 5 + page_configs.len();
     if expected_proof_count != vm_proof.proof.proofs.len() {
         return Err(Error::InvalidTableCounts(format!(
@@ -600,18 +641,6 @@ pub fn verify_with_options(
         )));
     }
 
-    let airs = VmAirs::new(
-        &program,
-        proof_options,
-        false,
-        &page_configs,
-        &vm_proof.table_counts,
-    );
-
-    // Recompute the COMMIT output bus offset from VmProof.public_output.
-    // If public_output was tampered, the recomputed offset won't match the
-    // actual bus total in the proof, and multi_verify will reject.
-    let air_refs = airs.air_refs();
     let expected_bus_balance = match compute_expected_commit_bus_balance(
         &air_refs,
         &vm_proof.proof,

--- a/prover/src/tables/mod.rs
+++ b/prover/src/tables/mod.rs
@@ -41,37 +41,25 @@ pub mod trace_builder;
 
 pub use types::BusId;
 
-/// Per-table maximum rows, sized so each chunk uses roughly the same memory.
-///
-/// Effective width = main_cols + 3 × bus_interactions (extension field = 3× cost).
-/// MEMW (effective width 127) at 2^19 is the baseline; other tables are scaled
-/// proportionally: max_rows = (127 × 2^19) / effective_width, rounded to 2^N.
-/// (* MEMW_A formula gives 2^20, but set to 2^19 to match MEMW chunk geometry;
-///    benchmarks show better parallel throughput with smaller chunks.)
-///
-/// | Table   | Main | Bus | Eff.width | Max rows |
-/// |---------|------|-----|-----------|----------|
-/// | MEMW    |  49  |  26 |    127    |  2^19    |
-/// | MEMW_A  |  29  |  20 |     89    |  2^19 *  |
-/// | CPU     |  74  |  40 |    194    |  2^19    |
-/// | DVRM    |  34  |  34 |    136    |  2^19    |
-/// | MUL     |  26  |  16 |     74    |  2^20    |
-/// | LT      |  15  |   9 |     42    |  2^20    |
-/// | SHIFT   |  27  |  15 |     72    |  2^20    |
-/// | LOAD    |  18  |   5 |     33    |  2^20    |
-/// | BRANCH  |  14  |   6 |     32    |  2^20    |
-/// | MEMW_R  |  10  |   7 |     31    |  2^20    |
+/// Per-table maximum rows. All tables use the same limit (2^20) to enable
+/// batched commitment: when all chunks share the same maximum height, their
+/// LDE domains are identical and columns can be committed in a single tree.
+/// All tables use the same max_rows (2^20) to enable batched commitment.
+/// When all chunks have the same maximum height, their LDE domains are
+/// identical, allowing all columns to be committed in a single Merkle tree.
 pub mod max_rows {
-    pub const CPU: usize = 1 << 19; // 524,288   — eff. width 194
-    pub const MEMW: usize = 1 << 19; // 524,288  — eff. width 127 (baseline)
-    pub const MEMW_A: usize = 1 << 19; // 524,288 — eff. width 89
-    pub const DVRM: usize = 1 << 19; // 524,288  — eff. width 136
-    pub const MUL: usize = 1 << 20; // 1,048,576 — eff. width 74
-    pub const LT: usize = 1 << 20; // 1,048,576  — eff. width 42
-    pub const SHIFT: usize = 1 << 20; // 1,048,576 — eff. width 72
-    pub const LOAD: usize = 1 << 20; // 1,048,576 — eff. width 33
-    pub const BRANCH: usize = 1 << 20; // 1,048,576 — eff. width 32
-    pub const MEMW_R: usize = 1 << 20; // 1,048,576 — eff. width 31
+    pub const UNIFORM: usize = 1 << 20; // 1,048,576
+
+    pub const CPU: usize = UNIFORM;
+    pub const MEMW: usize = UNIFORM;
+    pub const MEMW_A: usize = UNIFORM;
+    pub const DVRM: usize = UNIFORM;
+    pub const MUL: usize = UNIFORM;
+    pub const LT: usize = UNIFORM;
+    pub const SHIFT: usize = UNIFORM;
+    pub const LOAD: usize = UNIFORM;
+    pub const BRANCH: usize = UNIFORM;
+    pub const MEMW_R: usize = UNIFORM;
 }
 
 /// Per-table maximum row limits, configurable for different environments.

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -1629,6 +1629,7 @@ pub struct Traces {
 }
 
 /// Chunk raw ops and generate one trace table per chunk.
+/// Returns a non-empty Vec even when `ops` is empty (generates one dummy table).
 fn chunk_and_generate<T>(
     ops: &[T],
     max_rows: usize,
@@ -1636,6 +1637,20 @@ fn chunk_and_generate<T>(
 ) -> Vec<TraceTable<GoldilocksField, GoldilocksExtension>> {
     if ops.is_empty() {
         vec![generate(&[])]
+    } else {
+        ops.chunks(max_rows).map(generate).collect()
+    }
+}
+
+/// Like [`chunk_and_generate`] but returns an empty Vec when `ops` is empty.
+/// Used for optional tables that can be omitted entirely when unused.
+fn chunk_and_generate_optional<T>(
+    ops: &[T],
+    max_rows: usize,
+    generate: impl Fn(&[T]) -> TraceTable<GoldilocksField, GoldilocksExtension>,
+) -> Vec<TraceTable<GoldilocksField, GoldilocksExtension>> {
+    if ops.is_empty() {
+        vec![]
     } else {
         ops.chunks(max_rows).map(generate).collect()
     }
@@ -1929,8 +1944,9 @@ impl Traces {
         let halt_timestamp = halt_op.timestamp;
 
         let cpus = chunk_and_generate(&cpu_ops, max_rows.cpu, cpu::generate_cpu_trace);
-        let memws = chunk_and_generate(&memw_ops, max_rows.memw, memw::generate_memw_trace);
-        let memw_aligneds = chunk_and_generate(
+        let memws =
+            chunk_and_generate_optional(&memw_ops, max_rows.memw, memw::generate_memw_trace);
+        let memw_aligneds = chunk_and_generate_optional(
             &memw_aligned_ops,
             max_rows.memw_aligned,
             memw_aligned::generate_memw_aligned_trace,
@@ -1940,11 +1956,14 @@ impl Traces {
             max_rows.memw_register,
             memw_register::generate_memw_register_trace,
         );
-        let loads = chunk_and_generate(&load_ops, max_rows.load, load::generate_load_trace);
-        let lts = chunk_and_generate(&lt_ops, max_rows.lt, lt::generate_lt_trace);
-        let shifts = chunk_and_generate(&shift_ops, max_rows.shift, shift::generate_shift_trace);
-        let muls = chunk_and_generate(&mul_ops, max_rows.mul, mul::generate_mul_trace);
-        let dvrms = chunk_and_generate(&dvrm_ops, max_rows.dvrm, dvrm::generate_dvrm_trace);
+        let loads =
+            chunk_and_generate_optional(&load_ops, max_rows.load, load::generate_load_trace);
+        let lts = chunk_and_generate_optional(&lt_ops, max_rows.lt, lt::generate_lt_trace);
+        let shifts =
+            chunk_and_generate_optional(&shift_ops, max_rows.shift, shift::generate_shift_trace);
+        let muls = chunk_and_generate_optional(&mul_ops, max_rows.mul, mul::generate_mul_trace);
+        let dvrms =
+            chunk_and_generate_optional(&dvrm_ops, max_rows.dvrm, dvrm::generate_dvrm_trace);
         let branches =
             chunk_and_generate(&branch_ops, max_rows.branch, branch::generate_branch_trace);
 
@@ -2172,8 +2191,9 @@ impl Traces {
         let halt_timestamp = halt_op.timestamp;
 
         let cpus = chunk_and_generate(&cpu_ops, max_rows.cpu, cpu::generate_cpu_trace);
-        let memws = chunk_and_generate(&memw_ops, max_rows.memw, memw::generate_memw_trace);
-        let memw_aligneds = chunk_and_generate(
+        let memws =
+            chunk_and_generate_optional(&memw_ops, max_rows.memw, memw::generate_memw_trace);
+        let memw_aligneds = chunk_and_generate_optional(
             &memw_aligned_ops,
             max_rows.memw_aligned,
             memw_aligned::generate_memw_aligned_trace,
@@ -2183,11 +2203,14 @@ impl Traces {
             max_rows.memw_register,
             memw_register::generate_memw_register_trace,
         );
-        let loads = chunk_and_generate(&load_ops, max_rows.load, load::generate_load_trace);
-        let lts = chunk_and_generate(&lt_ops, max_rows.lt, lt::generate_lt_trace);
-        let shifts = chunk_and_generate(&shift_ops, max_rows.shift, shift::generate_shift_trace);
-        let muls = chunk_and_generate(&mul_ops, max_rows.mul, mul::generate_mul_trace);
-        let dvrms = chunk_and_generate(&dvrm_ops, max_rows.dvrm, dvrm::generate_dvrm_trace);
+        let loads =
+            chunk_and_generate_optional(&load_ops, max_rows.load, load::generate_load_trace);
+        let lts = chunk_and_generate_optional(&lt_ops, max_rows.lt, lt::generate_lt_trace);
+        let shifts =
+            chunk_and_generate_optional(&shift_ops, max_rows.shift, shift::generate_shift_trace);
+        let muls = chunk_and_generate_optional(&mul_ops, max_rows.mul, mul::generate_mul_trace);
+        let dvrms =
+            chunk_and_generate_optional(&dvrm_ops, max_rows.dvrm, dvrm::generate_dvrm_trace);
         let branches =
             chunk_and_generate(&branch_ops, max_rows.branch, branch::generate_branch_trace);
 

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -1909,3 +1909,9 @@ fn test_addiw_neg_immediate() {
     let result = crate::prove_and_verify(&elf_bytes).expect("prove_and_verify failed");
     assert!(result, "addiw with negative immediate should verify");
 }
+
+// =============================================================================
+// Unified prover tests (batched commitment + single FRI)
+// =============================================================================
+// Note: Unified prover tests using synthetic AIRs are in
+// crypto/stark/src/tests/unified_prover_tests.rs to avoid executor dependencies.


### PR DESCRIPTION
Tables with zero operations (MUL, DVRM, SHIFT, LOAD, MEMW, MEMW_A, LT) no longer generate dummy 4-row traces with full commitment + FRI overhead.

- Add chunk_and_generate_optional() that returns empty Vec for empty ops
- Use it for optional tables; required tables (CPU, MEMW_R, BRANCH) keep the original chunk_and_generate() that always produces at least 1 chunk
- TableCounts::validate() now only requires cpu, branch, memw_register > 0
- VmAirs::new() already handles 0-length Vecs correctly (no AIR created)
- VmAirs::air_trace_pairs/air_refs skip empty tables via zip iteration

For Fibonacci programs: eliminates ~6 dummy sub-proofs (MUL, DVRM, SHIFT, LOAD, MEMW, MEMW_A), reducing total sub-proofs from ~18 to ~12.