### PR TITLE
refactor: decompose composition poly via squared-coset intermediate

### DIFF
--- a/crypto/stark/src/batched_layout.rs
+++ b/crypto/stark/src/batched_layout.rs
@@ -1,0 +1,76 @@
+/// Tracks per-table column offsets within a shared batched Merkle tree.
+/// Each phase (main, aux, composition) has its own layout.
+#[derive(Debug, Clone)]
+pub struct BatchedLayout {
+    /// (col_start, col_end) for each table in the concatenated row.
+    pub table_ranges: Vec<(usize, usize)>,
+    /// Total number of columns across all tables.
+    pub total_columns: usize,
+    /// Domain size (LDE size for main/aux, trace size for composition).
+    pub domain_size: usize,
+}
+
+impl BatchedLayout {
+    /// Build layout from per-table column counts.
+    pub fn new(column_counts: &[usize], domain_size: usize) -> Self {
+        let mut ranges = Vec::with_capacity(column_counts.len());
+        let mut offset = 0;
+        for &count in column_counts {
+            ranges.push((offset, offset + count));
+            offset += count;
+        }
+        BatchedLayout {
+            table_ranges: ranges,
+            total_columns: offset,
+            domain_size,
+        }
+    }
+
+    pub fn num_tables(&self) -> usize {
+        self.table_ranges.len()
+    }
+
+    /// Extract one table's columns from a full row of opened values.
+    pub fn extract_table<T: Clone>(&self, table_idx: usize, row: &[T]) -> Vec<T> {
+        let (start, end) = self.table_ranges[table_idx];
+        row[start..end].to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_layout_construction() {
+        let layout = BatchedLayout::new(&[5, 3, 7], 1024);
+        assert_eq!(layout.total_columns, 15);
+        assert_eq!(layout.table_ranges, vec![(0, 5), (5, 8), (8, 15)]);
+        assert_eq!(layout.num_tables(), 3);
+        assert_eq!(layout.domain_size, 1024);
+    }
+
+    #[test]
+    fn test_extract_table() {
+        let layout = BatchedLayout::new(&[2, 3], 1024);
+        let row = vec![10, 20, 30, 40, 50];
+        assert_eq!(layout.extract_table(0, &row), vec![10, 20]);
+        assert_eq!(layout.extract_table(1, &row), vec![30, 40, 50]);
+    }
+
+    #[test]
+    fn test_empty_tables() {
+        let layout = BatchedLayout::new(&[0, 3, 0], 512);
+        assert_eq!(layout.total_columns, 3);
+        assert_eq!(layout.table_ranges, vec![(0, 0), (0, 3), (3, 3)]);
+        assert_eq!(layout.extract_table::<i32>(0, &[1, 2, 3]), vec![]);
+        assert_eq!(layout.extract_table(1, &[1, 2, 3]), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_single_table() {
+        let layout = BatchedLayout::new(&[4], 2048);
+        assert_eq!(layout.total_columns, 4);
+        assert_eq!(layout.table_ranges, vec![(0, 4)]);
+    }
+}

--- a/crypto/stark/src/fri/mod.rs
+++ b/crypto/stark/src/fri/mod.rs
@@ -85,6 +85,89 @@ where
     (last_value, fri_layer_list)
 }
 
+/// FRI commit phase with optional injection after the first fold.
+///
+/// After the first fold reduces 2N evaluations to N, the `injection` vector
+/// (if provided) is added elementwise. This allows committing auxiliary
+/// polynomials (e.g. composition DEEP quotient) at a smaller domain size
+/// without extending them to the full LDE domain.
+///
+/// The injection vector must be in bit-reversed order on the squared coset,
+/// matching the output order of the first fold.
+pub fn commit_phase_from_evaluations_with_injection<
+    F: IsFFTField + IsSubFieldOf<E>,
+    E: IsField,
+>(
+    number_layers: usize,
+    mut evals: Vec<FieldElement<E>>,
+    injection: Option<Vec<FieldElement<E>>>,
+    transcript: &mut impl IsStarkTranscript<E, F>,
+    coset_offset: &FieldElement<F>,
+    domain_size: usize,
+) -> (
+    FieldElement<E>,
+    Vec<FriLayer<E, FriLayerMerkleTreeBackend<E>>>,
+)
+where
+    FieldElement<F>: AsBytes + Sync + Send,
+    FieldElement<E>: AsBytes + Sync + Send,
+{
+    let mut inv_twiddles = compute_coset_twiddles_inv(coset_offset, domain_size);
+
+    let mut fri_layer_list = Vec::with_capacity(number_layers);
+    let mut current_coset_offset = coset_offset.clone();
+    let mut current_domain_size = domain_size;
+    let mut first_fold = true;
+
+    for _ in 1..number_layers {
+        let zeta = transcript.sample_field_element();
+        current_coset_offset = current_coset_offset.square();
+        current_domain_size /= 2;
+
+        fold_evaluations_in_place(&mut evals, &zeta, &inv_twiddles);
+
+        // After the first fold, inject composition DEEP values if provided.
+        if first_fold {
+            if let Some(ref inj) = injection {
+                debug_assert_eq!(
+                    evals.len(),
+                    inj.len(),
+                    "Injection vector size must match folded evaluation size"
+                );
+                for (e, v) in evals.iter_mut().zip(inj.iter()) {
+                    *e = &*e + v;
+                }
+            }
+            first_fold = false;
+        }
+
+        let leaves: Vec<[FieldElement<E>; 2]> = evals
+            .chunks_exact(2)
+            .map(|chunk| [chunk[0].clone(), chunk[1].clone()])
+            .collect();
+        let merkle_tree = FriLayerMerkleTree::build(&leaves)
+            .expect("FRI commit: Merkle tree construction must succeed");
+        let root = merkle_tree.root;
+        fri_layer_list.push(FriLayer::new(
+            &evals,
+            merkle_tree,
+            current_coset_offset.clone().to_extension(),
+            current_domain_size,
+        ));
+
+        transcript.append_bytes(&root);
+        update_twiddles_in_place(&mut inv_twiddles);
+    }
+
+    let zeta = transcript.sample_field_element();
+    fold_evaluations_in_place(&mut evals, &zeta, &inv_twiddles);
+
+    let last_value = evals.first().unwrap_or(&FieldElement::zero()).clone();
+    transcript.append_field_element(&last_value);
+
+    (last_value, fri_layer_list)
+}
+
 pub fn query_phase<F: IsField>(
     fri_layers: &Vec<FriLayer<F, FriLayerMerkleTreeBackend<F>>>,
     iotas: &[usize],

--- a/crypto/stark/src/lib.rs
+++ b/crypto/stark/src/lib.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "debug-checks")]
 pub mod bus_debug;
+pub mod batched_layout;
 pub mod constraints;
 pub mod context;
 pub mod debug;

--- a/crypto/stark/src/proof/stark.rs
+++ b/crypto/stark/src/proof/stark.rs
@@ -78,3 +78,48 @@ pub struct StarkProof<F: IsSubFieldOf<E>, E: IsField, PI> {
 pub struct MultiProof<F: IsSubFieldOf<E>, E: IsField, PI> {
     pub proofs: Vec<StarkProof<F, E, PI>>,
 }
+
+/// Per-table data in a batched proof (OOD evaluations + public inputs).
+#[derive(Debug, Clone)]
+pub struct TableProofData<F: IsField, E: IsField, PI> {
+    pub trace_length: usize,
+    pub public_inputs: PI,
+    pub trace_ood_evaluations: Table<E>,
+    pub composition_poly_parts_ood_evaluation: Vec<FieldElement<E>>,
+    pub bus_public_inputs: Option<BusPublicInputs<E>>,
+    _phantom: core::marker::PhantomData<F>,
+}
+
+/// Per-query opening from all shared Merkle trees.
+#[derive(Debug, Clone)]
+pub struct BatchedQueryOpening<F: IsField, E: IsField> {
+    /// Main trace: opened row and symmetric row + Merkle proofs.
+    pub main_trace: PolynomialOpenings<F>,
+    /// Aux trace: opened row and symmetric row + Merkle proofs (if any table has aux).
+    pub aux_trace: Option<PolynomialOpenings<E>>,
+    /// Composition poly: opened values + Merkle proof.
+    pub composition_poly: PolynomialOpenings<E>,
+}
+
+/// Proof format with shared Merkle trees across all tables.
+#[derive(Debug, Clone)]
+pub struct BatchedProof<F: IsField, E: IsField, PI> {
+    /// Shared Merkle root for all tables' main trace columns.
+    pub main_merkle_root: Commitment,
+    /// Shared Merkle root for all tables' aux trace columns.
+    pub aux_merkle_root: Option<Commitment>,
+    /// Shared Merkle root for all tables' composition poly evaluations.
+    pub composition_merkle_root: Commitment,
+    /// Per-table OOD data and public inputs.
+    pub tables: Vec<TableProofData<F, E, PI>>,
+    /// Shared FRI layer roots.
+    pub fri_layers_merkle_roots: Vec<Commitment>,
+    /// Shared FRI last value.
+    pub fri_last_value: FieldElement<E>,
+    /// Shared FRI decommitments (one per query).
+    pub query_list: Vec<FriDecommitment<E>>,
+    /// Per-query openings from the shared trees.
+    pub query_openings: Vec<BatchedQueryOpening<F, E>>,
+    /// Grinding nonce.
+    pub nonce: Option<u64>,
+}

--- a/crypto/stark/src/proof/stark.rs
+++ b/crypto/stark/src/proof/stark.rs
@@ -87,7 +87,30 @@ pub struct TableProofData<F: IsField, E: IsField, PI> {
     pub trace_ood_evaluations: Table<E>,
     pub composition_poly_parts_ood_evaluation: Vec<FieldElement<E>>,
     pub bus_public_inputs: Option<BusPublicInputs<E>>,
+    /// Number of composition poly parts for this table.
+    pub num_composition_parts: usize,
     _phantom: core::marker::PhantomData<F>,
+}
+
+impl<F: IsField, E: IsField, PI> TableProofData<F, E, PI> {
+    pub fn new(
+        trace_length: usize,
+        public_inputs: PI,
+        trace_ood_evaluations: Table<E>,
+        composition_poly_parts_ood_evaluation: Vec<FieldElement<E>>,
+        bus_public_inputs: Option<BusPublicInputs<E>>,
+        num_composition_parts: usize,
+    ) -> Self {
+        Self {
+            trace_length,
+            public_inputs,
+            trace_ood_evaluations,
+            composition_poly_parts_ood_evaluation,
+            bus_public_inputs,
+            num_composition_parts,
+            _phantom: core::marker::PhantomData,
+        }
+    }
 }
 
 /// Per-query opening from all shared Merkle trees.

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -293,8 +293,8 @@ where
     F: IsField,
     FieldElement<F>: AsBytes,
 {
-    /// Evaluations of the composition polynomial parts over the LDE domain.
-    pub(crate) lde_composition_poly_evaluations: Vec<Vec<FieldElement<F>>>,
+    /// Evaluations of the composition polynomial parts over the LDE domain (2N points each).
+    pub(crate) composition_poly_evaluations: Vec<Vec<FieldElement<F>>>,
     /// The Merkle tree built to compute the commitment to the composition polynomial parts.
     pub(crate) composition_poly_merkle_tree: BatchedMerkleTree<F>,
     /// The commitment to the composition polynomial parts.
@@ -745,18 +745,12 @@ pub trait IsStarkProver<
         Some((tree, root))
     }
 
-    /// Algebraically decompose H(x) = H₀(x²) + x·H₁(x²) on the LDE coset, then
-    /// extend each half to the full LDE domain. This replaces the expensive
-    /// iFFT(2N) + break_in_parts + FFT(2N)×2 pipeline with:
-    ///   O(N) pointwise ops + iFFT(N)×2 + FFT(2N)×2
+    /// Algebraically decompose H(x) = H₀(x²) + x·H₁(x²) on the LDE coset,
+    /// returning N evaluations of each part on the squared coset {g²·θ^i}.
     ///
-    /// The identity used:
-    ///   H₀(x²) = (H(x) + H(-x)) / 2
-    ///   H₁(x²) = (H(x) - H(-x)) / (2x)
-    ///
-    /// On the LDE coset {g·ω^i | i=0..2N-1}, we have -g·ω^i = g·ω^{i+N}
-    /// since ω^N = -1 for a 2N-th root of unity ω.
-    fn decompose_and_extend_d2(
+    /// No iFFT or FFT is performed — only O(N) pointwise arithmetic.
+    /// The caller is responsible for extending these to 2N LDE points if needed.
+    fn decompose_d2(
         constraint_evaluations: &[FieldElement<FieldExtension>],
         domain: &Domain<Field>,
     ) -> Vec<Vec<FieldElement<FieldExtension>>>
@@ -809,48 +803,7 @@ pub trait IsStarkProver<
             }
         };
 
-        // Step 3: Extend each part from N evals on g²-coset to 2N evals on g-coset.
-        // The squared coset offset is g² (= coset_offset²).
-        let coset_offset_squared = &domain.coset_offset * &domain.coset_offset;
-
-        #[cfg(feature = "parallel")]
-        let (lde_h0, lde_h1) = rayon::join(
-            || Self::extend_half_to_lde(&h0_evals, &coset_offset_squared, domain),
-            || Self::extend_half_to_lde(&h1_evals, &coset_offset_squared, domain),
-        );
-
-        #[cfg(not(feature = "parallel"))]
-        let (lde_h0, lde_h1) = (
-            Self::extend_half_to_lde(&h0_evals, &coset_offset_squared, domain),
-            Self::extend_half_to_lde(&h1_evals, &coset_offset_squared, domain),
-        );
-
-        vec![lde_h0, lde_h1]
-    }
-
-    /// Given N evaluations of a degree-<N polynomial on the g²-coset,
-    /// extend to 2N evaluations on the g-coset (the full LDE domain).
-    /// This is: iFFT(N, offset=g²) → coefficients → FFT(2N, offset=g).
-    fn extend_half_to_lde(
-        half_evals: &[FieldElement<FieldExtension>],
-        squared_offset: &FieldElement<Field>,
-        domain: &Domain<Field>,
-    ) -> Vec<FieldElement<FieldExtension>>
-    where
-        FieldElement<Field>: AsBytes,
-        FieldElement<FieldExtension>: AsBytes,
-    {
-        // iFFT on the N-point squared coset to get coefficients
-        let poly = Polynomial::interpolate_offset_fft(half_evals, squared_offset)
-            .expect("iFFT should succeed");
-        // Evaluate on the full LDE domain (2N points on the g-coset)
-        evaluate_polynomial_on_lde_domain(
-            &poly,
-            domain.blowup_factor,
-            domain.interpolation_domain_size,
-            &domain.coset_offset,
-        )
-        .expect("LDE evaluation should succeed")
+        vec![h0_evals, h1_evals]
     }
 
     /// Returns the result of the second round of the STARK Prove protocol.
@@ -893,12 +846,28 @@ pub trait IsStarkProver<
         #[cfg(feature = "instruments")]
         let t_sub = Instant::now();
         let lde_composition_poly_parts_evaluations = if number_of_parts == 2 {
-            // Direct quotient decomposition: avoid full-size iFFT by algebraically
-            // splitting H(x) = H₀(x²) + x·H₁(x²) using:
-            //   H₀(x²) = (H(x) + H(-x)) / 2
-            //   H₁(x²) = (H(x) - H(-x)) / (2x)
-            // On the LDE coset {g·ω^i}, we have -g·ω^i = g·ω^{i+N} since ω^N = -1.
-            Self::decompose_and_extend_d2(&constraint_evaluations, domain)
+            // Decompose H(x) = H₀(x²) + x·H₁(x²) via O(N) pointwise ops,
+            // then extend each part from the N-point squared coset (g²) to the
+            // 2N-point LDE domain (g) via iFFT(N) + FFT(2N) per part.
+            {
+                let parts = Self::decompose_d2(&constraint_evaluations, domain);
+                let coset_offset_sq = &domain.coset_offset * &domain.coset_offset;
+                parts
+                    .into_iter()
+                    .map(|sq_evals| {
+                        let poly =
+                            Polynomial::interpolate_offset_fft(&sq_evals, &coset_offset_sq)
+                                .expect("iFFT on squared-coset evaluations");
+                        evaluate_polynomial_on_lde_domain(
+                            &poly,
+                            domain.blowup_factor,
+                            domain.interpolation_domain_size,
+                            &domain.coset_offset,
+                        )
+                        .expect("LDE evaluation")
+                    })
+                    .collect()
+            }
         } else if number_of_parts == 1 {
             // Degree bound equals trace length: constraint evals are the LDE directly.
             vec![constraint_evaluations]
@@ -938,7 +907,7 @@ pub trait IsStarkProver<
         crate::instruments::store_r2_sub(constraints_dur, fft_dur, merkle_dur);
 
         Ok(Round2 {
-            lde_composition_poly_evaluations: lde_composition_poly_parts_evaluations,
+            composition_poly_evaluations: lde_composition_poly_parts_evaluations,
             composition_poly_merkle_tree,
             composition_poly_root,
         })
@@ -956,19 +925,16 @@ pub trait IsStarkProver<
         FieldElement<Field>: AsBytes,
         FieldElement<FieldExtension>: AsBytes,
     {
-        let num_parts = round_2_result.lde_composition_poly_evaluations.len();
+        let num_parts = round_2_result.composition_poly_evaluations.len();
         let z_power = z.pow(num_parts);
         let domain_size = domain.interpolation_domain_size;
         let blowup_factor = domain.blowup_factor;
 
         // === Composition poly parts: barycentric evaluation at z^num_parts ===
-        // Extract trace-size coset points from the LDE coset (stride = blowup_factor)
-        // Keep coset points in base field — mixed F×E arithmetic is cheaper than E×E.
+        // All paths produce 2N-point LDE evaluations. Extract at stride for barycentric OOD.
         let coset_points: Vec<FieldElement<Field>> = (0..domain_size)
             .map(|i| domain.lde_roots_of_unity_coset[i * blowup_factor].clone())
             .collect();
-        // Keep coset_offset_pow_n and g_n_inv in base field F — the barycentric
-        // functions use F×E→E mixed arithmetic, avoiding field conversions.
         let coset_offset_pow_n: FieldElement<Field> = domain.coset_offset.pow(domain_size);
         let domain_size_inv: FieldElement<Field> = FieldElement::<Field>::from(domain_size as u64)
             .inv()
@@ -976,16 +942,13 @@ pub trait IsStarkProver<
         let g_n_inv: FieldElement<Field> = coset_offset_pow_n
             .inv()
             .expect("coset_offset_pow_n is non-zero");
-
-        // Precompute inv_denoms for z^num_parts (shared across all composition poly parts)
         let comp_z_pow_n = z_power.pow(domain_size);
         let comp_inv_denoms = math::polynomial::barycentric_inv_denoms(&z_power, &coset_points);
 
         let composition_poly_parts_ood_evaluation: Vec<_> = round_2_result
-            .lde_composition_poly_evaluations
+            .composition_poly_evaluations
             .iter()
             .map(|lde_evals| {
-                // Extract trace-size evaluations (stride = blowup_factor)
                 let evals: Vec<FieldElement<FieldExtension>> = (0..domain_size)
                     .map(|i| lde_evals[i * blowup_factor].clone())
                     .collect();
@@ -1037,7 +1000,7 @@ pub trait IsStarkProver<
 
         let gamma = transcript.sample_field_element();
 
-        let n_terms_composition_poly = round_2_result.lde_composition_poly_evaluations.len();
+        let n_terms_composition_poly = round_2_result.composition_poly_evaluations.len();
         let num_terms_trace =
             air.context().transition_offsets.len() * air.step_size() * air.context().trace_columns;
 
@@ -1057,10 +1020,10 @@ pub trait IsStarkProver<
         // <<<< Receive challenges: 𝛾ⱼ, 𝛾ⱼ'
         let gammas = deep_composition_coefficients;
 
-        // Compute p₀ (deep composition polynomial) as N evaluations on trace-size coset
+        // Compute full DEEP polynomial at N trace-coset points.
         #[cfg(feature = "instruments")]
         let t_sub = Instant::now();
-        let deep_evals = Self::compute_deep_composition_poly_evaluations(
+        let deep_evals = Self::compute_deep_with_composition(
             &round_1_result.lde_trace,
             round_2_result,
             round_3_result,
@@ -1074,8 +1037,6 @@ pub trait IsStarkProver<
         let other_dur_1 = t_sub.elapsed();
 
         // Extend N trace-coset evaluations to 2N LDE-coset evaluations via standard LDE.
-        // deep_evals[i] = h(offset·ω_N^i) = f(ω_N^i) where f(x) = h(offset·x).
-        // Standard iFFT+FFT recovers f and evaluates on the 2N-th roots: f(Ω^j) = h(offset·Ω^j).
         let domain_size = domain.lde_roots_of_unity_coset.len();
         #[cfg(feature = "instruments")]
         let t_sub = Instant::now();
@@ -1087,7 +1048,7 @@ pub trait IsStarkProver<
         #[cfg(feature = "instruments")]
         let r4_fft_dur = t_sub.elapsed();
 
-        // FRI commit phase from pre-computed evaluations (no initial FFT)
+        // FRI commit phase (no injection needed — composition is in the DEEP polynomial)
         #[cfg(feature = "instruments")]
         let t_sub = Instant::now();
         let (fri_last_value, fri_layers) =
@@ -1152,16 +1113,10 @@ pub trait IsStarkProver<
             .collect::<Vec<usize>>()
     }
 
-    /// Computes the DEEP composition polynomial as evaluations on the trace-size coset.
-    ///
-    /// Evaluates `deep(x_i)` at N points (every bf-th point of the LDE coset).
-    /// The caller extends to the full 2N-point LDE domain before feeding to FRI.
-    ///
-    /// The DEEP polynomial is:
-    ///   deep(X) = Σ_j γ_j * (H_j(X) - H_j(z^K)) / (X - z^K)
-    ///           + Σ_{j,k} γ'_{j,k} * (t_j(X) - t_j(z·w^k)) / (X - z·w^k)
+    /// Computes DEEP polynomial with both trace and composition terms.
+    /// Reads composition values from the Round 2 LDE evaluations at stride.
     #[allow(clippy::too_many_arguments)]
-    fn compute_deep_composition_poly_evaluations(
+    fn compute_deep_with_composition(
         lde_trace: &LDETraceTable<Field, FieldExtension>,
         round_2_result: &Round2<FieldExtension>,
         round_3_result: &Round3<FieldExtension>,
@@ -1177,17 +1132,15 @@ pub trait IsStarkProver<
     {
         let domain_size = domain.interpolation_domain_size;
         let blowup_factor = domain.blowup_factor;
-        let num_parts = round_2_result.lde_composition_poly_evaluations.len();
-        let z_power = z.pow(num_parts); // pole for H terms
+        let num_parts = round_2_result.composition_poly_evaluations.len();
+        let z_power = z.pow(num_parts);
 
-        // Number of evaluation points per trace column (= transition_offsets.len() * step_size)
         let num_eval_points = if trace_terms_gammas.is_empty() {
             0
         } else {
             trace_terms_gammas[0].len()
         };
 
-        // Trace poles: z_shifted[k] = primitive_root^k * z for k = 0..num_eval_points
         let mut z_shifted = Vec::with_capacity(num_eval_points);
         let mut current_z = z.clone();
         for _ in 0..num_eval_points {
@@ -1195,64 +1148,50 @@ pub trait IsStarkProver<
             current_z = primitive_root * &current_z;
         }
 
-        // Number of main and aux columns in the LDE trace
         let num_main_cols = lde_trace.num_main_cols();
         let num_aux_cols = lde_trace.num_aux_cols();
 
-        // Precompute all inverse denominators via batch inversion.
         let num_denoms = domain_size * (1 + num_eval_points);
         let mut denoms: Vec<FieldElement<FieldExtension>> = Vec::with_capacity(num_denoms);
-
-        // H-term denominators: x_i - z^K
         for i in 0..domain_size {
             let x_i = &domain.lde_roots_of_unity_coset[i * blowup_factor];
             denoms.push(x_i - &z_power);
         }
-
-        // Trace-term denominators: x_i - z_shifted[k]
         for z_k in z_shifted.iter().take(num_eval_points) {
             for i in 0..domain_size {
                 let x_i = &domain.lde_roots_of_unity_coset[i * blowup_factor];
                 denoms.push(x_i - z_k);
             }
         }
-
         FieldElement::inplace_batch_inverse(&mut denoms)
-            .expect("Denominators should be non-zero: coset points are base field, poles are extension field");
+            .expect("Denominators should be non-zero");
 
         let inv_h = &denoms[0..domain_size];
-
-        // OOD evaluations
         let h_ood = &round_3_result.composition_poly_parts_ood_evaluation;
         let trace_ood_columns = round_3_result.trace_ood_evaluations.columns();
 
-        // Compute deep(x_i) for each trace-size coset point
         #[cfg(feature = "parallel")]
         let iter = (0..domain_size).into_par_iter();
         #[cfg(not(feature = "parallel"))]
         let iter = 0..domain_size;
 
         iter.map(|i| {
-            let row_idx = i * blowup_factor; // LDE row index
-
-            // H terms: Σ_j γ_j * (H_j(x_i) - H_j(z^K)) * inv_h[i]
+            let row_idx = i * blowup_factor;
             let mut result = FieldElement::<FieldExtension>::zero();
+
             for j in 0..num_parts {
-                let h_j_val = &round_2_result.lde_composition_poly_evaluations[j][row_idx];
+                let h_j_val = &round_2_result.composition_poly_evaluations[j][row_idx];
                 let h_j_ood = &h_ood[j];
                 let numerator = h_j_val - h_j_ood;
                 result += &composition_poly_gammas[j] * numerator * &inv_h[i];
             }
 
-            // Trace terms: Σ_{j,k} γ'_{j,k} * (t_j(x_i) - t_j(z·w^k)) * inv_t_k[i]
             let num_total_cols = num_main_cols + num_aux_cols;
             for j in 0..num_total_cols {
                 let gammas_j = &trace_terms_gammas[j];
                 let ood_evals_j = &trace_ood_columns[j];
-
                 for k in 0..num_eval_points {
                     let inv_t_k_i = &denoms[(1 + k) * domain_size + i];
-
                     let t_j_ood = &ood_evals_j[k];
                     let numerator: FieldElement<FieldExtension> = if j < num_main_cols {
                         lde_trace.get_main(row_idx, j) - t_j_ood
@@ -1262,7 +1201,6 @@ pub trait IsStarkProver<
                     result += &gammas_j[k] * numerator * inv_t_k_i;
                 }
             }
-
             result
         })
         .collect()
@@ -1273,7 +1211,7 @@ pub trait IsStarkProver<
     /// element.
     fn open_composition_poly(
         composition_poly_merkle_tree: &BatchedMerkleTree<FieldExtension>,
-        lde_composition_poly_evaluations: &[Vec<FieldElement<FieldExtension>>],
+        composition_poly_evaluations: &[Vec<FieldElement<FieldExtension>>],
         index: usize,
     ) -> PolynomialOpenings<FieldExtension>
     where
@@ -1284,29 +1222,22 @@ pub trait IsStarkProver<
             .get_proof_by_pos(index)
             .unwrap();
 
-        let lde_composition_poly_parts_evaluation: Vec<_> = lde_composition_poly_evaluations
+        let num_evals = composition_poly_evaluations[0].len();
+        let evaluations: Vec<_> = composition_poly_evaluations
             .iter()
-            .flat_map(|part| {
-                vec![
-                    part[reverse_index(index * 2, part.len() as u64)].clone(),
-                    part[reverse_index(index * 2 + 1, part.len() as u64)].clone(),
-                ]
-            })
+            .map(|part| part[reverse_index(index * 2, num_evals as u64)].clone())
+            .collect();
+
+        let evaluations_sym: Vec<_> = composition_poly_evaluations
+            .iter()
+            .map(|part| part[reverse_index(index * 2 + 1, num_evals as u64)].clone())
             .collect();
 
         PolynomialOpenings {
             proof: proof.clone(),
             proof_sym: proof,
-            evaluations: lde_composition_poly_parts_evaluation
-                .clone()
-                .into_iter()
-                .step_by(2)
-                .collect(),
-            evaluations_sym: lde_composition_poly_parts_evaluation
-                .into_iter()
-                .skip(1)
-                .step_by(2)
-                .collect(),
+            evaluations,
+            evaluations_sym,
         }
     }
 
@@ -1449,7 +1380,7 @@ pub trait IsStarkProver<
 
             let composition_openings = Self::open_composition_poly(
                 &round_2_result.composition_poly_merkle_tree,
-                &round_2_result.lde_composition_poly_evaluations,
+                &round_2_result.composition_poly_evaluations,
                 *index,
             );
 

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -439,6 +439,31 @@ pub trait IsStarkProver<
         Ok((tree, root, layout))
     }
 
+    /// Commit all tables' composition poly parts into a shared N-point Merkle tree.
+    /// The parts are the output of `decompose_d2` — N evaluations on the squared coset.
+    /// This commits at half the domain size, skipping the 2N-point extension FFTs.
+    fn commit_composition_polys_batched(
+        per_table_parts: &[Vec<Vec<FieldElement<FieldExtension>>>],
+        trace_length: usize,
+    ) -> Result<(BatchedMerkleTree<FieldExtension>, Commitment, BatchedLayout), ProvingError>
+    where
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send + math::traits::ByteConversion,
+    {
+        let column_counts: Vec<usize> = per_table_parts.iter().map(|parts| parts.len()).collect();
+        let layout = BatchedLayout::new(&column_counts, trace_length);
+
+        let all_columns: Vec<Vec<FieldElement<FieldExtension>>> = per_table_parts
+            .iter()
+            .flat_map(|parts| parts.iter().cloned())
+            .collect();
+
+        let (tree, root) = Self::commit_columns_bit_reversed(&all_columns)
+            .ok_or(ProvingError::EmptyCommitment)?;
+
+        Ok((tree, root, layout))
+    }
+
     /// Compute the LDE commitment for a subset of columns from a trace (for testing).
     ///
     /// This helper computes the same commitment the prover generates internally,

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -24,6 +24,7 @@ use rayon::prelude::{
 
 #[cfg(feature = "debug-checks")]
 use crate::debug::validate_trace;
+use crate::batched_layout::BatchedLayout;
 use crate::domain::new_domain;
 use crate::fri;
 use crate::lookup::LOGUP_NUM_CHALLENGES;
@@ -410,6 +411,32 @@ pub trait IsStarkProver<
         let tree = BatchedMerkleTree::<E>::build_from_hashed_leaves(hashed_leaves)?;
         let root = tree.root;
         Some((tree, root))
+    }
+
+
+    /// Commit all tables' main trace columns into a single shared Merkle tree.
+    /// Columns from all tables are concatenated: [table0_col0, table0_col1, ..., table1_col0, ...].
+    /// Returns the tree, root, and a layout mapping tables to column ranges.
+    fn commit_main_traces_batched(
+        per_table_columns: &[Vec<Vec<FieldElement<Field>>>],
+        lde_size: usize,
+    ) -> Result<(BatchedMerkleTree<Field>, Commitment, BatchedLayout), ProvingError>
+    where
+        FieldElement<Field>: AsBytes + Sync + Send,
+    {
+        let column_counts: Vec<usize> = per_table_columns.iter().map(|cols| cols.len()).collect();
+        let layout = BatchedLayout::new(&column_counts, lde_size);
+
+        // Flatten all tables' columns into one contiguous Vec
+        let all_columns: Vec<Vec<FieldElement<Field>>> = per_table_columns
+            .iter()
+            .flat_map(|cols| cols.iter().cloned())
+            .collect();
+
+        let (tree, root) = Self::commit_columns_bit_reversed(&all_columns)
+            .ok_or(ProvingError::EmptyCommitment)?;
+
+        Ok((tree, root, layout))
     }
 
     /// Compute the LDE commitment for a subset of columns from a trace (for testing).

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -38,7 +38,10 @@ use super::domain::Domain;
 use super::fri::fri_decommit::FriDecommitment;
 use super::grinding;
 use super::lookup::BusPublicInputs;
-use super::proof::stark::{DeepPolynomialOpening, MultiProof, StarkProof};
+use super::proof::stark::{
+    BatchedProof, BatchedQueryOpening, DeepPolynomialOpening, MultiProof, StarkProof,
+    TableProofData,
+};
 use super::trace::TraceTable;
 use super::traits::AIR;
 
@@ -1258,6 +1261,99 @@ pub trait IsStarkProver<
         .collect()
     }
 
+    /// Like `compute_deep_with_composition` but takes composition poly evaluations directly
+    /// instead of a `Round2` struct. Used by `multi_prove_batched` which doesn't build per-table Round2.
+    #[allow(clippy::too_many_arguments)]
+    fn compute_deep_with_composition_from_evals(
+        lde_trace: &LDETraceTable<Field, FieldExtension>,
+        composition_poly_evaluations: &[Vec<FieldElement<FieldExtension>>],
+        round_3_result: &Round3<FieldExtension>,
+        z: &FieldElement<FieldExtension>,
+        domain: &Domain<Field>,
+        primitive_root: &FieldElement<Field>,
+        composition_poly_gammas: &[FieldElement<FieldExtension>],
+        trace_terms_gammas: &[Vec<FieldElement<FieldExtension>>],
+    ) -> Vec<FieldElement<FieldExtension>>
+    where
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
+    {
+        let domain_size = domain.interpolation_domain_size;
+        let blowup_factor = domain.blowup_factor;
+        let num_parts = composition_poly_evaluations.len();
+        let z_power = z.pow(num_parts);
+
+        let num_eval_points = if trace_terms_gammas.is_empty() {
+            0
+        } else {
+            trace_terms_gammas[0].len()
+        };
+
+        let mut z_shifted = Vec::with_capacity(num_eval_points);
+        let mut current_z = z.clone();
+        for _ in 0..num_eval_points {
+            z_shifted.push(current_z.clone());
+            current_z = primitive_root * &current_z;
+        }
+
+        let num_main_cols = lde_trace.num_main_cols();
+        let num_aux_cols = lde_trace.num_aux_cols();
+
+        let num_denoms = domain_size * (1 + num_eval_points);
+        let mut denoms: Vec<FieldElement<FieldExtension>> = Vec::with_capacity(num_denoms);
+        for i in 0..domain_size {
+            let x_i = &domain.lde_roots_of_unity_coset[i * blowup_factor];
+            denoms.push(x_i - &z_power);
+        }
+        for z_k in z_shifted.iter().take(num_eval_points) {
+            for i in 0..domain_size {
+                let x_i = &domain.lde_roots_of_unity_coset[i * blowup_factor];
+                denoms.push(x_i - z_k);
+            }
+        }
+        FieldElement::inplace_batch_inverse(&mut denoms)
+            .expect("Denominators should be non-zero");
+
+        let inv_h = &denoms[0..domain_size];
+        let h_ood = &round_3_result.composition_poly_parts_ood_evaluation;
+        let trace_ood_columns = round_3_result.trace_ood_evaluations.columns();
+
+        #[cfg(feature = "parallel")]
+        let iter = (0..domain_size).into_par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let iter = 0..domain_size;
+
+        iter.map(|i| {
+            let row_idx = i * blowup_factor;
+            let mut result = FieldElement::<FieldExtension>::zero();
+
+            for j in 0..num_parts {
+                let h_j_val = &composition_poly_evaluations[j][row_idx];
+                let h_j_ood = &h_ood[j];
+                let numerator = h_j_val - h_j_ood;
+                result += &composition_poly_gammas[j] * numerator * &inv_h[i];
+            }
+
+            let num_total_cols = num_main_cols + num_aux_cols;
+            for j in 0..num_total_cols {
+                let gammas_j = &trace_terms_gammas[j];
+                let ood_evals_j = &trace_ood_columns[j];
+                for k in 0..num_eval_points {
+                    let inv_t_k_i = &denoms[(1 + k) * domain_size + i];
+                    let t_j_ood = &ood_evals_j[k];
+                    let numerator: FieldElement<FieldExtension> = if j < num_main_cols {
+                        lde_trace.get_main(row_idx, j) - t_j_ood
+                    } else {
+                        lde_trace.get_aux(row_idx, j - num_main_cols) - t_j_ood
+                    };
+                    result += &gammas_j[k] * numerator * inv_t_k_i;
+                }
+            }
+            result
+        })
+        .collect()
+    }
+
     /// Computes values and validity proofs of the evaluations of the composition polynomial parts
     /// at the domain value corresponding to the FRI query challenge `index` and its symmetric
     /// element.
@@ -1874,6 +1970,686 @@ pub trait IsStarkProver<
         let air_trace_pairs = vec![(air, trace, pub_inputs)];
         Self::multi_prove(air_trace_pairs, transcript)
             .map(|mut multi_proof| multi_proof.proofs.remove(0))
+    }
+
+    /// Generates a batched STARK proof for multiple AIRs with shared Merkle trees and shared FRI.
+    ///
+    /// Unlike `multi_prove` which creates independent proofs per table, this function:
+    /// - Commits all tables' main traces in ONE shared Merkle tree
+    /// - Commits all tables' auxiliary traces in ONE shared Merkle tree
+    /// - Commits all tables' composition polys in ONE shared Merkle tree
+    /// - Runs ONE shared FRI instance over alpha-batched DEEP polynomials
+    ///
+    /// Assumption: all tables share the same trace length (uniform table sizing).
+    fn multi_prove_batched(
+        mut air_trace_pairs: Vec<AirTracePair<'_, Field, FieldExtension, PI>>,
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone + Send),
+    ) -> Result<BatchedProof<Field, FieldExtension, PI>, ProvingError>
+    where
+        FieldElement<Field>: AsBytes,
+        FieldElement<FieldExtension>: AsBytes,
+        PI: Send + Sync + Clone,
+    {
+        let num_airs = air_trace_pairs.len();
+        assert!(num_airs > 0, "multi_prove_batched requires at least one AIR");
+
+        let needs_lookup_challenges = air_trace_pairs
+            .iter()
+            .any(|(air, _, _)| air.has_aux_trace());
+
+        // =====================================================================
+        // Pre-pass: compute domains and twiddles (all tables same trace length)
+        // =====================================================================
+
+        let mut domains = Vec::with_capacity(num_airs);
+        let mut twiddle_caches: Vec<LdeTwiddles<Field>> = Vec::with_capacity(num_airs);
+
+        for (air, trace, _) in &*air_trace_pairs {
+            let trace_length = trace.num_rows();
+            let domain = new_domain(*air, trace_length);
+            let twiddles = LdeTwiddles::new(&domain);
+            domains.push(domain);
+            twiddle_caches.push(twiddles);
+        }
+
+        // =====================================================================
+        // Phase A: Build all main trace LDEs and commit in ONE shared tree
+        // =====================================================================
+
+        let mut all_main_ldes: Vec<Vec<Vec<FieldElement<Field>>>> = Vec::with_capacity(num_airs);
+        for (idx, (_air, trace, _)) in air_trace_pairs.iter().enumerate() {
+            let domain = &domains[idx];
+            let twiddles = &twiddle_caches[idx];
+            let lde_size = domain.interpolation_domain_size * domain.blowup_factor;
+            let mut columns = trace.extract_columns_main(lde_size);
+            Self::expand_columns_to_lde::<Field>(&mut columns, domain, twiddles);
+            all_main_ldes.push(columns);
+        }
+
+        let lde_size = domains[0].interpolation_domain_size * domains[0].blowup_factor;
+        let per_table_main_refs: Vec<Vec<Vec<FieldElement<Field>>>> = all_main_ldes.to_vec();
+        let (main_tree, main_root, main_layout) =
+            Self::commit_main_traces_batched(&per_table_main_refs, lde_size)?;
+        let main_tree = Arc::new(main_tree);
+
+        // >>>> Append shared main root to transcript
+        transcript.append_bytes(&main_root);
+
+        // =====================================================================
+        // Phase B: Sample shared LogUp challenges
+        // =====================================================================
+
+        let lookup_challenges: Vec<FieldElement<FieldExtension>> = if needs_lookup_challenges {
+            (0..LOGUP_NUM_CHALLENGES)
+                .map(|_| transcript.sample_field_element())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // Build auxiliary traces
+        let bus_inputs_vec: Vec<Option<BusPublicInputs<FieldExtension>>> = air_trace_pairs
+            .iter_mut()
+            .map(|(air, trace, _)| {
+                if air.has_aux_trace() {
+                    air.build_auxiliary_trace(*trace, &lookup_challenges)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // =====================================================================
+        // Phase C: Build all aux trace LDEs and commit in ONE shared tree
+        // =====================================================================
+
+        let mut all_aux_ldes: Vec<Vec<Vec<FieldElement<FieldExtension>>>> = Vec::with_capacity(num_airs);
+        let has_any_aux = air_trace_pairs.iter().any(|(air, _, _)| air.has_aux_trace());
+
+        for (idx, (air, trace, _)) in air_trace_pairs.iter().enumerate() {
+            if air.has_aux_trace() {
+                let domain = &domains[idx];
+                let twiddles = &twiddle_caches[idx];
+                let lde_size = domain.interpolation_domain_size * domain.blowup_factor;
+                let mut columns = trace.extract_columns_aux(lde_size);
+                Self::expand_columns_to_lde::<FieldExtension>(&mut columns, domain, twiddles);
+                all_aux_ldes.push(columns);
+            } else {
+                all_aux_ldes.push(Vec::new());
+            }
+        }
+
+        let (aux_tree, aux_root) = if has_any_aux {
+            // Commit all aux columns in one shared tree
+            let aux_column_counts: Vec<usize> = all_aux_ldes.iter().map(|cols| cols.len()).collect();
+            let aux_layout = BatchedLayout::new(&aux_column_counts, lde_size);
+            let all_aux_columns: Vec<Vec<FieldElement<FieldExtension>>> = all_aux_ldes
+                .iter()
+                .flat_map(|cols| cols.iter().cloned())
+                .collect();
+
+            if all_aux_columns.is_empty() {
+                (None, None)
+            } else {
+                let (tree, root) = Self::commit_columns_bit_reversed(&all_aux_columns)
+                    .ok_or(ProvingError::EmptyCommitment)?;
+                let _ = aux_layout; // layout stored for query phase
+                (Some(Arc::new(tree)), Some(root))
+            }
+        } else {
+            (None, None)
+        };
+
+        if let Some(ref root) = aux_root {
+            transcript.append_bytes(root);
+        }
+
+        // =====================================================================
+        // Fork transcripts per table (same as multi_prove)
+        // =====================================================================
+
+        let mut table_transcripts: Vec<_> = (0..num_airs)
+            .map(|idx| {
+                let mut t = transcript.clone();
+                if num_airs > 1 {
+                    t.append_bytes(&(idx as u64).to_le_bytes());
+                }
+                t
+            })
+            .collect();
+
+        // Bind bus_public_inputs to each table's transcript
+        for (idx, bpi) in bus_inputs_vec.iter().enumerate() {
+            if let Some(bpi) = bpi {
+                table_transcripts[idx].append_field_element(&bpi.table_contribution);
+            }
+        }
+
+        // =====================================================================
+        // Round 2: Evaluate constraints per table, commit composition in shared tree
+        // =====================================================================
+
+        // Build Round1 structures for constraint evaluation (per-table)
+        let mut per_table_round1: Vec<Round1<Field, FieldExtension>> = Vec::with_capacity(num_airs);
+        for idx in 0..num_airs {
+            let (air, _, _) = &air_trace_pairs[idx];
+            let domain = &domains[idx];
+            let main_lde = std::mem::take(&mut all_main_ldes[idx]);
+            let aux_lde = std::mem::take(&mut all_aux_ldes[idx]);
+
+            let lde_trace = LDETraceTable::from_columns(
+                main_lde,
+                aux_lde,
+                air.step_size(),
+                domain.blowup_factor,
+            );
+
+            // Build minimal Round1CommitmentData (trees not needed for constraint eval)
+            let main_commit = Round1CommitmentData::<Field> {
+                lde_trace_merkle_tree: Arc::clone(&main_tree),
+                lde_trace_merkle_root: main_root,
+                precomputed_merkle_tree: None,
+                precomputed_merkle_root: None,
+                num_precomputed_cols: 0,
+            };
+
+            let aux_commit = if air.has_aux_trace() {
+                Some(Round1CommitmentData::<FieldExtension> {
+                    lde_trace_merkle_tree: aux_tree
+                        .as_ref()
+                        .map(Arc::clone)
+                        .expect("aux tree must exist"),
+                    lde_trace_merkle_root: aux_root.expect("aux root must exist"),
+                    precomputed_merkle_tree: None,
+                    precomputed_merkle_root: None,
+                    num_precomputed_cols: 0,
+                })
+            } else {
+                None
+            };
+
+            per_table_round1.push(Round1 {
+                lde_trace,
+                main: main_commit,
+                aux: aux_commit,
+                rap_challenges: lookup_challenges.clone(),
+                bus_public_inputs: bus_inputs_vec[idx].clone(),
+            });
+        }
+
+        // Evaluate constraints and get composition poly parts per table
+        let mut per_table_comp_evals: Vec<Vec<Vec<FieldElement<FieldExtension>>>> =
+            Vec::with_capacity(num_airs);
+        let mut per_table_num_parts: Vec<usize> = Vec::with_capacity(num_airs);
+
+        for idx in 0..num_airs {
+            let (air, _, pub_inputs) = &air_trace_pairs[idx];
+            let domain = &domains[idx];
+            let round_1 = &per_table_round1[idx];
+
+            // Sample beta from per-table transcript
+            let beta: FieldElement<FieldExtension> = table_transcripts[idx].sample_field_element();
+            let trace_length = domain.interpolation_domain_size;
+            let num_boundary_constraints = air
+                .boundary_constraints(
+                    *pub_inputs,
+                    &round_1.rap_challenges,
+                    round_1.bus_public_inputs.as_ref(),
+                    trace_length,
+                )
+                .constraints
+                .len();
+
+            let num_transition_constraints = air.context().num_transition_constraints;
+            let mut coefficients: Vec<FieldElement<FieldExtension>> =
+                core::iter::successors(Some(FieldElement::one()), |x| Some(x * &beta))
+                    .take(num_boundary_constraints + num_transition_constraints)
+                    .collect();
+            let transition_coefficients: Vec<_> =
+                coefficients.drain(..num_transition_constraints).collect();
+            let boundary_coefficients = coefficients;
+
+            // Evaluate constraints
+            let evaluator = ConstraintEvaluator::new(
+                *air,
+                *pub_inputs,
+                &round_1.rap_challenges,
+                round_1.bus_public_inputs.as_ref(),
+                trace_length,
+            );
+            let constraint_evaluations = evaluator.evaluate(
+                *air,
+                &round_1.lde_trace,
+                domain,
+                &transition_coefficients,
+                &boundary_coefficients,
+                &round_1.rap_challenges,
+            );
+
+            let number_of_parts =
+                air.composition_poly_degree_bound(trace_length) / trace_length;
+            per_table_num_parts.push(number_of_parts);
+
+            // Decompose and extend to 2N-point LDE evaluations
+            let lde_comp_parts = if number_of_parts == 2 {
+                let parts = Self::decompose_d2(&constraint_evaluations, domain);
+                let coset_offset_sq = &domain.coset_offset * &domain.coset_offset;
+                parts
+                    .into_iter()
+                    .map(|sq_evals| {
+                        let poly =
+                            Polynomial::interpolate_offset_fft(&sq_evals, &coset_offset_sq)
+                                .expect("iFFT on squared-coset evaluations");
+                        evaluate_polynomial_on_lde_domain(
+                            &poly,
+                            domain.blowup_factor,
+                            domain.interpolation_domain_size,
+                            &domain.coset_offset,
+                        )
+                        .expect("LDE evaluation")
+                    })
+                    .collect()
+            } else if number_of_parts == 1 {
+                vec![constraint_evaluations]
+            } else {
+                let composition_poly = Polynomial::interpolate_offset_fft(
+                    &constraint_evaluations,
+                    &domain.coset_offset,
+                )
+                .unwrap();
+                let composition_poly_parts = composition_poly.break_in_parts(number_of_parts);
+                composition_poly_parts
+                    .iter()
+                    .map(|part| {
+                        evaluate_polynomial_on_lde_domain(
+                            part,
+                            domain.blowup_factor,
+                            domain.interpolation_domain_size,
+                            &domain.coset_offset,
+                        )
+                        .unwrap()
+                    })
+                    .collect()
+            };
+
+            per_table_comp_evals.push(lde_comp_parts);
+        }
+
+        // Commit all composition polys in ONE shared tree (2N-point evaluations)
+        let all_comp_columns: Vec<Vec<FieldElement<FieldExtension>>> = per_table_comp_evals
+            .iter()
+            .flat_map(|parts| parts.iter().cloned())
+            .collect();
+        let comp_column_counts: Vec<usize> =
+            per_table_comp_evals.iter().map(|parts| parts.len()).collect();
+        let comp_layout = BatchedLayout::new(
+            &comp_column_counts,
+            domains[0].interpolation_domain_size * domains[0].blowup_factor,
+        );
+
+        let (comp_tree, comp_root) =
+            Self::commit_composition_polynomial(&all_comp_columns)
+                .ok_or(ProvingError::EmptyCommitment)?;
+        let comp_tree = Arc::new(comp_tree);
+
+        // Append composition root to each table's transcript
+        for t in table_transcripts.iter_mut() {
+            t.append_bytes(&comp_root);
+        }
+
+        // =====================================================================
+        // Round 3: OOD evaluations per table
+        // =====================================================================
+
+        let mut per_table_z: Vec<FieldElement<FieldExtension>> = Vec::with_capacity(num_airs);
+        let mut per_table_round3: Vec<Round3<FieldExtension>> = Vec::with_capacity(num_airs);
+
+        for idx in 0..num_airs {
+            let (air, _, _) = &air_trace_pairs[idx];
+            let domain = &domains[idx];
+            let round_1 = &per_table_round1[idx];
+
+            let z = table_transcripts[idx].sample_z_ood(
+                &domain.lde_roots_of_unity_coset,
+                &domain.trace_roots_of_unity,
+            );
+
+            // OOD evaluation of composition poly parts via barycentric on 2N LDE
+            let num_parts = per_table_num_parts[idx];
+            let z_power = z.pow(num_parts);
+            let domain_size = domain.interpolation_domain_size;
+            let blowup_factor = domain.blowup_factor;
+
+            let coset_points: Vec<FieldElement<Field>> = (0..domain_size)
+                .map(|i| domain.lde_roots_of_unity_coset[i * blowup_factor].clone())
+                .collect();
+            let coset_offset_pow_n: FieldElement<Field> =
+                domain.coset_offset.pow(domain_size);
+            let domain_size_inv: FieldElement<Field> =
+                FieldElement::<Field>::from(domain_size as u64)
+                    .inv()
+                    .expect("domain_size is a power of two");
+            let g_n_inv: FieldElement<Field> = coset_offset_pow_n
+                .inv()
+                .expect("coset_offset_pow_n is non-zero");
+            let comp_z_pow_n = z_power.pow(domain_size);
+            let comp_inv_denoms =
+                math::polynomial::barycentric_inv_denoms(&z_power, &coset_points);
+
+            let composition_poly_parts_ood_evaluation: Vec<_> = per_table_comp_evals[idx]
+                .iter()
+                .map(|lde_evals| {
+                    let evals: Vec<FieldElement<FieldExtension>> = (0..domain_size)
+                        .map(|i| lde_evals[i * blowup_factor].clone())
+                        .collect();
+                    math::polynomial::interpolate_coset_eval_ext_with_g_n_inv(
+                        &comp_z_pow_n,
+                        &coset_offset_pow_n,
+                        &domain_size_inv,
+                        &g_n_inv,
+                        &coset_points,
+                        &evals,
+                        &comp_inv_denoms,
+                    )
+                })
+                .collect();
+
+            let trace_ood_evaluations = crate::trace::get_trace_evaluations_from_lde(
+                &round_1.lde_trace,
+                domain,
+                &z,
+                &air.context().transition_offsets,
+                air.step_size(),
+            );
+
+            per_table_z.push(z.clone());
+
+            // Append OOD values to transcript
+            let trace_ood_columns = trace_ood_evaluations.columns();
+            for col in trace_ood_columns.iter() {
+                for elem in col.iter() {
+                    table_transcripts[idx].append_field_element(elem);
+                }
+            }
+            for element in composition_poly_parts_ood_evaluation.iter() {
+                table_transcripts[idx].append_field_element(element);
+            }
+
+            per_table_round3.push(Round3 {
+                trace_ood_evaluations,
+                composition_poly_parts_ood_evaluation,
+            });
+        }
+
+        // =====================================================================
+        // Round 4: Compute per-table DEEP polys, alpha-batch, run shared FRI
+        // =====================================================================
+
+        // For each table, compute the full DEEP polynomial (trace + composition)
+        // at N trace-coset points, then combine.
+        let domain_size = domains[0].interpolation_domain_size;
+        let blowup_factor = domains[0].blowup_factor;
+        let lde_domain_size = domain_size * blowup_factor;
+
+        // Sample per-table gamma and compute deep coefficients
+        let mut per_table_deep_evals: Vec<Vec<FieldElement<FieldExtension>>> =
+            Vec::with_capacity(num_airs);
+
+        for idx in 0..num_airs {
+            let (air, _, _) = &air_trace_pairs[idx];
+            let domain = &domains[idx];
+            let round_1 = &per_table_round1[idx];
+            let round_3 = &per_table_round3[idx];
+            let z = &per_table_z[idx];
+
+            let gamma: FieldElement<FieldExtension> =
+                table_transcripts[idx].sample_field_element();
+
+            let n_terms_composition_poly = per_table_comp_evals[idx].len();
+            let num_terms_trace = air.context().transition_offsets.len()
+                * air.step_size()
+                * air.context().trace_columns;
+
+            let mut deep_composition_coefficients: Vec<_> =
+                core::iter::successors(Some(FieldElement::one()), |x| Some(x * &gamma))
+                    .take(n_terms_composition_poly + num_terms_trace)
+                    .collect();
+
+            let trace_term_coeffs: Vec<_> = deep_composition_coefficients
+                .drain(..num_terms_trace)
+                .collect::<Vec<_>>()
+                .chunks(air.context().transition_offsets.len() * air.step_size())
+                .map(|chunk| chunk.to_vec())
+                .collect();
+
+            let gammas = deep_composition_coefficients;
+
+            // Compute full DEEP polynomial (trace + composition) at N trace-coset points
+            let deep_evals = Self::compute_deep_with_composition_from_evals(
+                &round_1.lde_trace,
+                &per_table_comp_evals[idx],
+                round_3,
+                z,
+                domain,
+                &domain.trace_primitive_root,
+                &gammas,
+                &trace_term_coeffs,
+            );
+
+            per_table_deep_evals.push(deep_evals);
+        }
+
+        // Alpha-batch all tables' DEEP evaluations
+        // Sample a fresh alpha challenge from a combined transcript
+        // We use the first table's transcript and add a domain separator
+        let alpha: FieldElement<FieldExtension> = {
+            // Build alpha from a shared state: hash all table transcripts' states together
+            let mut alpha_transcript = table_transcripts[0].clone();
+            for t in table_transcripts.iter().skip(1) {
+                let state = t.state();
+                alpha_transcript.append_bytes(&state);
+            }
+            alpha_transcript.sample_field_element()
+        };
+
+        // Combine: batched[i] = sum_t alpha^t * deep_t[i]
+        let mut batched_deep = vec![FieldElement::<FieldExtension>::zero(); domain_size];
+        let mut alpha_power = FieldElement::<FieldExtension>::one();
+        for deep_evals in &per_table_deep_evals {
+            for (i, eval) in deep_evals.iter().enumerate() {
+                batched_deep[i] = &batched_deep[i] + &alpha_power * eval;
+            }
+            alpha_power = &alpha_power * &alpha;
+        }
+
+        // Extend to 2N via iFFT + FFT
+        let deep_poly =
+            Polynomial::interpolate_fft::<Field>(&batched_deep).expect("iFFT should succeed");
+        let mut lde_evals =
+            Polynomial::evaluate_fft::<Field>(&deep_poly, 1, Some(lde_domain_size))
+                .expect("FFT should succeed");
+        in_place_bit_reverse_permute(&mut lde_evals);
+
+        // Run shared FRI
+        let coset_offset = FieldElement::<Field>::from(
+            air_trace_pairs[0].0.context().proof_options.coset_offset,
+        );
+
+        // We need a combined transcript for FRI. Use alpha_transcript state as basis.
+        let mut fri_transcript = {
+            let mut t = table_transcripts[0].clone();
+            for table_t in table_transcripts.iter().skip(1) {
+                let state = table_t.state();
+                t.append_bytes(&state);
+            }
+            t
+        };
+
+        // Append alpha to FRI transcript to bind it
+        fri_transcript.append_field_element(&alpha);
+
+        let (fri_last_value, fri_layers) =
+            fri::commit_phase_from_evaluations::<Field, FieldExtension>(
+                domains[0].root_order as usize,
+                lde_evals,
+                &mut fri_transcript,
+                &coset_offset,
+                lde_domain_size,
+            );
+
+        // Grinding
+        let security_bits = air_trace_pairs[0].0.context().proof_options.grinding_factor;
+        let mut nonce = None;
+        if security_bits > 0 {
+            let nonce_value = grinding::generate_nonce(&fri_transcript.state(), security_bits)
+                .expect("nonce not found");
+            fri_transcript.append_bytes(&nonce_value.to_be_bytes());
+            nonce = Some(nonce_value);
+        }
+
+        // Query phase
+        let number_of_queries = air_trace_pairs[0].0.options().fri_number_of_queries;
+        let iotas = Self::sample_query_indexes(number_of_queries, &domains[0], &mut fri_transcript);
+
+        let query_list = fri::query_phase(&fri_layers, &iotas);
+
+        let fri_layers_merkle_roots: Vec<_> = fri_layers
+            .iter()
+            .map(|layer| layer.merkle_tree.root)
+            .collect();
+
+        // =====================================================================
+        // Open shared trees at query points
+        // =====================================================================
+
+        let aux_column_counts: Vec<usize> = per_table_round1
+            .iter()
+            .map(|r1| r1.lde_trace.num_aux_cols())
+            .collect();
+        let aux_layout = BatchedLayout::new(&aux_column_counts, lde_size);
+
+        let mut query_openings: Vec<BatchedQueryOpening<Field, FieldExtension>> =
+            Vec::with_capacity(iotas.len());
+
+        for &iota in &iotas {
+            let index = iota * 2;
+            let index_sym = iota * 2 + 1;
+
+            // Open shared main tree
+            let main_proof = main_tree.get_proof_by_pos(index).unwrap();
+            let main_proof_sym = main_tree.get_proof_by_pos(index_sym).unwrap();
+
+            // Gather evaluations from LDE columns (all tables concatenated)
+            let mut main_evals = Vec::with_capacity(main_layout.total_columns);
+            let mut main_evals_sym = Vec::with_capacity(main_layout.total_columns);
+            let br_idx = reverse_index(index, lde_size as u64);
+            let br_idx_sym = reverse_index(index_sym, lde_size as u64);
+
+            for r1 in &per_table_round1 {
+                for col_idx in 0..r1.lde_trace.num_main_cols() {
+                    main_evals.push(r1.lde_trace.get_main(br_idx, col_idx).clone());
+                    main_evals_sym.push(r1.lde_trace.get_main(br_idx_sym, col_idx).clone());
+                }
+            }
+
+            let main_opening = PolynomialOpenings {
+                proof: main_proof,
+                proof_sym: main_proof_sym,
+                evaluations: main_evals,
+                evaluations_sym: main_evals_sym,
+            };
+
+            // Open shared aux tree
+            let aux_opening = if let Some(ref aux_tree) = aux_tree {
+                let aux_proof = aux_tree.get_proof_by_pos(index).unwrap();
+                let aux_proof_sym = aux_tree.get_proof_by_pos(index_sym).unwrap();
+
+                let mut aux_evals =
+                    Vec::with_capacity(aux_layout.total_columns);
+                let mut aux_evals_sym =
+                    Vec::with_capacity(aux_layout.total_columns);
+
+                for r1 in &per_table_round1 {
+                    for col_idx in 0..r1.lde_trace.num_aux_cols() {
+                        aux_evals.push(r1.lde_trace.get_aux(br_idx, col_idx).clone());
+                        aux_evals_sym
+                            .push(r1.lde_trace.get_aux(br_idx_sym, col_idx).clone());
+                    }
+                }
+
+                Some(PolynomialOpenings {
+                    proof: aux_proof,
+                    proof_sym: aux_proof_sym,
+                    evaluations: aux_evals,
+                    evaluations_sym: aux_evals_sym,
+                })
+            } else {
+                None
+            };
+
+            // Open shared composition tree
+            let num_comp_evals = per_table_comp_evals[0][0].len();
+            let comp_proof = comp_tree.get_proof_by_pos(iota).unwrap();
+
+            let mut comp_evals = Vec::with_capacity(comp_layout.total_columns);
+            let mut comp_evals_sym = Vec::with_capacity(comp_layout.total_columns);
+
+            for parts in &per_table_comp_evals {
+                for part in parts {
+                    comp_evals.push(
+                        part[reverse_index(iota * 2, num_comp_evals as u64)].clone(),
+                    );
+                    comp_evals_sym.push(
+                        part[reverse_index(iota * 2 + 1, num_comp_evals as u64)].clone(),
+                    );
+                }
+            }
+
+            let comp_opening = PolynomialOpenings {
+                proof: comp_proof.clone(),
+                proof_sym: comp_proof,
+                evaluations: comp_evals,
+                evaluations_sym: comp_evals_sym,
+            };
+
+            query_openings.push(BatchedQueryOpening {
+                main_trace: main_opening,
+                aux_trace: aux_opening,
+                composition_poly: comp_opening,
+            });
+        }
+
+        // =====================================================================
+        // Build the proof
+        // =====================================================================
+
+        let tables: Vec<TableProofData<Field, FieldExtension, PI>> = (0..num_airs)
+            .map(|idx| {
+                let (_, _, pub_inputs) = &air_trace_pairs[idx];
+                TableProofData::new(
+                    domains[idx].interpolation_domain_size,
+                    (*pub_inputs).clone(),
+                    per_table_round3[idx].trace_ood_evaluations.clone(),
+                    per_table_round3[idx]
+                        .composition_poly_parts_ood_evaluation
+                        .clone(),
+                    per_table_round1[idx].bus_public_inputs.clone(),
+                    per_table_num_parts[idx],
+                )
+            })
+            .collect();
+
+        Ok(BatchedProof {
+            main_merkle_root: main_root,
+            aux_merkle_root: aux_root,
+            composition_merkle_root: comp_root,
+            tables,
+            fri_layers_merkle_roots,
+            fri_last_value,
+            query_list,
+            query_openings,
+            nonce,
+        })
     }
 
     // TODO: propagate errors instead of unwrap() in open_deep_composition_poly and FRI operations

--- a/crypto/stark/src/tests/batched_tests.rs
+++ b/crypto/stark/src/tests/batched_tests.rs
@@ -43,3 +43,53 @@ fn test_batched_main_trace_commit_and_open() {
         .collect();
     assert!(proof.verify::<BatchedMerkleTreeBackend<GoldilocksField>>(&root, 0, &opened_row));
 }
+
+#[test]
+fn test_batched_composition_commit_n_point() {
+    use math::field::extensions_goldilocks::Degree3GoldilocksExtensionField;
+    type FeltExt = FieldElement<Degree3GoldilocksExtensionField>;
+
+    // Create fake composition parts for 2 tables (each has 2 parts of N=8 evals)
+    let n = 8usize;
+    let table0_parts: Vec<Vec<FeltExt>> = (0..2)
+        .map(|p| {
+            (0..n)
+                .map(|i| FeltExt::from((p * 100 + i) as u64))
+                .collect()
+        })
+        .collect();
+    let table1_parts: Vec<Vec<FeltExt>> = (0..2)
+        .map(|p| {
+            (0..n)
+                .map(|i| FeltExt::from((p * 200 + i) as u64))
+                .collect()
+        })
+        .collect();
+
+    let per_table = vec![table0_parts.clone(), table1_parts.clone()];
+    let (tree, root, layout) =
+        Prover::<GoldilocksField, Degree3GoldilocksExtensionField, ()>::commit_composition_polys_batched(
+            &per_table, n,
+        )
+        .expect("Commit should succeed");
+
+    // Layout: 2 + 2 = 4 total columns, domain_size = N (not 2N)
+    assert_eq!(layout.total_columns, 4);
+    assert_eq!(layout.domain_size, n);
+    assert_eq!(layout.table_ranges, vec![(0, 2), (2, 4)]);
+
+    // Open at index 0 and verify the Merkle proof
+    let proof = tree
+        .get_proof_by_pos(0)
+        .expect("Should get proof at index 0");
+    let br_0 = math::fft::cpu::bit_reversing::reverse_index(0, n as u64);
+    let opened_row: Vec<FeltExt> = vec![
+        table0_parts[0][br_0].clone(),
+        table0_parts[1][br_0].clone(),
+        table1_parts[0][br_0].clone(),
+        table1_parts[1][br_0].clone(),
+    ];
+    assert!(proof.verify::<BatchedMerkleTreeBackend<Degree3GoldilocksExtensionField>>(
+        &root, 0, &opened_row
+    ));
+}

--- a/crypto/stark/src/tests/batched_tests.rs
+++ b/crypto/stark/src/tests/batched_tests.rs
@@ -1,0 +1,45 @@
+use math::field::element::FieldElement;
+use math::field::goldilocks::GoldilocksField;
+
+use crate::config::BatchedMerkleTreeBackend;
+use crate::prover::{IsStarkProver, Prover};
+
+type Felt = FieldElement<GoldilocksField>;
+
+#[test]
+fn test_batched_main_trace_commit_and_open() {
+    // Create two "tables" with different column counts
+    let lde_size = 8;
+    let table0_cols: Vec<Vec<Felt>> = (0..3)
+        .map(|c| (0..lde_size).map(|r| Felt::from((c * 100 + r) as u64)).collect())
+        .collect();
+    let table1_cols: Vec<Vec<Felt>> = (0..2)
+        .map(|c| (0..lde_size).map(|r| Felt::from((c * 200 + r) as u64)).collect())
+        .collect();
+
+    let per_table = vec![table0_cols.clone(), table1_cols.clone()];
+    let (tree, root, layout) =
+        Prover::<GoldilocksField, GoldilocksField, ()>::commit_main_traces_batched(
+            &per_table, lde_size,
+        )
+        .expect("Commit should succeed");
+
+    // Layout should track 3 + 2 = 5 total columns
+    assert_eq!(layout.total_columns, 5);
+    assert_eq!(layout.table_ranges, vec![(0, 3), (3, 5)]);
+
+    // Open at index 0 and verify the Merkle proof
+    let proof = tree.get_proof_by_pos(0).expect("Should get proof at index 0");
+    // The leaf at position 0 was built from column values at bit-reversed row 0
+    let br_0 = math::fft::cpu::bit_reversing::reverse_index(0, lde_size as u64);
+    let opened_row: Vec<Felt> = (0..5)
+        .map(|c| {
+            if c < 3 {
+                table0_cols[c][br_0].clone()
+            } else {
+                table1_cols[c - 3][br_0].clone()
+            }
+        })
+        .collect();
+    assert!(proof.verify::<BatchedMerkleTreeBackend<GoldilocksField>>(&root, 0, &opened_row));
+}

--- a/crypto/stark/src/tests/batched_tests.rs
+++ b/crypto/stark/src/tests/batched_tests.rs
@@ -1,8 +1,17 @@
+use crypto::fiat_shamir::default_transcript::DefaultTranscript;
 use math::field::element::FieldElement;
+use math::field::extensions_goldilocks::Degree3GoldilocksExtensionField;
 use math::field::goldilocks::GoldilocksField;
 
 use crate::config::BatchedMerkleTreeBackend;
+use crate::examples::multi_table_lookup::{
+    new_add_air_with_lookup, new_cpu_air_with_lookup, new_mul_air_with_lookup,
+};
+use crate::proof::options::ProofOptions;
 use crate::prover::{IsStarkProver, Prover};
+use crate::trace::TraceTable;
+use crate::traits::AIR;
+use crate::verifier::{IsStarkVerifier, Verifier};
 
 type Felt = FieldElement<GoldilocksField>;
 
@@ -91,5 +100,274 @@ fn test_batched_composition_commit_n_point() {
     ];
     assert!(proof.verify::<BatchedMerkleTreeBackend<Degree3GoldilocksExtensionField>>(
         &root, 0, &opened_row
+    ));
+}
+
+type F = GoldilocksField;
+type E = Degree3GoldilocksExtensionField;
+type FE = FieldElement<F>;
+
+/// Full prove/verify roundtrip test using batched proving with shared trees and FRI.
+///
+/// Uses the multi-table lookup example (CPU, ADD, MUL tables linked via LogUp bus).
+/// All tables have the same trace length (uniform sizing).
+#[test_log::test]
+fn test_multi_prove_verify_batched_roundtrip() {
+    // CPU Trace (8 rows): dispatches operations to ADD and MUL tables
+    let add_column = vec![
+        FE::one(),
+        FE::zero(),
+        FE::one(),
+        FE::zero(),
+        FE::one(),
+        FE::one(),
+        FE::zero(),
+        FE::zero(),
+    ];
+    let mul_column = vec![
+        FE::zero(),
+        FE::one(),
+        FE::zero(),
+        FE::one(),
+        FE::zero(),
+        FE::zero(),
+        FE::one(),
+        FE::one(),
+    ];
+    let a_column = vec![
+        FE::from(1),
+        FE::from(2),
+        FE::from(3),
+        FE::from(4),
+        FE::from(5),
+        FE::from(6),
+        FE::from(7),
+        FE::from(8),
+    ];
+    let b_column = vec![
+        FE::from(10),
+        FE::from(20),
+        FE::from(30),
+        FE::from(40),
+        FE::from(50),
+        FE::from(60),
+        FE::from(70),
+        FE::from(80),
+    ];
+    let c_column = vec![
+        FE::from(11),  // 1 + 10
+        FE::from(40),  // 2 * 20
+        FE::from(33),  // 3 + 30
+        FE::from(160), // 4 * 40
+        FE::from(55),  // 5 + 50
+        FE::from(66),  // 6 + 60
+        FE::from(490), // 7 * 70
+        FE::from(640), // 8 * 80
+    ];
+
+    // All tables must have same trace length for batched proving (uniform sizing)
+    let trace_len = 8;
+
+    let mut cpu_trace = TraceTable::from_columns_main(
+        vec![add_column, mul_column, a_column, b_column, c_column],
+        1,
+    );
+
+    // ADD Trace (8 rows): receives addition operations, padded to match CPU trace length
+    let mut add_trace = TraceTable::from_columns_main(
+        vec![
+            vec![
+                FE::from(1),
+                FE::from(3),
+                FE::from(5),
+                FE::from(6),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::from(10),
+                FE::from(30),
+                FE::from(50),
+                FE::from(60),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::from(11),
+                FE::from(33),
+                FE::from(55),
+                FE::from(66),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::one(),
+                FE::one(),
+                FE::one(),
+                FE::one(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+        ],
+        1,
+    );
+
+    // MUL Trace (8 rows): receives multiplication operations, padded to match CPU trace length
+    let mut mul_trace = TraceTable::from_columns_main(
+        vec![
+            vec![
+                FE::from(2),
+                FE::from(4),
+                FE::from(7),
+                FE::from(8),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::from(20),
+                FE::from(40),
+                FE::from(70),
+                FE::from(80),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::from(40),
+                FE::from(160),
+                FE::from(490),
+                FE::from(640),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+            vec![
+                FE::one(),
+                FE::one(),
+                FE::one(),
+                FE::one(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+                FE::zero(),
+            ],
+        ],
+        1,
+    );
+
+    assert_eq!(cpu_trace.num_rows(), trace_len);
+    assert_eq!(add_trace.num_rows(), trace_len);
+    assert_eq!(mul_trace.num_rows(), trace_len);
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = new_cpu_air_with_lookup(&proof_options);
+    let add_air = new_add_air_with_lookup(&proof_options);
+    let mul_air = new_mul_air_with_lookup(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut cpu_trace, &()),
+        (&add_air, &mut add_trace, &()),
+        (&mul_air, &mut mul_trace, &()),
+    ];
+
+    let batched_proof = Prover::multi_prove_batched(
+        air_trace_pairs,
+        &mut DefaultTranscript::<E>::new(&[]),
+    )
+    .expect("Batched proving should succeed");
+
+    // Verify
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&cpu_air, &add_air, &mul_air];
+
+    assert!(Verifier::multi_verify_batched(
+        &airs,
+        &batched_proof,
+        &mut DefaultTranscript::<E>::new(&[]),
+        &FieldElement::zero(),
+    ));
+}
+
+/// All padding rows should also verify correctly with batched proving.
+#[test_log::test]
+fn test_batched_all_padding() {
+    let trace_len = 8;
+
+    let mut cpu_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::zero(); trace_len],
+            vec![FE::zero(); trace_len],
+            vec![FE::zero(); trace_len],
+            vec![FE::zero(); trace_len],
+            vec![FE::zero(); trace_len],
+        ],
+        1,
+    );
+
+    let mut add_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::zero(); trace_len],
+            vec![FE::zero(); trace_len],
+            vec![FE::zero(); trace_len],
+            vec![FE::zero(); trace_len],
+        ],
+        1,
+    );
+
+    let mut mul_trace = TraceTable::from_columns_main(
+        vec![
+            vec![FE::zero(); trace_len],
+            vec![FE::zero(); trace_len],
+            vec![FE::zero(); trace_len],
+            vec![FE::zero(); trace_len],
+        ],
+        1,
+    );
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = new_cpu_air_with_lookup(&proof_options);
+    let add_air = new_add_air_with_lookup(&proof_options);
+    let mul_air = new_mul_air_with_lookup(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut cpu_trace, &()),
+        (&add_air, &mut add_trace, &()),
+        (&mul_air, &mut mul_trace, &()),
+    ];
+
+    let batched_proof = Prover::multi_prove_batched(
+        air_trace_pairs,
+        &mut DefaultTranscript::<E>::new(&[]),
+    )
+    .expect("Batched proving should succeed");
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&cpu_air, &add_air, &mul_air];
+
+    assert!(Verifier::multi_verify_batched(
+        &airs,
+        &batched_proof,
+        &mut DefaultTranscript::<E>::new(&[]),
+        &FieldElement::zero(),
     ));
 }

--- a/crypto/stark/src/tests/mod.rs
+++ b/crypto/stark/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod air_tests;
+pub mod batched_tests;
 pub mod boundary_tests;
 pub mod bus_tests;
 pub mod fri_tests;

--- a/crypto/stark/src/tests/prover_tests.rs
+++ b/crypto/stark/src/tests/prover_tests.rs
@@ -206,21 +206,31 @@ fn test_decompose_and_extend_d2_matches_original() {
         .collect();
     assert_eq!(constraint_evaluations.len(), two_n);
 
-    // --- Original path: iFFT(2N) + break_in_parts(2) + FFT(2N) each ---
+    // --- Original path: iFFT(2N) + break_in_parts(2) to get N-point evals on squared coset ---
     let composition_poly =
         Polynomial::interpolate_offset_fft(&constraint_evaluations, &domain.coset_offset)
             .expect("interpolation failed");
     let parts = composition_poly.break_in_parts(2);
+    // Evaluate each part on the squared coset (N points with offset g²)
+    let coset_offset_sq = &domain.coset_offset * &domain.coset_offset;
     let original: Vec<Vec<Felt>> = parts
         .iter()
         .map(|part| {
-            evaluate_polynomial_on_lde_domain(part, blowup_factor, n, &domain.coset_offset)
-                .expect("LDE evaluation failed")
+            let primitive_root =
+                GoldilocksField::get_primitive_root_of_unity((n as u64).trailing_zeros() as u64)
+                    .expect("root exists");
+            let mut evals = Vec::with_capacity(n);
+            let mut point = coset_offset_sq.clone();
+            for _ in 0..n {
+                evals.push(part.evaluate(&point));
+                point = &point * &primitive_root;
+            }
+            evals
         })
         .collect();
 
-    // --- New path: algebraic decomposition ---
-    let new_result = Prover::<GoldilocksField, GoldilocksField, ()>::decompose_and_extend_d2(
+    // --- New path: eval-form decomposition (no extension) ---
+    let new_result = Prover::<GoldilocksField, GoldilocksField, ()>::decompose_d2(
         &constraint_evaluations,
         &domain,
     );

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -7,10 +7,11 @@ use super::{
     traits::{AIR, TransitionEvaluationContext},
 };
 use crate::{
+    batched_layout::BatchedLayout,
     config::Commitment,
     domain::new_verifier_domain,
     lookup::{LOGUP_CHALLENGE_ALPHA, LOGUP_NUM_CHALLENGES, PackingShifts, compute_alpha_powers},
-    proof::stark::{DeepPolynomialOpening, MultiProof},
+    proof::stark::{BatchedProof, DeepPolynomialOpening, MultiProof},
 };
 use crypto::{fiat_shamir::is_transcript::IsStarkTranscript, merkle_tree::proof::Proof};
 #[cfg(not(feature = "test_fiat_shamir"))]
@@ -1338,5 +1339,699 @@ pub trait IsStarkVerifier<
         }
 
         true
+    }
+
+    /// Verifies a batched proof with shared Merkle trees and shared FRI.
+    ///
+    /// Replays the transcript identically to `multi_prove_batched`:
+    /// 1. Append shared main root -> sample LogUp challenges -> append shared aux root
+    /// 2. Fork transcript per table, verify OOD consistency
+    /// 3. Reconstruct alpha-batched DEEP, verify shared FRI
+    /// 4. Verify shared tree openings at query points
+    fn multi_verify_batched(
+        airs: &[&dyn AIR<Field = Field, FieldExtension = FieldExtension, PublicInputs = PI>],
+        proof: &BatchedProof<Field, FieldExtension, PI>,
+        transcript: &mut (impl IsStarkTranscript<FieldExtension, Field> + Clone),
+        expected_bus_balance: &FieldElement<FieldExtension>,
+    ) -> bool
+    where
+        FieldElement<Field>: AsBytes + Sync + Send,
+        FieldElement<FieldExtension>: AsBytes + Sync + Send,
+        PI: Clone,
+    {
+        let num_tables = airs.len();
+        if num_tables != proof.tables.len() {
+            #[cfg(not(feature = "test_fiat_shamir"))]
+            error!(
+                "AIR count ({}) does not match table count ({})",
+                num_tables,
+                proof.tables.len()
+            );
+            return false;
+        }
+
+        let needs_lookup_challenges = airs.iter().any(|air| air.has_aux_trace());
+
+        // =====================================================================
+        // Phase A: Replay shared main root
+        // =====================================================================
+        transcript.append_bytes(&proof.main_merkle_root);
+
+        // =====================================================================
+        // Phase B: Sample shared LogUp challenges
+        // =====================================================================
+        let lookup_challenges: Vec<FieldElement<FieldExtension>> = if needs_lookup_challenges {
+            (0..LOGUP_NUM_CHALLENGES)
+                .map(|_| transcript.sample_field_element())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // Phase C: Replay shared aux root
+        if let Some(ref root) = proof.aux_merkle_root {
+            transcript.append_bytes(root);
+        }
+
+        // =====================================================================
+        // Validate bus_public_inputs presence
+        // =====================================================================
+        for (idx, (air, table)) in airs.iter().zip(&proof.tables).enumerate() {
+            if air.has_trace_interaction() && table.bus_public_inputs.is_none() {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!(
+                    "Batched table {idx}: AIR has LogUp but proof missing bus_public_inputs"
+                );
+                return false;
+            }
+            if !air.has_trace_interaction() && table.bus_public_inputs.is_some() {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!(
+                    "Batched table {idx}: AIR has no LogUp but proof contains bus_public_inputs"
+                );
+                return false;
+            }
+        }
+
+        // =====================================================================
+        // Fork transcripts per table
+        // =====================================================================
+        let mut table_transcripts: Vec<_> = (0..num_tables)
+            .map(|idx| {
+                let mut t = transcript.clone();
+                if num_tables > 1 {
+                    t.append_bytes(&(idx as u64).to_le_bytes());
+                }
+                t
+            })
+            .collect();
+
+        // Bind bus_public_inputs to each table's transcript
+        for (idx, table) in proof.tables.iter().enumerate() {
+            if let Some(ref bpi) = table.bus_public_inputs {
+                table_transcripts[idx].append_field_element(&bpi.table_contribution);
+            }
+        }
+
+        // =====================================================================
+        // Round 2: Replay per-table beta + composition root
+        // =====================================================================
+        // Build per-table domains
+        let domains: Vec<VerifierDomain<Field>> = airs
+            .iter()
+            .zip(&proof.tables)
+            .map(|(air, table)| new_verifier_domain(*air, table.trace_length))
+            .collect();
+
+        // For each table: sample beta (matching prover), append shared comp root, sample z,
+        // verify OOD consistency
+        let mut per_table_z: Vec<FieldElement<FieldExtension>> = Vec::with_capacity(num_tables);
+        let mut per_table_gammas: Vec<Vec<FieldElement<FieldExtension>>> =
+            Vec::with_capacity(num_tables);
+        let mut per_table_trace_term_coeffs: Vec<Vec<Vec<FieldElement<FieldExtension>>>> =
+            Vec::with_capacity(num_tables);
+
+        for (idx, (air, table)) in airs.iter().zip(&proof.tables).enumerate() {
+            let domain = &domains[idx];
+            let trace_length = table.trace_length;
+
+            // Round 2: sample beta
+            let beta: FieldElement<FieldExtension> =
+                table_transcripts[idx].sample_field_element();
+            let num_boundary_constraints = air
+                .boundary_constraints(
+                    &table.public_inputs,
+                    &lookup_challenges,
+                    table.bus_public_inputs.as_ref(),
+                    trace_length,
+                )
+                .constraints
+                .len();
+            let num_transition_constraints = air.context().num_transition_constraints;
+
+            let _coefficients: Vec<FieldElement<FieldExtension>> =
+                core::iter::successors(Some(FieldElement::one()), |x| Some(x * &beta))
+                    .take(num_boundary_constraints + num_transition_constraints)
+                    .collect();
+
+            // Append shared composition root
+            table_transcripts[idx].append_bytes(&proof.composition_merkle_root);
+
+            // Round 3: sample z
+            let z = table_transcripts[idx].sample_z_ood_with_domain_params(
+                domain.trace_length,
+                domain.lde_length,
+                &domain.coset_offset,
+            );
+
+            // Append OOD values to transcript (matching prover)
+            let trace_ood_columns = table.trace_ood_evaluations.columns();
+            for col in trace_ood_columns.iter() {
+                for elem in col.iter() {
+                    table_transcripts[idx].append_field_element(elem);
+                }
+            }
+            for element in table.composition_poly_parts_ood_evaluation.iter() {
+                table_transcripts[idx].append_field_element(element);
+            }
+
+            // Verify OOD consistency (step 2)
+            let boundary_constraints = air.boundary_constraints(
+                &table.public_inputs,
+                &lookup_challenges,
+                table.bus_public_inputs.as_ref(),
+                trace_length,
+            );
+            let number_of_b_constraints = boundary_constraints.constraints.len();
+
+            let mut boundary_step_points: Vec<(usize, FieldElement<Field>)> = Vec::new();
+
+            #[allow(clippy::type_complexity)]
+            let (boundary_c_i_evaluations_num, mut boundary_c_i_evaluations_den): (
+                Vec<FieldElement<FieldExtension>>,
+                Vec<FieldElement<FieldExtension>>,
+            ) = (0..number_of_b_constraints)
+                .map(|index| {
+                    let step = boundary_constraints.constraints[index].step;
+                    let is_aux = boundary_constraints.constraints[index].is_aux;
+                    let point = match boundary_step_points.iter().find(|(s, _)| *s == step) {
+                        Some((_, p)) => p.clone(),
+                        None => {
+                            let p = domain.trace_primitive_root.pow(step as u64);
+                            boundary_step_points.push((step, p.clone()));
+                            p
+                        }
+                    };
+                    let column_idx = boundary_constraints.constraints[index].col;
+                    let trace_evaluation = if is_aux {
+                        let column_idx = air.trace_layout().0 + column_idx;
+                        &table.trace_ood_evaluations.get_row(0)[column_idx]
+                    } else {
+                        &table.trace_ood_evaluations.get_row(0)[column_idx]
+                    };
+                    let boundary_zerofier_den = -point + &z;
+                    let boundary_quotient_num =
+                        -&boundary_constraints.constraints[index].value + trace_evaluation;
+                    (boundary_quotient_num, boundary_zerofier_den)
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .unzip();
+
+            FieldElement::inplace_batch_inverse(&mut boundary_c_i_evaluations_den).unwrap();
+
+            // Recompute beta powers for boundary/transition
+            let mut coefficients: Vec<FieldElement<FieldExtension>> =
+                core::iter::successors(Some(FieldElement::one()), |x| Some(x * &beta))
+                    .take(number_of_b_constraints + num_transition_constraints)
+                    .collect();
+            let transition_coeffs: Vec<_> =
+                coefficients.drain(..num_transition_constraints).collect();
+            let boundary_coeffs = coefficients;
+
+            let boundary_quotient_ood_evaluation: FieldElement<FieldExtension> =
+                boundary_c_i_evaluations_num
+                    .iter()
+                    .zip(&boundary_c_i_evaluations_den)
+                    .zip(&boundary_coeffs)
+                    .map(|((num, den), beta_coeff)| num * den * beta_coeff)
+                    .fold(FieldElement::<FieldExtension>::zero(), |acc, x| acc + x);
+
+            let periodic_values = air
+                .get_periodic_column_polynomials(trace_length)
+                .iter()
+                .map(|poly| poly.evaluate(&z))
+                .collect::<Vec<FieldElement<FieldExtension>>>();
+
+            let num_main_trace_columns =
+                table.trace_ood_evaluations.width - air.num_auxiliary_rap_columns();
+
+            let logup_alpha_powers: Vec<FieldElement<FieldExtension>> =
+                if lookup_challenges.len() > LOGUP_CHALLENGE_ALPHA {
+                    compute_alpha_powers(
+                        &lookup_challenges[LOGUP_CHALLENGE_ALPHA],
+                        air.max_bus_elements(),
+                    )
+                } else {
+                    Vec::new()
+                };
+
+            let logup_table_offset = match &table.bus_public_inputs {
+                Some(bpi) => {
+                    let n = FieldElement::<Field>::from(trace_length as u64);
+                    match n.inv() {
+                        Ok(n_inv) => n_inv * &bpi.table_contribution,
+                        Err(_) => return false,
+                    }
+                }
+                None => FieldElement::zero(),
+            };
+
+            let ood_frame = table
+                .trace_ood_evaluations
+                .into_frame(num_main_trace_columns, air.step_size());
+            let packing_shifts = PackingShifts::<FieldExtension>::new();
+            let transition_evaluation_context = TransitionEvaluationContext::new_verifier(
+                &ood_frame,
+                &periodic_values,
+                &lookup_challenges,
+                &logup_alpha_powers,
+                &logup_table_offset,
+                &packing_shifts,
+            );
+            let transition_ood_frame_evaluations =
+                air.compute_transition(&transition_evaluation_context);
+
+            let mut denominators =
+                vec![FieldElement::<FieldExtension>::zero(); air.num_transition_constraints()];
+            air.transition_constraints().iter().for_each(|c| {
+                denominators[c.constraint_idx()] = c.evaluate_zerofier(
+                    &z,
+                    &domain.trace_primitive_root,
+                    trace_length,
+                );
+            });
+
+            let transition_c_i_evaluations_sum = itertools::izip!(
+                transition_ood_frame_evaluations,
+                &transition_coeffs,
+                denominators
+            )
+            .fold(FieldElement::zero(), |acc, (eval, beta_coeff, denom)| {
+                acc + beta_coeff * eval * &denom
+            });
+
+            let composition_poly_ood_evaluation =
+                &boundary_quotient_ood_evaluation + transition_c_i_evaluations_sum;
+
+            let composition_poly_claimed_ood_evaluation = table
+                .composition_poly_parts_ood_evaluation
+                .iter()
+                .rev()
+                .fold(FieldElement::zero(), |acc, coeff| acc * &z + coeff);
+
+            if composition_poly_claimed_ood_evaluation != composition_poly_ood_evaluation {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!("Batched table {idx}: OOD composition poly verification failed");
+                return false;
+            }
+
+            // Round 4: sample gamma, compute deep coefficients
+            let gamma: FieldElement<FieldExtension> =
+                table_transcripts[idx].sample_field_element();
+            let n_terms_composition_poly = table.composition_poly_parts_ood_evaluation.len();
+            let num_terms_trace = air.context().transition_offsets.len()
+                * air.step_size()
+                * air.context().trace_columns;
+
+            let mut deep_composition_coefficients: Vec<_> =
+                core::iter::successors(Some(FieldElement::one()), |x| Some(x * &gamma))
+                    .take(n_terms_composition_poly + num_terms_trace)
+                    .collect();
+            let trace_term_coeffs_table: Vec<_> = deep_composition_coefficients
+                .drain(..num_terms_trace)
+                .collect::<Vec<_>>()
+                .chunks(air.context().transition_offsets.len() * air.step_size())
+                .map(|chunk| chunk.to_vec())
+                .collect();
+            let gammas_table = deep_composition_coefficients;
+
+            per_table_z.push(z);
+            per_table_gammas.push(gammas_table);
+            per_table_trace_term_coeffs.push(trace_term_coeffs_table);
+        }
+
+        // =====================================================================
+        // Round 4: Replay shared FRI
+        // =====================================================================
+
+        // Build combined FRI transcript (matching prover)
+        let alpha: FieldElement<FieldExtension> = {
+            let mut alpha_transcript = table_transcripts[0].clone();
+            for t in table_transcripts.iter().skip(1) {
+                let state = t.state();
+                alpha_transcript.append_bytes(&state);
+            }
+            alpha_transcript.sample_field_element()
+        };
+
+        let mut fri_transcript = {
+            let mut t = table_transcripts[0].clone();
+            for table_t in table_transcripts.iter().skip(1) {
+                let state = table_t.state();
+                t.append_bytes(&state);
+            }
+            t
+        };
+        fri_transcript.append_field_element(&alpha);
+
+        // Replay FRI commit phase
+        let merkle_roots = &proof.fri_layers_merkle_roots;
+        let mut zetas = merkle_roots
+            .iter()
+            .map(|root| {
+                let element = fri_transcript.sample_field_element();
+                fri_transcript.append_bytes(root);
+                element
+            })
+            .collect::<Vec<FieldElement<FieldExtension>>>();
+        zetas.push(fri_transcript.sample_field_element());
+
+        fri_transcript.append_field_element(&proof.fri_last_value);
+
+        // Replay grinding
+        let security_bits = airs[0].context().proof_options.grinding_factor;
+        if security_bits > 0 {
+            let grinding_seed = fri_transcript.state();
+            let nonce_is_valid = proof.nonce.is_some_and(|nonce_value| {
+                grinding::is_valid_nonce(&grinding_seed, nonce_value, security_bits)
+            });
+            if !nonce_is_valid {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!("Batched proof: grinding factor not satisfied");
+                return false;
+            }
+            if let Some(nonce_value) = proof.nonce {
+                fri_transcript.append_bytes(&nonce_value.to_be_bytes());
+            }
+        }
+
+        // Sample query indices
+        let number_of_queries = airs[0].options().fri_number_of_queries;
+        let iotas = Self::sample_query_indexes(number_of_queries, &domains[0], &mut fri_transcript);
+
+        // =====================================================================
+        // Verify query openings against shared trees
+        // =====================================================================
+        let main_column_counts: Vec<usize> = airs
+            .iter()
+            .zip(&proof.tables)
+            .map(|(air, _table)| air.trace_layout().0)
+            .collect();
+        let main_layout = BatchedLayout::new(
+            &main_column_counts,
+            domains[0].lde_length,
+        );
+
+        let aux_column_counts: Vec<usize> = airs
+            .iter()
+            .map(|air| air.trace_layout().1)
+            .collect();
+        let aux_layout = BatchedLayout::new(&aux_column_counts, domains[0].lde_length);
+
+        let comp_column_counts: Vec<usize> = proof
+            .tables
+            .iter()
+            .map(|t| t.num_composition_parts)
+            .collect();
+
+        for (q_idx, iota) in iotas.iter().enumerate() {
+            let opening = &proof.query_openings[q_idx];
+
+            let index = iota * 2;
+            let index_sym = iota * 2 + 1;
+
+            // Verify main trace opening against shared tree
+            if !Self::verify_opening::<Field>(
+                &opening.main_trace.proof,
+                &proof.main_merkle_root,
+                index,
+                &opening.main_trace.evaluations,
+            ) {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!("Batched: main trace opening verification failed at query {q_idx}");
+                return false;
+            }
+            if !Self::verify_opening::<Field>(
+                &opening.main_trace.proof_sym,
+                &proof.main_merkle_root,
+                index_sym,
+                &opening.main_trace.evaluations_sym,
+            ) {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!(
+                    "Batched: main trace sym opening verification failed at query {q_idx}"
+                );
+                return false;
+            }
+
+            // Verify aux trace opening
+            if let (Some(aux_root), Some(aux_opening)) =
+                (&proof.aux_merkle_root, &opening.aux_trace)
+            {
+                if !Self::verify_opening::<FieldExtension>(
+                    &aux_opening.proof,
+                    aux_root,
+                    index,
+                    &aux_opening.evaluations,
+                ) {
+                    #[cfg(not(feature = "test_fiat_shamir"))]
+                    error!(
+                        "Batched: aux trace opening verification failed at query {q_idx}"
+                    );
+                    return false;
+                }
+                if !Self::verify_opening::<FieldExtension>(
+                    &aux_opening.proof_sym,
+                    aux_root,
+                    index_sym,
+                    &aux_opening.evaluations_sym,
+                ) {
+                    #[cfg(not(feature = "test_fiat_shamir"))]
+                    error!(
+                        "Batched: aux trace sym opening verification failed at query {q_idx}"
+                    );
+                    return false;
+                }
+            }
+
+            // Verify composition opening
+            // Composition tree uses the paired-row layout (same as commit_composition_polynomial)
+            let mut comp_value = opening.composition_poly.evaluations.clone();
+            comp_value.extend_from_slice(&opening.composition_poly.evaluations_sym);
+            if !opening.composition_poly.proof.verify::<BatchedMerkleTreeBackend<FieldExtension>>(
+                &proof.composition_merkle_root,
+                *iota,
+                &comp_value,
+            ) {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!(
+                    "Batched: composition poly opening verification failed at query {q_idx}"
+                );
+                return false;
+            }
+
+            // Reconstruct per-table DEEP values at query point and alpha-batch
+            let evaluation_point = Self::query_challenge_to_evaluation_point(*iota, &domains[0]);
+            let evaluation_point_sym =
+                Self::query_challenge_to_evaluation_point_sym(*iota, &domains[0]);
+
+            let primitive_root =
+                &Field::get_primitive_root_of_unity(domains[0].root_order as u64).unwrap();
+
+            let mut batched_deep = FieldElement::<FieldExtension>::zero();
+            let mut batched_deep_sym = FieldElement::<FieldExtension>::zero();
+            let mut alpha_power = FieldElement::<FieldExtension>::one();
+
+            for (t_idx, (_air, table)) in airs.iter().zip(&proof.tables).enumerate() {
+                let z = &per_table_z[t_idx];
+                let gammas = &per_table_gammas[t_idx];
+                let trace_term_coeffs = &per_table_trace_term_coeffs[t_idx];
+
+                // Extract per-table trace evaluations from shared opening
+                let main_evals: Vec<FieldElement<FieldExtension>> = main_layout
+                    .extract_table(t_idx, &opening.main_trace.evaluations)
+                    .into_iter()
+                    .map(|x| x.to_extension())
+                    .collect();
+                let main_evals_sym: Vec<FieldElement<FieldExtension>> = main_layout
+                    .extract_table(t_idx, &opening.main_trace.evaluations_sym)
+                    .into_iter()
+                    .map(|x| x.to_extension())
+                    .collect();
+
+                let mut all_trace_evals = main_evals.clone();
+                let mut all_trace_evals_sym = main_evals_sym.clone();
+
+                if let Some(aux_opening) = &opening.aux_trace {
+                    let aux_evals: Vec<FieldElement<FieldExtension>> =
+                        aux_layout.extract_table(t_idx, &aux_opening.evaluations);
+                    let aux_evals_sym: Vec<FieldElement<FieldExtension>> =
+                        aux_layout.extract_table(t_idx, &aux_opening.evaluations_sym);
+                    all_trace_evals.extend(aux_evals);
+                    all_trace_evals_sym.extend(aux_evals_sym);
+                }
+
+                // Extract per-table composition evaluations from shared opening
+                let comp_start: usize = comp_column_counts[..t_idx].iter().sum();
+                let comp_end = comp_start + comp_column_counts[t_idx];
+                let comp_evals: Vec<FieldElement<FieldExtension>> =
+                    opening.composition_poly.evaluations[comp_start..comp_end].to_vec();
+                let comp_evals_sym: Vec<FieldElement<FieldExtension>> =
+                    opening.composition_poly.evaluations_sym[comp_start..comp_end].to_vec();
+
+                // Reconstruct full DEEP at evaluation_point
+                let deep_val = Self::reconstruct_full_deep_evaluation_from_parts(
+                    table,
+                    &evaluation_point,
+                    primitive_root,
+                    z,
+                    trace_term_coeffs,
+                    gammas,
+                    &all_trace_evals,
+                    &comp_evals,
+                );
+                let deep_val_sym = Self::reconstruct_full_deep_evaluation_from_parts(
+                    table,
+                    &evaluation_point_sym,
+                    primitive_root,
+                    z,
+                    trace_term_coeffs,
+                    gammas,
+                    &all_trace_evals_sym,
+                    &comp_evals_sym,
+                );
+
+                batched_deep += &alpha_power * &deep_val;
+                batched_deep_sym += &alpha_power * &deep_val_sym;
+                alpha_power = &alpha_power * &alpha;
+            }
+
+            // Verify FRI consistency
+            let mut evaluation_point_inv = evaluation_point
+                .inv()
+                .expect("evaluation_point should be non-zero");
+
+            // Reconstruct p1(v^2) from p0(v) and p0(-v) using first fold
+            let mut v = (&batched_deep + &batched_deep_sym)
+                + evaluation_point_inv.clone() * &zetas[0] * (&batched_deep - &batched_deep_sym);
+
+            let fri_decommitment = &proof.query_list[q_idx];
+            let mut fri_index = *iota;
+
+            if proof.fri_layers_merkle_roots.is_empty() {
+                if v != proof.fri_last_value {
+                    #[cfg(not(feature = "test_fiat_shamir"))]
+                    error!("Batched: FRI final value mismatch at query {q_idx}");
+                    return false;
+                }
+                continue;
+            }
+
+            // Verify FRI layers
+            for (i, merkle_root) in proof.fri_layers_merkle_roots.iter().enumerate() {
+                let evaluation_sym = &fri_decommitment.layers_evaluations_sym[i];
+                let auth_path_sym = &fri_decommitment.layers_auth_paths[i];
+
+                if !Self::verify_fri_layer_openings(
+                    merkle_root,
+                    auth_path_sym,
+                    &v,
+                    evaluation_sym,
+                    fri_index,
+                ) {
+                    #[cfg(not(feature = "test_fiat_shamir"))]
+                    error!(
+                        "Batched: FRI layer {i} opening verification failed at query {q_idx}"
+                    );
+                    return false;
+                }
+
+                evaluation_point_inv = evaluation_point_inv.square();
+                v = (&v + evaluation_sym)
+                    + evaluation_point_inv.clone() * &zetas[i + 1] * (&v - evaluation_sym);
+                fri_index >>= 1;
+
+                if i == fri_decommitment.layers_evaluations_sym.len() - 1
+                    && v != proof.fri_last_value
+                {
+                    #[cfg(not(feature = "test_fiat_shamir"))]
+                    error!(
+                        "Batched: FRI final value mismatch at query {q_idx}, layer {i}"
+                    );
+                    return false;
+                }
+            }
+        }
+
+        // =====================================================================
+        // Bus Balance Check
+        // =====================================================================
+        if needs_lookup_challenges {
+            let mut total = FieldElement::<FieldExtension>::zero();
+            for (air, table) in airs.iter().zip(&proof.tables) {
+                if air.has_trace_interaction()
+                    && let Some(interaction) = &table.bus_public_inputs
+                {
+                    total = total + &interaction.table_contribution;
+                }
+            }
+
+            if total != *expected_bus_balance {
+                #[cfg(not(feature = "test_fiat_shamir"))]
+                error!(
+                    "Batched: LogUp bus does not balance: sum does not match target. total={:?}, target={:?}",
+                    total, expected_bus_balance
+                );
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Reconstructs the full DEEP polynomial value (trace + composition) at a query point,
+    /// given per-table parameters. Used by `multi_verify_batched`.
+    #[allow(clippy::too_many_arguments)]
+    fn reconstruct_full_deep_evaluation_from_parts(
+        table: &crate::proof::stark::TableProofData<Field, FieldExtension, PI>,
+        evaluation_point: &FieldElement<Field>,
+        primitive_root: &FieldElement<Field>,
+        z: &FieldElement<FieldExtension>,
+        trace_term_coeffs: &[Vec<FieldElement<FieldExtension>>],
+        gammas: &[FieldElement<FieldExtension>],
+        lde_trace_evaluations: &[FieldElement<FieldExtension>],
+        lde_composition_poly_parts_evaluation: &[FieldElement<FieldExtension>],
+    ) -> FieldElement<FieldExtension> {
+        // Trace DEEP terms
+        let ood_evaluations_table_height = table.trace_ood_evaluations.height;
+        let ood_evaluations_table_width = table.trace_ood_evaluations.width;
+
+        let mut denoms_trace = Vec::with_capacity(ood_evaluations_table_height);
+        let mut current_z = z.clone();
+        for _ in 0..ood_evaluations_table_height {
+            denoms_trace.push(evaluation_point - &current_z);
+            current_z = primitive_root * &current_z;
+        }
+        FieldElement::inplace_batch_inverse(&mut denoms_trace).unwrap();
+
+        let trace_term = (0..ood_evaluations_table_width)
+            .zip(trace_term_coeffs)
+            .fold(FieldElement::zero(), |trace_terms, (col_idx, coeff_row)| {
+                let trace_i = (0..ood_evaluations_table_height).zip(coeff_row).fold(
+                    FieldElement::zero(),
+                    |trace_t, (row_idx, coeff)| {
+                        let poly_evaluation = (lde_trace_evaluations[col_idx].clone()
+                            - table.trace_ood_evaluations.get_row(row_idx)[col_idx].clone())
+                            * &denoms_trace[row_idx];
+                        trace_t + &poly_evaluation * coeff
+                    },
+                );
+                trace_terms + trace_i
+            });
+
+        // Composition DEEP terms
+        let number_of_parts = lde_composition_poly_parts_evaluation.len();
+        let z_pow = z.pow(number_of_parts);
+        let denom_composition = (evaluation_point - &z_pow).inv().unwrap();
+        let mut h_terms = FieldElement::zero();
+        for (j, h_i_upsilon) in lde_composition_poly_parts_evaluation.iter().enumerate() {
+            let h_i_zpower = &table.composition_poly_parts_ood_evaluation[j];
+            let h_i_term = (h_i_upsilon - h_i_zpower) * &gammas[j];
+            h_terms += h_i_term;
+        }
+        h_terms *= denom_composition;
+
+        trace_term + h_terms
     }
 }

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -652,18 +652,15 @@ pub trait IsStarkVerifier<
         // Reconstruct p₁(𝜐²)
         let mut v =
             (p0_eval + p0_eval_sym) + evaluation_point_inv * &zetas[0] * (p0_eval - p0_eval_sym);
+
         let mut index = iota;
 
         // Handle case with 0 FRI layers (trace_length <= 2)
-        // In this case, the fold loop below doesn't iterate, so we need to verify
-        // the final value directly here.
         if fri_layers_merkle_roots.is_empty() {
             return v == proof.fri_last_value;
         }
 
-        // For each FRI layer, starting from the layer 1: use the proof to verify the validity of values pᵢ(−𝜐^(2ⁱ)) (given by the prover) and
-        // pᵢ(𝜐^(2ⁱ)) (computed on the previous iteration by the verifier). Then use them to obtain pᵢ₊₁(𝜐^(2ⁱ⁺¹)).
-        // Finally, check that the final value coincides with the given by the prover.
+        // For each FRI layer: verify pᵢ(−𝜐^(2ⁱ)) and pᵢ(𝜐^(2ⁱ)), compute pᵢ₊₁(𝜐^(2ⁱ⁺¹)).
         fri_layers_merkle_roots
             .iter()
             .enumerate()
@@ -714,11 +711,11 @@ pub trait IsStarkVerifier<
         let num_queries = challenges.iotas.len();
         let mut deep_poly_evaluations = Vec::with_capacity(num_queries);
         let mut deep_poly_evaluations_sym = Vec::with_capacity(num_queries);
+
         for (i, iota) in challenges.iotas.iter().enumerate() {
             let primitive_root =
                 &Field::get_primitive_root_of_unity(domain.root_order as u64).unwrap();
 
-            // For preprocessed tables: precomputed columns come FIRST, then multiplicities
             let mut evaluations: Vec<FieldElement<FieldExtension>> = Vec::new();
             if let Some(precomputed_polys) = &proof.deep_poly_openings[i].precomputed_trace_polys {
                 evaluations.extend(
@@ -742,16 +739,7 @@ pub trait IsStarkVerifier<
             }
 
             let evaluation_point = Self::query_challenge_to_evaluation_point(*iota, domain);
-            deep_poly_evaluations.push(Self::reconstruct_deep_composition_poly_evaluation(
-                proof,
-                &evaluation_point,
-                primitive_root,
-                challenges,
-                &evaluations,
-                &proof.deep_poly_openings[i].composition_poly.evaluations,
-            ));
 
-            // For preprocessed tables: precomputed columns come FIRST, then multiplicities
             let mut evaluations_sym: Vec<FieldElement<FieldExtension>> = Vec::new();
             if let Some(precomputed_polys) = &proof.deep_poly_openings[i].precomputed_trace_polys {
                 evaluations_sym.extend(
@@ -774,26 +762,71 @@ pub trait IsStarkVerifier<
                 evaluations_sym.extend_from_slice(&aux_trace_polys.evaluations_sym);
             }
 
-            let evaluation_point = Self::query_challenge_to_evaluation_point_sym(*iota, domain);
-            deep_poly_evaluations_sym.push(Self::reconstruct_deep_composition_poly_evaluation(
-                proof,
-                &evaluation_point,
-                primitive_root,
-                challenges,
-                &evaluations_sym,
-                &proof.deep_poly_openings[i].composition_poly.evaluations_sym,
-            ));
+            let evaluation_point_sym =
+                Self::query_challenge_to_evaluation_point_sym(*iota, domain);
+
+            {
+                deep_poly_evaluations.push(Self::reconstruct_full_deep_evaluation(
+                    proof,
+                    &evaluation_point,
+                    primitive_root,
+                    challenges,
+                    &evaluations,
+                    &proof.deep_poly_openings[i].composition_poly.evaluations,
+                ));
+                deep_poly_evaluations_sym.push(Self::reconstruct_full_deep_evaluation(
+                    proof,
+                    &evaluation_point_sym,
+                    primitive_root,
+                    challenges,
+                    &evaluations_sym,
+                    &proof.deep_poly_openings[i].composition_poly.evaluations_sym,
+                ));
+            }
         }
         (deep_poly_evaluations, deep_poly_evaluations_sym)
     }
 
-    fn reconstruct_deep_composition_poly_evaluation(
+    /// Reconstructs the full DEEP polynomial (trace + composition) at a query point.
+    /// Used for the non-injection path (number_of_parts != 2).
+    fn reconstruct_full_deep_evaluation(
         proof: &StarkProof<Field, FieldExtension, PI>,
         evaluation_point: &FieldElement<Field>,
         primitive_root: &FieldElement<Field>,
         challenges: &Challenges<FieldExtension>,
         lde_trace_evaluations: &[FieldElement<FieldExtension>],
         lde_composition_poly_parts_evaluation: &[FieldElement<FieldExtension>],
+    ) -> FieldElement<FieldExtension> {
+        let trace_term = Self::reconstruct_trace_deep_evaluation(
+            proof,
+            evaluation_point,
+            primitive_root,
+            challenges,
+            lde_trace_evaluations,
+        );
+
+        let number_of_parts = lde_composition_poly_parts_evaluation.len();
+        let z_pow = &challenges.z.pow(number_of_parts);
+        let denom_composition = (evaluation_point - z_pow).inv().unwrap();
+        let mut h_terms = FieldElement::zero();
+        for (j, h_i_upsilon) in lde_composition_poly_parts_evaluation.iter().enumerate() {
+            let h_i_zpower = &proof.composition_poly_parts_ood_evaluation[j];
+            let h_i_term = (h_i_upsilon - h_i_zpower) * &challenges.gammas[j];
+            h_terms += h_i_term;
+        }
+        h_terms *= denom_composition;
+
+        trace_term + h_terms
+    }
+
+    /// Reconstructs the trace-only DEEP polynomial at a query point.
+    /// Composition terms are NOT included — they enter via FRI injection.
+    fn reconstruct_trace_deep_evaluation(
+        proof: &StarkProof<Field, FieldExtension, PI>,
+        evaluation_point: &FieldElement<Field>,
+        primitive_root: &FieldElement<Field>,
+        challenges: &Challenges<FieldExtension>,
+        lde_trace_evaluations: &[FieldElement<FieldExtension>],
     ) -> FieldElement<FieldExtension> {
         let ood_evaluations_table_height = proof.trace_ood_evaluations.height;
         let ood_evaluations_table_width = proof.trace_ood_evaluations.width;
@@ -811,7 +844,7 @@ pub trait IsStarkVerifier<
         }
         FieldElement::inplace_batch_inverse(&mut denoms_trace).unwrap();
 
-        let trace_term = (0..ood_evaluations_table_width)
+        (0..ood_evaluations_table_width)
             .zip(&challenges.trace_term_coeffs)
             .fold(FieldElement::zero(), |trace_terms, (col_idx, coeff_row)| {
                 let trace_i = (0..ood_evaluations_table_height).zip(coeff_row).fold(
@@ -824,21 +857,31 @@ pub trait IsStarkVerifier<
                     },
                 );
                 trace_terms + trace_i
-            });
+            })
+    }
 
-        let number_of_parts = lde_composition_poly_parts_evaluation.len();
+    /// Computes the composition DEEP injection value at a squared-coset query point.
+    ///
+    /// This is: Σ_j γ_j * (H_j(v²) - H_j(z²)) / (v² - z²)
+    ///
+    /// The evaluation_point here is v² (the squared evaluation point after FRI's first fold).
+    fn compute_composition_injection_value(
+        proof: &StarkProof<Field, FieldExtension, PI>,
+        evaluation_point_sq: &FieldElement<FieldExtension>,
+        challenges: &Challenges<FieldExtension>,
+        composition_poly_evaluations: &[FieldElement<FieldExtension>],
+    ) -> FieldElement<FieldExtension> {
+        let number_of_parts = composition_poly_evaluations.len();
         let z_pow = &challenges.z.pow(number_of_parts);
 
-        let denom_composition = (evaluation_point - z_pow).inv().unwrap();
+        let denom_composition = (evaluation_point_sq - z_pow).inv().unwrap();
         let mut h_terms = FieldElement::zero();
-        for (j, h_i_upsilon) in lde_composition_poly_parts_evaluation.iter().enumerate() {
-            let h_i_zpower = &proof.composition_poly_parts_ood_evaluation[j];
-            let h_i_term = (h_i_upsilon - h_i_zpower) * &challenges.gammas[j];
-            h_terms += h_i_term;
+        for (j, h_j_val) in composition_poly_evaluations.iter().enumerate() {
+            let h_j_zpower = &proof.composition_poly_parts_ood_evaluation[j];
+            let h_j_term = (h_j_val - h_j_zpower) * &challenges.gammas[j];
+            h_terms += h_j_term;
         }
-        h_terms *= denom_composition;
-
-        trace_term + h_terms
+        h_terms * denom_composition
     }
 
     /// Verifies one or more STARK proofs with their corresponding AIRs.

--- a/docs/superpowers/plans/2026-04-20-mmcs-batched-commitment.md
+++ b/docs/superpowers/plans/2026-04-20-mmcs-batched-commitment.md
@@ -1,0 +1,137 @@
+# MMCS Batched Commitment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Replace per-table independent Merkle trees with shared batched trees (one per commitment phase), enabling shared FRI and eval-form quotient commitment.
+
+**Architecture:** All tables' columns for a given phase (main, aux, composition) are concatenated into a single wide Merkle tree. With uniform table sizing (all tables capped at 2^20 LDE rows), this is pure column concatenation — no jagged-height insertion needed. Each query opens one row from the shared tree, which contains columns from ALL tables. A BatchedLayout maps column ranges to tables. The composition polynomial parts from decompose_d2 are committed at N points (half-size) in their own shared tree, enabling eval-form quotient savings.
+
+**Tech Stack:** Rust, Goldilocks field, Keccak256 Merkle trees, existing BatchedMerkleTree and commit_columns_bit_reversed infrastructure.
+
+**Branch:** feat/eval-form-quotient (continues from the decompose_d2 refactoring).
+
+---
+
+## Task 1: BatchedLayout — Column offset tracking
+
+**Files:**
+- Create: crypto/stark/src/batched_layout.rs
+- Modify: crypto/stark/src/lib.rs (add module)
+
+Tracks where each table's columns live in the concatenated Merkle tree row. new(column_counts, lde_size) builds ranges. extract_table(idx, row) slices a table's columns from an opened row.
+
+- [ ] Step 1: Define BatchedLayout struct with new() and extract_table()
+- [ ] Step 2: Add unit tests
+- [ ] Step 3: Register module in lib.rs
+- [ ] Step 4: Run tests, commit
+
+---
+
+## Task 2: BatchedProof — New proof structure with shared roots
+
+**Files:**
+- Modify: crypto/stark/src/proof/stark.rs
+
+New BatchedProof struct: shared main/aux/composition Merkle roots, shared FRI data, per-table OOD data in Vec<TableProofData>, per-query BatchedQueryOpening with openings from all three shared trees. Old MultiProof kept for backward compatibility.
+
+- [ ] Step 1: Define BatchedProof, TableProofData, BatchedQueryOpening structs
+- [ ] Step 2: Verify existing tests still pass (no regressions)
+- [ ] Step 3: Commit
+
+---
+
+## Task 3: Batched main trace commitment
+
+**Files:**
+- Modify: crypto/stark/src/prover.rs — add commit_main_traces_batched
+- Create: crypto/stark/src/tests/batched_tests.rs
+
+Build a single Merkle tree from all tables' main trace LDE columns concatenated. Flatten per-table columns into one Vec, call commit_columns_bit_reversed. Return tree + root + BatchedLayout.
+
+- [ ] Step 1: Write commit_main_traces_batched function
+- [ ] Step 2: Write test for batched commit/open roundtrip
+- [ ] Step 3: Run tests, commit
+
+---
+
+## Task 4: Batched composition commitment with eval-form quotient
+
+**Files:**
+- Modify: crypto/stark/src/prover.rs
+
+All tables' composition parts (H0, H1 from decompose_d2) committed at N squared-coset points in a shared tree. No iFFT+FFT extension needed — the N-point evaluations go directly into the batched tree. This is where the FFT savings land.
+
+- [ ] Step 1: Write commit_composition_polys_batched (N-point tree)
+- [ ] Step 2: Update round_2 to return N-point evaluations for batched path
+- [ ] Step 3: Test OOD evaluation from N-point squared-coset matches extended path
+- [ ] Step 4: Commit
+
+---
+
+## Task 5: Shared FRI with alpha-batching
+
+**Files:**
+- Modify: crypto/stark/src/prover.rs
+- Modify: crypto/stark/src/fri/mod.rs
+
+All tables' trace-only DEEP polynomials are alpha-batched into one 2N-point vector. Composition DEEP values (N-point, from the batched composition tree) are alpha-batched and injected after the first FRI fold via commit_phase_from_evaluations_with_injection. One FRI instance for all tables.
+
+- [ ] Step 1: Implement alpha_batch_deep_polynomials
+- [ ] Step 2: Implement composition DEEP injection for shared FRI
+- [ ] Step 3: Update multi_prove to use shared Round 4
+- [ ] Step 4: Write multi-table batched prove roundtrip test
+- [ ] Step 5: Commit
+
+---
+
+## Task 6: Batched verifier
+
+**Files:**
+- Modify: crypto/stark/src/verifier.rs
+
+Verifier replays shared transcript, opens shared trees at query indices, extracts per-table values via BatchedLayout, reconstructs alpha-batched DEEP + composition injection, verifies shared FRI.
+
+- [ ] Step 1: Implement multi_verify_batched
+- [ ] Step 2: Run full test suite (old + new paths)
+- [ ] Step 3: Commit
+
+---
+
+## Task 7: Integration — Wire into multi_prove/multi_verify
+
+**Files:**
+- Modify: crypto/stark/src/prover.rs
+- Modify: crypto/stark/src/verifier.rs
+- Modify: prover/src/lib.rs (VM prover entry point)
+
+New multi_prove_batched and multi_verify_batched entry points alongside existing functions. Run VM prover benchmarks.
+
+- [ ] Step 1: Add multi_prove_batched entry point
+- [ ] Step 2: Add multi_verify_batched entry point
+- [ ] Step 3: Run VM prover benchmarks, compare against baseline
+- [ ] Step 4: Commit + push
+
+---
+
+## Task 8: Cleanup — Drop extension FFTs in batched mode
+
+**Files:**
+- Modify: crypto/stark/src/prover.rs
+
+In the batched path, decompose_d2 output is committed directly at N points. No iFFT+FFT extension in Round 2. The DEEP uses coset-shifted values (iFFT(N,g2) + FFT(N,g)) or verifier-side barycentric interpolation from query openings.
+
+- [ ] Step 1: Drop extension in batched Round 2
+- [ ] Step 2: Verify all tests pass
+- [ ] Step 3: Commit
+
+---
+
+## Expected Savings
+
+| Metric | Current | After MMCS + Shared FRI |
+|--------|---------|------------------------|
+| Merkle trees per proof | ~32 | 3 |
+| FRI instances | ~12 | 1 |
+| FRI layer trees | ~228 | ~19 |
+| Composition FFTs (Round 2) | 2 iFFT(N) + 2 FFT(2N) per table | 0 (N-point commit) |
+| Proof size | ~2.5 MB | ~0.8 MB (est.) |


### PR DESCRIPTION
Factor decompose_and_extend_d2 into decompose_d2 (O(N) pointwise decomposition on squared coset) + iFFT(N,g²) + FFT(2N,g) extension. Mathematically identical to the old path.

This factoring exposes the N-point squared-coset representation as an intermediate step, which is the foundation for future eval-form quotient commitment (committing at N points instead of 2N, saving half the composition Merkle tree) once shared/multi-input FRI is available.

Changes:
- prover: decompose_d2 extracts H₀,H₁ at N squared-coset points
- prover: inline extension from squared coset to 2N LDE domain
- prover: rename lde_composition_poly_evaluations → composition_poly_evaluations
- verifier: factor reconstruct_deep into trace + full variants
- fri: add commit_phase_from_evaluations_with_injection (unused, infrastructure for future shared FRI injection)
- test: update decomposition test to verify N-point output