### PR TITLE
spec: shiroa fixes

### DIFF
--- a/spec/.gitignore
+++ b/spec/.gitignore
@@ -1,2 +1,3 @@
 dist/*
+interaction_count.json
 ebook.pdf

--- a/spec/book.typ
+++ b/spec/book.typ
@@ -106,6 +106,7 @@
 
 // Invisibly include another chapter, so that its labels can be resolved
 #let xref-include(f) = {
+  show ref: none
   context {
     place(hide(box(width: auto, height: 0%, strip-all(include "/" + f))))
   }
@@ -170,13 +171,19 @@
         }
       })
       let cond() = _toplevel.final() == file
-      project.with(..args, title: context meta_sections.find(x => x.at(0) == _toplevel.final()).at(1), cond: cond)([
-        #show ref: it => context if _toplevel.final() == file {
-          xref(it)
-        }
+      show ref: it => context if _toplevel.final() == file {
+        xref(it)
+      }
+      let title = context {
+        // Strip raw, because shiroa already makes the title raw
+        show raw: it => it.text
+        meta_sections.find(x => x.at(0) == _toplevel.final()).at(1)
+      }
+      project.with(..args, title: title, description: plain-text(meta_sections.find(x => x.at(0) == file).at(1)), cond: cond)([
         #context _xref-included.final().pairs().map(((key, value)) => context if value and cond() {
           xref-include(key)
         }).join()
+        #metadata(json("interaction_count.json").sum(default: (:)))<interaction_count>
         #body
       ])
     }

--- a/spec/book.typ
+++ b/spec/book.typ
@@ -171,9 +171,7 @@
         }
       })
       let cond() = _toplevel.final() == file
-      show ref: it => context if _toplevel.final() == file {
-        xref(it)
-      }
+      show ref: it => context if cond() { xref(it) }
       let title = context {
         // Strip raw, because shiroa already makes the title raw
         show raw: it => it.text

--- a/spec/build_shiroa.sh
+++ b/spec/build_shiroa.sh
@@ -14,5 +14,14 @@ trap 'rm -f interaction_count.json' EXIT
 # Query the ebook version for the proper counts
 typst query ebook.typ '<interaction_count>' --field value > interaction_count.json
 
+# Check if there's enough memory available for a parallel shiroa build
+# 20GiB as comfortable baseline
+available_kb=$(awk '/MemAvailable/ { print $2 }' /proc/meminfo)
+required_kb=$((20 * 1024 * 1024))
+if [ "$available_kb" -lt "$required_kb" ]; then
+  echo "Falling back to single-thread"
+  export RAYON_NUM_THREADS=1
+fi
+
 # And build
 shiroa build

--- a/spec/build_shiroa.sh
+++ b/spec/build_shiroa.sh
@@ -2,6 +2,17 @@
 
 set -euo pipefail
 
-typst query ebook.typ '<interaction_count>' --field value > interaction_count.json
-shiroa build
+# cd into the script directory
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Clean up potential old file
 rm -f interaction_count.json
+
+# Always clean up after ourselves
+trap 'rm -f interaction_count.json' EXIT
+
+# Query the ebook version for the proper counts
+typst query ebook.typ '<interaction_count>' --field value > interaction_count.json
+
+# And build
+shiroa build

--- a/spec/build_shiroa.sh
+++ b/spec/build_shiroa.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+typst query ebook.typ '<interaction_count>' --field value > interaction_count.json
+shiroa build
+rm -f interaction_count.json

--- a/spec/chip.typ
+++ b/spec/chip.typ
@@ -48,14 +48,19 @@
 // store it as metadata under the `<interaction_count>` label
 // with tag `chip.name`. This tag is overwritten by `name` when specified.
 #let set_nr_interactions(chip, name: none) = {
+  // Skip when building shiroa, since the web/chapter structure fails to converge properly
+  import "book.typ": is-shiroa
+  if is-shiroa {
+    return
+  }
   if name == none {
-      name = chip.name
-    }
+    name = chip.name
+  }
 
   let constraints = chip
     .constraints
     .values()
-    .flatten()
+    .sum(default: ())
 
   // nr. of direct interactions
   let nr-direct-interactions = constraints


### PR DESCRIPTION
- Strip raw blocks from chapter titles for `project` argument
- Add an explicit description (based on chapter title) to chapters to avoid compilation issues when context appears early in the chapter
- Export interaction counts from the pdf version to use in shiroa, since otherwise we run into convergence issues that are hard to debug