### PR TITLE
spec: `ARE_BYTES`

### DIFF
--- a/spec/bitwise.typ
+++ b/spec/bitwise.typ
@@ -37,8 +37,6 @@ This chip adds the following interactions to the lookup:
 
 = Notes/Optimizations
 The following ideas may prove to be optimizations for the #bitwise chip:
-+ Extend `IS_BYTE[X]` to `ARE_BYTES[X, Y]`, such that two bytes are range checked at once. 
-  When only a single check is required, one can still execute `IS_BYTE[X] := ARE_BYTES[X, 0]`.
 + Drop `MSB8` column, and instead define the `MSB8` lookup as `MSB8<X> := MSB16[256X]`.
   Note: currently, `MSB8` also implicity range checks the input `X` (the lookup fails if `X` is not a `Byte`).
   This optimization should only be executed when all chips leveraging `MSB8` do _not_ need this implicit range check.

--- a/spec/book.typ
+++ b/spec/book.typ
@@ -18,6 +18,7 @@
     )),
     ("TEMPLATES", (
       ("is_bit.typ", [`IS_BIT` template], <isbit>),
+      ("is_byte.typ", [`IS_BYTE` template], <isbyte>),
       ("sign.typ", [`SIGN` template], <sign>),
       ("add.typ", [`ADD`/`SUB` template], <add>),
       ("neg.typ", [`NEG` template], <neg>),

--- a/spec/is_byte.typ
+++ b/spec/is_byte.typ
@@ -8,9 +8,9 @@
 #show: book-page(chip.name)
 #let is_byte = raw(chip.name)
 
-#is_byte is a constraint template that is used to assert that a variable lies in the range $[0, 255]$ with given multiplicity.
+#is_byte is a constraint template that is used to assert that a variable lies in the range $[0, 255]$ under the condition that `cond` is non-zero. Note: when `cond` is omitted, it defaults to $1$.
 
-When a chip leverages this template twice or more, implementors are encouraged to merge pairs of #is_byte interactions with identical multiplicities into `ARE_BYTES` interactions; the #is_byte template is included for convenience of notation, and to complete the specification of chips that use an odd number of #is_byte range checks.
+When a chip leverages this template twice or more, implementors are encouraged to merge pairs of #is_byte interactions with identical conditions into `ARE_BYTES` interactions; the #is_byte template is included for convenience of notation, and to complete the specification of chips that use an odd number of #is_byte range checks.
 
 = Variables
 #let nr_interactions = compute_nr_interactions(chip)

--- a/spec/is_byte.typ
+++ b/spec/is_byte.typ
@@ -1,0 +1,22 @@
+#import "/book.typ": book-page
+#import "/src.typ": load_config, load_chip
+#import "/chip.typ": render_chip_variable_table, render_constraint_table, compute_nr_interactions, total_nr_variables, total_nr_instantiated_columns
+
+#let config = load_config()
+#let chip = load_chip("src/is_byte.toml", config)
+
+#show: book-page(chip.name)
+#let is_byte = raw(chip.name)
+
+#is_byte is a constraint template that is used to assert that a variable lies in the range $[0, 255]$ with given multiplicity.
+
+When a chip leverages this template twice or more, implementors are encouraged to merge pairs of #is_byte interactions with identical multiplicities into `ARE_BYTES` interactions; the #is_byte template is included for convenience of notation, and to complete the specification of chips that use an odd number of #is_byte range checks.
+
+= Variables
+#let nr_interactions = compute_nr_interactions(chip)
+
+The #is_byte template leverages #nr_interactions interaction(s):
+#render_chip_variable_table(chip, config)
+
+= Constraints
+#render_constraint_table(chip, config)

--- a/spec/src/bitwise.toml
+++ b/spec/src/bitwise.toml
@@ -168,10 +168,9 @@ output = "ZERO"
 multiplicity = ["-", "μ_ZERO"]
 
 [[constraints.contributions]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = ["X"]
-multiplicity = ["-", "μ_IS_BYTE"]
+input = ["X", ["-", "μ_IS_BYTE"]]
 
 [[constraints.contributions]]
 kind = "interaction"

--- a/spec/src/bitwise.toml
+++ b/spec/src/bitwise.toml
@@ -102,6 +102,11 @@ type = "BaseField"
 desc = ""
 
 [[variables.multiplicity]]
+name = "μ_ARE_BYTES"
+type = "BaseField"
+desc = ""
+
+[[variables.multiplicity]]
 name = "μ_IS_HALF"
 type = "BaseField"
 desc = ""
@@ -167,6 +172,12 @@ kind = "interaction"
 tag = "IS_BYTE"
 input = ["X"]
 multiplicity = ["-", "μ_IS_BYTE"]
+
+[[constraints.contributions]]
+kind = "interaction"
+tag = "ARE_BYTES"
+input = ["X", "Y"]
+multiplicity = ["-", "μ_ARE_BYTES"]
 
 [[constraints.contributions]]
 kind = "interaction"

--- a/spec/src/bitwise.toml
+++ b/spec/src/bitwise.toml
@@ -168,11 +168,6 @@ output = "ZERO"
 multiplicity = ["-", "μ_ZERO"]
 
 [[constraints.contributions]]
-kind = "template"
-tag = "IS_BYTE"
-input = ["X", ["-", "μ_IS_BYTE"]]
-
-[[constraints.contributions]]
 kind = "interaction"
 tag = "ARE_BYTES"
 input = ["X", "Y"]

--- a/spec/src/branch.toml
+++ b/spec/src/branch.toml
@@ -118,7 +118,8 @@ cond = "JALR"
 [[constraints.all]]
 kind = "template"
 tag = "IS_BYTE"
-input = [["idx", "next_pc_low", 1], "μ"]
+input = [["idx", "next_pc_low", 1]]
+cond = "μ"
 
 [[constraints.all]]
 kind = "interaction"

--- a/spec/src/branch.toml
+++ b/spec/src/branch.toml
@@ -116,10 +116,9 @@ output = "next_pc_unmasked"
 cond = "JALR"
 
 [[constraints.all]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = [["idx", "next_pc_low", 1]]
-multiplicity = "μ"
+input = [["idx", "next_pc_low", 1], "μ"]
 
 [[constraints.all]]
 kind = "interaction"

--- a/spec/src/cpu.toml
+++ b/spec/src/cpu.toml
@@ -513,34 +513,34 @@ ref = "cpu:c:range_EBREAK"
 [[constraints.range]]
 kind = "template"
 tag = "IS_BYTE"
-input = ["rs1", 1]
+input = ["rs1"]
 
 [[constraints.range]]
 kind = "template"
 tag = "IS_BYTE"
-input = ["rs2", 1]
+input = ["rs2"]
 
 [[constraints.range]]
 kind = "template"
 tag = "IS_BYTE"
-input = ["rd", 1]
+input = ["rd"]
 
 [[constraints.range]]
 kind = "template"
 tag = "IS_BYTE"
-input = [["idx", "arg1", "i"], 1]
+input = [["idx", "arg1", "i"]]
 iter = ["i", 0, 7]
 
 [[constraints.range]]
 kind = "template"
 tag = "IS_BYTE"
-input = [["idx", "arg2", "i"], 1]
+input = [["idx", "arg2", "i"]]
 iter = ["i", 0, 7]
 
 [[constraints.range]]
 kind = "template"
 tag = "IS_BYTE"
-input = [["idx", "res", "i"], 1]
+input = [["idx", "res", "i"]]
 iter = ["i", 0, 7]
 
 

--- a/spec/src/cpu.toml
+++ b/spec/src/cpu.toml
@@ -511,43 +511,37 @@ input = ["EBREAK"]
 ref = "cpu:c:range_EBREAK"
 
 [[constraints.range]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = ["rs1"]
-multiplicity = 1
+input = ["rs1", 1]
 
 [[constraints.range]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = ["rs2"]
-multiplicity = 1
+input = ["rs2", 1]
 
 [[constraints.range]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = ["rd"]
-multiplicity = 1
+input = ["rd", 1]
 
 [[constraints.range]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = [["idx", "arg1", "i"]]
+input = [["idx", "arg1", "i"], 1]
 iter = ["i", 0, 7]
-multiplicity = 1
 
 [[constraints.range]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = [["idx", "arg2", "i"]]
+input = [["idx", "arg2", "i"], 1]
 iter = ["i", 0, 7]
-multiplicity = 1
 
 [[constraints.range]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = [["idx", "res", "i"]]
+input = [["idx", "res", "i"], 1]
 iter = ["i", 0, 7]
-multiplicity = 1
 
 
 [[constraint_groups]]

--- a/spec/src/is_byte.toml
+++ b/spec/src/is_byte.toml
@@ -1,14 +1,14 @@
 name = "IS_BYTE"
 
+[[variables.condition]]
+name = "cond"
+type = "BaseField"
+desc = ""
+
 [[variables.input]]
 name = "X"
 type = "BaseField"
 desc = "Value for which to assert that it lies in the range $[0, 255]$."
-
-[[variables.multiplicity]]
-name = "μ"
-type = "BaseField"
-desc = ""
 
 [[constraint_groups]]
 name = "all"
@@ -17,5 +17,5 @@ name = "all"
 kind = "interaction"
 tag = "ARE_BYTES"
 input = [0, "X"]
-multiplicity = "μ"
+multiplicity = "cond"
 ref = "isbyte:c:isbyte"

--- a/spec/src/is_byte.toml
+++ b/spec/src/is_byte.toml
@@ -1,0 +1,21 @@
+name = "IS_BYTE"
+
+[[variables.input]]
+name = "X"
+type = "BaseField"
+desc = "Value for which to assert that it lies in the range $[0, 255]$."
+
+[[variables.multiplicity]]
+name = "μ"
+type = "BaseField"
+desc = ""
+
+[[constraint_groups]]
+name = "all"
+
+[[constraints.all]]
+kind = "interaction"
+tag = "ARE_BYTES"
+input = [0, "X"]
+multiplicity = "μ"
+ref = "isbyte:c:isbyte"

--- a/spec/src/keccak_round.toml
+++ b/spec/src/keccak_round.toml
@@ -211,18 +211,16 @@ multiplicity = "μ"
 # Cxz_left  = [-1,  256, -1,  256, -1,  256, -1,  256] and
 # Cxz_right = [ 1, -256,  1, -256,  1, -256,  1, -256]
 [[constraints.theta]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = [["idx", ["idx", "Cxz_left", "x"], "z"]]
+input = [["idx", ["idx", "Cxz_left", "x"], "z"], "μ"]
 iters = [["x", 0, 4], ["z", 0, 7]]
-multiplicity = "μ"
 
 [[constraints.theta]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = [["idx", ["idx", "Cxz_right", "x"], "z"]]
+input = [["idx", ["idx", "Cxz_right", "x"], "z"], "μ"]
 iters = [["x", 0, 4], ["z", 0, 7]]
-multiplicity = "μ"
 
 [[constraints.theta]]
 kind = "interaction"
@@ -257,18 +255,16 @@ multiplicity = "μ"
 # rot_left  = [-1,  256, -1,  256, -1,  256, -1,  256] and
 # rot_right = [ 1, -256,  1, -256,  1, -256,  1, -256]
 [[constraints.rho]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = [["idx", ["idx", ["idx", "rot_left", "x"], "y"], "z"]]
-iters = [["x", 0, 4], ["y", 0, 4], ["z", 0, 7]]
-multiplicity = "μ"
+input = [["idx", ["idx", ["idx", "rot_left", "x"], "y"], "z"], "μ"]
+iters = [["x", 0, 4], ["y", 0, 4], ["z", 0, 7]] 
 
 [[constraints.rho]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = [["idx", ["idx", ["idx", "rot_right", "x"], "y"], "z"]]
+input = [["idx", ["idx", ["idx", "rot_right", "x"], "y"], "z"], "μ"]
 iters = [["x", 0, 4], ["y", 0, 4], ["z", 0, 7]]
-multiplicity = "μ"
 
 [[constraint_groups]]
 name = "chi"

--- a/spec/src/keccak_round.toml
+++ b/spec/src/keccak_round.toml
@@ -213,14 +213,16 @@ multiplicity = "μ"
 [[constraints.theta]]
 kind = "template"
 tag = "IS_BYTE"
-input = [["idx", ["idx", "Cxz_left", "x"], "z"], "μ"]
+input = [["idx", ["idx", "Cxz_left", "x"], "z"]]
 iters = [["x", 0, 4], ["z", 0, 7]]
+cond = "μ"
 
 [[constraints.theta]]
 kind = "template"
 tag = "IS_BYTE"
-input = [["idx", ["idx", "Cxz_right", "x"], "z"], "μ"]
+input = [["idx", ["idx", "Cxz_right", "x"], "z"]]
 iters = [["x", 0, 4], ["z", 0, 7]]
+cond = "μ"
 
 [[constraints.theta]]
 kind = "interaction"
@@ -257,14 +259,16 @@ multiplicity = "μ"
 [[constraints.rho]]
 kind = "template"
 tag = "IS_BYTE"
-input = [["idx", ["idx", ["idx", "rot_left", "x"], "y"], "z"], "μ"]
+input = [["idx", ["idx", ["idx", "rot_left", "x"], "y"], "z"]]
 iters = [["x", 0, 4], ["y", 0, 4], ["z", 0, 7]] 
+cond = "μ"
 
 [[constraints.rho]]
 kind = "template"
 tag = "IS_BYTE"
-input = [["idx", ["idx", ["idx", "rot_right", "x"], "y"], "z"], "μ"]
+input = [["idx", ["idx", ["idx", "rot_right", "x"], "y"], "z"]]
 iters = [["x", 0, 4], ["y", 0, 4], ["z", 0, 7]]
+cond = "μ"
 
 [[constraint_groups]]
 name = "chi"

--- a/spec/src/page.toml
+++ b/spec/src/page.toml
@@ -42,12 +42,12 @@ name = "all"
 [[constraints.all]]
 kind = "template"
 tag = "IS_BYTE"
-input = ["init", 1]
+input = ["init"]
 
 [[constraints.all]]
 kind = "template"
 tag = "IS_BYTE"
-input = ["fini", 1]
+input = ["fini"]
 
 [[constraints.all]]
 kind = "interaction"

--- a/spec/src/page.toml
+++ b/spec/src/page.toml
@@ -40,16 +40,14 @@ def = ["+", "page", ["*", "offset", ["cast", 1, "DWordWL"]]]
 name = "all"
 
 [[constraints.all]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = ["init"]
-multiplicity = 1
+input = ["init", 1]
 
 [[constraints.all]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = ["fini"]
-multiplicity = 1
+input = ["fini", 1]
 
 [[constraints.all]]
 kind = "interaction"

--- a/spec/src/sha256.toml
+++ b/spec/src/sha256.toml
@@ -234,8 +234,9 @@ multiplicity = ["-", "μ"]
 [[constraints.compress]]
 kind = "template"
 tag = "IS_BYTE"
-input = [["idx", "out", "i"], "μ"]
+input = [["idx", "out", "i"]]
 iter = ["i", 0, 31]
+cond = "μ"
 
 [[constraints.compress]]
 kind = "template"

--- a/spec/src/sha256.toml
+++ b/spec/src/sha256.toml
@@ -232,10 +232,9 @@ input = ["timestamp", "last_round_out", 64]
 multiplicity = ["-", "μ"]
 
 [[constraints.compress]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = [["idx", "out", "i"]]
-multiplicity = "μ"
+input = [["idx", "out", "i"], "μ"]
 iter = ["i", 0, 31]
 
 [[constraints.compress]]

--- a/spec/src/sha256msgsched.toml
+++ b/spec/src/sha256msgsched.toml
@@ -81,7 +81,8 @@ name = "lookback"
 [[constraints.lookback]]
 kind = "template"
 tag = "IS_BYTE"
-input = [["-", "index", 16], "μ"]
+input = [["-", "index", 16]]
+cond = "μ"
 
 [[constraints.lookback]]
 kind = "interaction"
@@ -131,7 +132,8 @@ multiplicity = "μ"
 [[constraints.calc]]
 kind = "template"
 tag = "IS_BYTE"
-input = ["carry", "μ"]
+input = ["carry"]
+cond = "μ"
 
 [[constraints.calc]]
 kind = "interaction"

--- a/spec/src/sha256msgsched.toml
+++ b/spec/src/sha256msgsched.toml
@@ -79,10 +79,9 @@ desc = "#`IS_WORD[SHA256_M[timestamp, i]]` for $0 <= i < #`index`$"
 name = "lookback"
 
 [[constraints.lookback]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = [["-", "index", 16]]
-multiplicity = "μ"
+input = [["-", "index", 16], "μ"]
 
 [[constraints.lookback]]
 kind = "interaction"
@@ -130,10 +129,9 @@ output = "s1"
 multiplicity = "μ"
 
 [[constraints.calc]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = ["carry"]
-multiplicity = "μ"
+input = ["carry", "μ"]
 
 [[constraints.calc]]
 kind = "interaction"

--- a/spec/src/sha256round.toml
+++ b/spec/src/sha256round.toml
@@ -256,7 +256,8 @@ iter = ["i", 0, 1]
 [[constraints.addition]]
 kind = "template"
 tag = "IS_BYTE"
-input = ["carry_a", "μ"]
+input = ["carry_a"]
+cond = "μ"
 
 [[constraints.addition]]
 kind = "interaction"
@@ -268,7 +269,8 @@ iter = ["i", 0, 1]
 [[constraints.addition]]
 kind = "template"
 tag = "IS_BYTE"
-input = ["carry_e", "μ"]
+input = ["carry_e"]
+cond = "μ"
 
 [[constraint_groups]]
 name = "output"

--- a/spec/src/sha256round.toml
+++ b/spec/src/sha256round.toml
@@ -254,10 +254,9 @@ multiplicity = "μ"
 iter = ["i", 0, 1]
 
 [[constraints.addition]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = ["carry_a"]
-multiplicity = "μ"
+input = ["carry_a", "μ"]
 
 [[constraints.addition]]
 kind = "interaction"
@@ -267,10 +266,9 @@ multiplicity = "μ"
 iter = ["i", 0, 1]
 
 [[constraints.addition]]
-kind = "interaction"
+kind = "template"
 tag = "IS_BYTE"
-input = ["carry_e"]
-multiplicity = "μ"
+input = ["carry_e", "μ"]
 
 [[constraint_groups]]
 name = "output"

--- a/spec/src/shift.toml
+++ b/spec/src/shift.toml
@@ -147,7 +147,7 @@ iter = ["i", 0, 3]
 ref = "shift:a:range_in"
 
 [[assumptions]]
-desc = "`IS_BYTE[shift]`"
+desc = "`IS_BYTE<shift>`"
 ref = "shift:a:range_shift"
 
 [[assumptions]]

--- a/spec/src/signatures.toml
+++ b/spec/src/signatures.toml
@@ -163,12 +163,6 @@ kind = "interaction"
 input = ["B20"]
 output = "Bit"
 
-# IS_BYTE[X]
-[[signatures]]
-tag = "IS_BYTE"
-kind = "interaction"
-input = ["Byte"]
-
 # ARE_BYTES[X, Y]
 [[signatures]]
 tag = "ARE_BYTES"

--- a/spec/src/signatures.toml
+++ b/spec/src/signatures.toml
@@ -163,6 +163,12 @@ tag = "IS_BYTE"
 kind = "interaction"
 input = ["Byte"]
 
+# ARE_BYTES[X, Y]
+[[signatures]]
+tag = "ARE_BYTES"
+kind = "interaction"
+input = ["Byte", "Byte"]
+
 # IS_HALF[X]
 [[signatures]]
 tag = "IS_HALF"

--- a/spec/src/signatures.toml
+++ b/spec/src/signatures.toml
@@ -5,6 +5,12 @@ kind = "template"
 input = ["BaseField"]
 cond = "BaseField"
 
+# IS_BYTE<X, μ>
+[[signatures]]
+tag = "IS_BYTE"
+kind = "template"
+input = ["BaseField", "BaseField"]
+
 # cond => ADD<sum; lhs, rhs>
 [[signatures]]
 tag = "ADD"

--- a/spec/src/signatures.toml
+++ b/spec/src/signatures.toml
@@ -9,7 +9,8 @@ cond = "BaseField"
 [[signatures]]
 tag = "IS_BYTE"
 kind = "template"
-input = ["BaseField", "BaseField"]
+input = ["BaseField"]
+cond = "BaseField"
 
 # cond => ADD<sum; lhs, rhs>
 [[signatures]]


### PR DESCRIPTION
i) introduces the `ARE_BYTES` lookup,
ii) introduces the `IS_BYTE<X, μ>` template that maps to `ARE_BYTES[0, X]/μ`
iii) removes the `IS_BYTE` lookup