### PR TITLE
perf(stark): fuse Round 4 DEEP LDE extend into single in-place buffer

### DIFF
--- a/crypto/math/src/fft/polynomial.rs
+++ b/crypto/math/src/fft/polynomial.rs
@@ -257,6 +257,65 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
 
         Ok(())
     }
+
+    /// In-place non-coset LDE: the buffer already contains N evaluation points on the
+    /// N-point (non-offset) domain. Expands to `N * blowup_factor` evaluations on the
+    /// `N * blowup_factor`-point (non-offset) domain.
+    ///
+    /// Steps:
+    /// 1. bit-reverse buffer[..N]; iFFT in place
+    /// 2. Scale buffer[..N] by 1/N
+    /// 3. Zero-pad to `N * blowup_factor`
+    /// 4. Forward FFT on the full buffer; bit-reverse
+    ///
+    /// This is mathematically equivalent to `interpolate_fft_with_twiddles` followed by
+    /// resizing the resulting coefficient vector and calling
+    /// `evaluate_fft_with_twiddles`, but avoids 4–5 intermediate Vec clones of N elements.
+    ///
+    /// Used for the Round 4 DEEP composition polynomial extension: input evaluations
+    /// on a trace-size coset are treated as f(ω_N^i) for f(x) = h(g·x). After
+    /// expansion, the output equals f on the 2N-th roots of unity, which coincides
+    /// with h on the 2N-point g-coset — i.e. the LDE values needed by FRI.
+    pub fn fft_expand_in_place<F: IsFFTField + IsSubFieldOf<E> + Send + Sync>(
+        buffer: &mut Vec<FieldElement<E>>,
+        blowup_factor: usize,
+        inv_twiddles: &LayerTwiddles<F>,
+        fwd_twiddles: &LayerTwiddles<F>,
+    ) -> Result<(), FFTError>
+    where
+        E: Send + Sync,
+    {
+        let n = buffer.len();
+        if n == 0 {
+            return Ok(());
+        }
+        if !n.is_power_of_two() {
+            return Err(FFTError::InputError(n));
+        }
+        let lde_size = n * blowup_factor;
+
+        if (lde_size.trailing_zeros() as u64) > F::TWO_ADICITY {
+            return Err(FFTError::DomainSizeError(lde_size.trailing_zeros() as usize));
+        }
+
+        in_place_bit_reverse_permute(&mut buffer[..n]);
+        dispatch_ifft(&mut buffer[..n], inv_twiddles)?;
+
+        // Scale by 1/n — base field scalar, F × E → E mixed multiplication.
+        let n_inv = FieldElement::<F>::from(n as u64)
+            .inv()
+            .expect("n is a power of two, hence non-zero in the field");
+        for coeff in buffer[..n].iter_mut() {
+            *coeff = &n_inv * &*coeff;
+        }
+
+        buffer.resize(lde_size, FieldElement::zero());
+
+        dispatch_fft(buffer, fwd_twiddles)?;
+        in_place_bit_reverse_permute(buffer);
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
-use math::fft::cpu::bit_reversing::{in_place_bit_reverse_permute, reverse_index};
+use math::fft::cpu::bit_reversing::reverse_index;
 use math::fft::cpu::bowers_fft::LayerTwiddles;
 use math::fft::errors::FFTError;
 
@@ -1057,10 +1057,14 @@ pub trait IsStarkProver<
         // <<<< Receive challenges: 𝛾ⱼ, 𝛾ⱼ'
         let gammas = deep_composition_coefficients;
 
-        // Compute p₀ (deep composition polynomial) as N evaluations on trace-size coset
+        // Compute p₀ (deep composition polynomial) as N evaluations on trace-size coset.
+        // The buffer is allocated at 2N capacity so `fft_expand_in_place` can grow
+        // in place without reallocating.
+        let domain_size = domain.lde_roots_of_unity_coset.len();
+        let n = domain.interpolation_domain_size;
         #[cfg(feature = "instruments")]
         let t_sub = Instant::now();
-        let deep_evals = Self::compute_deep_composition_poly_evaluations(
+        let mut lde_evals = Self::compute_deep_composition_poly_evaluations(
             &round_1_result.lde_trace,
             round_2_result,
             round_3_result,
@@ -1070,20 +1074,37 @@ pub trait IsStarkProver<
             &gammas,
             &trace_term_coeffs,
         );
+        // Ensure the buffer has capacity for the LDE-sized output so the subsequent
+        // `resize(domain_size, zero)` inside `fft_expand_in_place` is realloc-free.
+        lde_evals.reserve_exact(domain_size - lde_evals.len());
         #[cfg(feature = "instruments")]
         let other_dur_1 = t_sub.elapsed();
 
-        // Extend N trace-coset evaluations to 2N LDE-coset evaluations via standard LDE.
-        // deep_evals[i] = h(offset·ω_N^i) = f(ω_N^i) where f(x) = h(offset·x).
-        // Standard iFFT+FFT recovers f and evaluates on the 2N-th roots: f(Ω^j) = h(offset·Ω^j).
-        let domain_size = domain.lde_roots_of_unity_coset.len();
+        // Extend N trace-coset evaluations to 2N LDE-coset evaluations via a fused
+        // in-place iFFT + zero-pad + FFT on a single buffer.
+        // `deep_evals[i] = h(offset·ω_N^i) = f(ω_N^i)` where `f(x) = h(offset·x)`.
+        // Non-offset iFFT + non-offset FFT(2N) recovers `f(Ω^j) = h(offset·Ω^j)`,
+        // i.e. h on the 2N-point g-coset (the LDE domain).
+        //
+        // This replaces the old `interpolate_fft → coefficients.to_vec → evaluate_fft`
+        // chain, eliminating 4–5 full-N intermediate clones of extension-field data.
         #[cfg(feature = "instruments")]
         let t_sub = Instant::now();
-        let deep_poly =
-            Polynomial::interpolate_fft::<Field>(&deep_evals).expect("iFFT should succeed");
-        let mut lde_evals = Polynomial::evaluate_fft::<Field>(&deep_poly, 1, Some(domain_size))
-            .expect("FFT should succeed");
-        in_place_bit_reverse_permute(&mut lde_evals);
+        let inv_twiddles = LayerTwiddles::<Field>::new_inverse(n.trailing_zeros() as u64)
+            .expect("valid inverse twiddles");
+        let fwd_twiddles = LayerTwiddles::<Field>::new(domain_size.trailing_zeros() as u64)
+            .expect("valid forward twiddles");
+        Polynomial::<FieldElement<FieldExtension>>::fft_expand_in_place::<Field>(
+            &mut lde_evals,
+            domain.blowup_factor,
+            &inv_twiddles,
+            &fwd_twiddles,
+        )
+        .expect("in-place FFT expansion");
+        // FRI commit expects bit-reversed evaluations. `fft_expand_in_place` returns
+        // natural-order evaluations (matching `coset_lde_full_expand`), so bit-reverse
+        // once here — same as the original code did after `evaluate_fft`.
+        math::fft::cpu::bit_reversing::in_place_bit_reverse_permute(&mut lde_evals);
         #[cfg(feature = "instruments")]
         let r4_fft_dur = t_sub.elapsed();
 


### PR DESCRIPTION
The Round 4 deep composition polynomial was extended from N to 2N evaluations via a 4-statement chain:

    let deep_poly = Polynomial::interpolate_fft(&deep_evals)?;
    let mut lde_evals = Polynomial::evaluate_fft(&deep_poly, 1, Some(domain_size))?;
    in_place_bit_reverse_permute(&mut lde_evals);

Each helper internally allocates a fresh Vec of extension-field data: interpolate_fft runs `to_vec` + `Polynomial::new(cloned().collect())` + `scale_coeffs(collect())`, and evaluate_fft adds another `to_vec`. With N = 2^20 and cubic-extension Goldilocks (24 bytes/elem), each clone is ~24 MiB and there are four of them per table. Across 14+ tables per proof, that's >1 GiB of pure memory-bandwidth-bound memcpy work for no computation.

Add `Polynomial::fft_expand_in_place` that grows a single buffer from N to 2N in place:

    in_place_bit_reverse_permute(buffer[..n])
    dispatch_ifft(buffer[..n])
    scale by 1/n
    buffer.resize(2n, zero)
    dispatch_fft(buffer)
    in_place_bit_reverse_permute(buffer)

Output is in natural order, matching `coset_lde_full_expand`. The Round 4 caller pre-reserves 2N capacity on the `deep_evals` buffer returned by `compute_deep_composition_poly_evaluations`, then calls fft_expand_in_place and bit-reverses once for FRI (same final ordering as before).

All existing tests pass (121/121 in stark lib).