### PR TITLE
Fix fib_iterative programs

### DIFF
--- a/executor/programs/asm/fib_iterative_250k.s
+++ b/executor/programs/asm/fib_iterative_250k.s
@@ -19,5 +19,6 @@ main:
 	bnez	a0, .loop		# loop if n != 0
 
 	mv	a0, t1			# result = b
+	li	a0, 0
 	li	a7, 93
 	ecall				# halt with result in a0

--- a/executor/programs/asm/fib_iterative_250k.s
+++ b/executor/programs/asm/fib_iterative_250k.s
@@ -21,4 +21,4 @@ main:
 	mv	a0, t1			# result = b
 	li	a0, 0
 	li	a7, 93
-	ecall				# halt with result in a0
+	ecall				# halt with exit_code=0 in a0 (required by prover)

--- a/executor/programs/asm/fib_iterative_2M.s
+++ b/executor/programs/asm/fib_iterative_2M.s
@@ -19,5 +19,6 @@ main:
 	bnez	a0, .loop		# loop if n != 0
 
 	mv	a0, t1			# result = b
+	li	a0, 0
 	li	a7, 93
 	ecall				# halt with result in a0

--- a/executor/programs/asm/fib_iterative_500k.s
+++ b/executor/programs/asm/fib_iterative_500k.s
@@ -19,5 +19,6 @@ main:
 	bnez	a0, .loop		# loop if n != 0
 
 	mv	a0, t1			# result = b
+	li	a0, 0
 	li	a7, 93
 	ecall				# halt with result in a0


### PR DESCRIPTION
Some fib_iterative programs didn't have the halt instruction which caused verification to fail. This PR adds that instruction to the problematic fib_iterative programs.