### PR TITLE
perf(stark): parallelize open_deep_composition_poly over query indices

### DIFF
--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -1403,14 +1403,20 @@ pub trait IsStarkProver<
         FieldElement<Field>: AsBytes,
         FieldElement<FieldExtension>: AsBytes,
     {
-        let mut openings = Vec::with_capacity(indexes_to_open.len());
-
         // Check if this is a preprocessed table (has separate precomputed tree)
         let is_preprocessed = round_1_result.main.precomputed_merkle_tree.is_some();
         let num_precomputed_cols = round_1_result.main.num_precomputed_cols;
         let total_cols = round_1_result.lde_trace.num_main_cols();
 
-        for index in indexes_to_open.iter() {
+        // Each query is independent: its Merkle proofs and row gathers only read
+        // from shared (immutable) trees and the LDE. Runs after FRI commit so
+        // cross-table outer parallelism has already wound down.
+        #[cfg(feature = "parallel")]
+        let iter = indexes_to_open.par_iter();
+        #[cfg(not(feature = "parallel"))]
+        let iter = indexes_to_open.iter();
+
+        iter.map(|index| {
             // For preprocessed tables, open main (multiplicities) with column range
             // For normal tables, open all columns
             let main_trace_opening = if is_preprocessed {
@@ -1462,15 +1468,14 @@ pub trait IsStarkProver<
                 )
             });
 
-            openings.push(DeepPolynomialOpening {
+            DeepPolynomialOpening {
                 composition_poly: composition_openings,
                 main_trace_polys: main_trace_opening,
                 precomputed_trace_polys: precomputed_trace_opening,
                 aux_trace_polys,
-            });
-        }
-
-        openings
+            }
+        })
+        .collect()
     }
 
     // TODO: propagate errors instead of unwrap() in commit_columns, reconstruct_round1, and expand_columns_to_lde


### PR DESCRIPTION
The deep composition opening loop iterates over ~90 query indices (iotas), and each iteration does independent Merkle-proof-by-pos calls and row gathers. These reads only touch shared immutable data (Merkle trees, LDE trace, composition poly tree), so parallelizing the loop is safe.

This runs after the FRI commit phase, where the cross-table outer parallelism has already wound down, so there's spare capacity to exploit.