### PR TITLE
perf: skip redundant bit-reverse pair in R4 deep-composition LDE

### DIFF
--- a/crypto/math/src/fft/polynomial.rs
+++ b/crypto/math/src/fft/polynomial.rs
@@ -94,9 +94,6 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     {
         let domain_size = domain_size.unwrap_or(0);
         let len = core::cmp::max(poly.coeff_len(), domain_size).next_power_of_two() * blowup_factor;
-        if !len.is_power_of_two() {
-            return Err(FFTError::InputError(len));
-        }
         if len.trailing_zeros() as u64 > F::TWO_ADICITY {
             return Err(FFTError::DomainSizeError(len.trailing_zeros() as usize));
         }
@@ -107,11 +104,7 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
         let mut coeffs = poly.coefficients().to_vec();
         coeffs.resize(len, FieldElement::zero());
 
-        let order = len.trailing_zeros() as u64;
-        let layer_twiddles =
-            LayerTwiddles::<F>::new(order).ok_or(FFTError::DomainSizeError(order as usize))?;
-        dispatch_fft(&mut coeffs, &layer_twiddles)?;
-        Ok(coeffs)
+        evaluate_fft_cpu_raw::<F, E>(&coeffs, false)
     }
 
     /// Returns `N` evaluations with an offset of this polynomial using FFT over a domain in a subfield F of E
@@ -317,6 +310,17 @@ where
     F: IsFFTField + IsSubFieldOf<E>,
     E: IsField + Send + Sync,
 {
+    evaluate_fft_cpu_raw::<F, E>(coeffs, true)
+}
+
+fn evaluate_fft_cpu_raw<F, E>(
+    coeffs: &[FieldElement<E>],
+    permute_to_natural: bool,
+) -> Result<Vec<FieldElement<E>>, FFTError>
+where
+    F: IsFFTField + IsSubFieldOf<E>,
+    E: IsField + Send + Sync,
+{
     let n = coeffs.len();
     if !n.is_power_of_two() {
         return Err(FFTError::InputError(n));
@@ -327,7 +331,9 @@ where
 
     let mut result = coeffs.to_vec();
     dispatch_fft(&mut result, &layer_twiddles)?;
-    in_place_bit_reverse_permute(&mut result);
+    if permute_to_natural {
+        in_place_bit_reverse_permute(&mut result);
+    }
     Ok(result)
 }
 

--- a/crypto/math/src/fft/polynomial.rs
+++ b/crypto/math/src/fft/polynomial.rs
@@ -80,6 +80,37 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
         evaluate_fft_cpu::<F, E>(&coeffs)
     }
 
+    /// Same as `evaluate_fft` but returns the evaluations in bit-reversed order,
+    /// skipping the final natural-order permutation. Use when the consumer expects
+    /// bit-reversed input (e.g. FRI commit phase, which pairs consecutive values as
+    /// {f(x), f(-x)}).
+    pub fn evaluate_fft_bit_reversed<F: IsFFTField + IsSubFieldOf<E>>(
+        poly: &Polynomial<FieldElement<E>>,
+        blowup_factor: usize,
+        domain_size: Option<usize>,
+    ) -> Result<Vec<FieldElement<E>>, FFTError>
+    where
+        E: Send + Sync,
+    {
+        let domain_size = domain_size.unwrap_or(0);
+        let len = core::cmp::max(poly.coeff_len(), domain_size).next_power_of_two() * blowup_factor;
+        if len.trailing_zeros() as u64 > F::TWO_ADICITY {
+            return Err(FFTError::DomainSizeError(len.trailing_zeros() as usize));
+        }
+        if poly.coefficients().is_empty() {
+            return Ok(vec![FieldElement::zero(); len]);
+        }
+
+        let mut coeffs = poly.coefficients().to_vec();
+        coeffs.resize(len, FieldElement::zero());
+
+        let order = len.trailing_zeros() as u64;
+        let layer_twiddles =
+            LayerTwiddles::<F>::new(order).ok_or(FFTError::DomainSizeError(order as usize))?;
+        dispatch_fft(&mut coeffs, &layer_twiddles)?;
+        Ok(coeffs)
+    }
+
     /// Returns `N` evaluations with an offset of this polynomial using FFT over a domain in a subfield F of E
     /// (so the results are P(w^i), with w being a primitive root of unity).
     /// `N = max(self.coeff_len(), domain_size).next_power_of_two() * blowup_factor`.

--- a/crypto/math/src/fft/polynomial.rs
+++ b/crypto/math/src/fft/polynomial.rs
@@ -94,6 +94,9 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     {
         let domain_size = domain_size.unwrap_or(0);
         let len = core::cmp::max(poly.coeff_len(), domain_size).next_power_of_two() * blowup_factor;
+        if !len.is_power_of_two() {
+            return Err(FFTError::InputError(len));
+        }
         if len.trailing_zeros() as u64 > F::TWO_ADICITY {
             return Err(FFTError::DomainSizeError(len.trailing_zeros() as usize));
         }

--- a/crypto/math/src/tests/fft_tests.rs
+++ b/crypto/math/src/tests/fft_tests.rs
@@ -229,14 +229,13 @@ mod fft_polynomial_tests {
             }
 
             // Property-based test that ensures evaluate_fft_bit_reversed returns the same
-            // values as evaluate_fft followed by an in-place bit-reverse permutation.
+            // values as evaluate_fft followed by an in-place bit-reverse permutation,
+            // across varying blowup factors.
             #[test]
-            fn test_fft_bit_reversed_matches_evaluate_fft_then_permute(poly in poly(8)
-                                                           .prop_filter("Avoid polynomials of size not power of two",
-                                                                        |poly| poly.coeff_len().is_power_of_two())) {
-                let mut expected = Polynomial::evaluate_fft::<F>(&poly, 1, None).unwrap();
+            fn test_fft_bit_reversed_matches_evaluate_fft_then_permute(poly in poly(6), blowup_factor in powers_of_two(4)) {
+                let mut expected = Polynomial::evaluate_fft::<F>(&poly, blowup_factor, None).unwrap();
                 in_place_bit_reverse_permute(&mut expected);
-                let got = Polynomial::evaluate_fft_bit_reversed::<F>(&poly, 1, None).unwrap();
+                let got = Polynomial::evaluate_fft_bit_reversed::<F>(&poly, blowup_factor, None).unwrap();
                 prop_assert_eq!(got, expected);
             }
 
@@ -265,6 +264,24 @@ mod fft_polynomial_tests {
                 compose_fft::<F, F>(&p, &q),
                 Polynomial::new(&[FE::new(0), FE::new(0), FE::new(0), FE::new(2)])
             );
+        }
+
+        #[test]
+        fn fft_bit_reversed_handles_domain_size_greater_than_coeff_len() {
+            let poly = Polynomial::new(&[FE::new(1), FE::new(2), FE::new(3)]);
+            let domain_size = 32;
+            let mut expected = Polynomial::evaluate_fft::<F>(&poly, 1, Some(domain_size)).unwrap();
+            in_place_bit_reverse_permute(&mut expected);
+            let got =
+                Polynomial::evaluate_fft_bit_reversed::<F>(&poly, 1, Some(domain_size)).unwrap();
+            assert_eq!(got, expected);
+        }
+
+        #[test]
+        fn fft_bit_reversed_returns_zeros_for_empty_polynomial() {
+            let poly: Polynomial<FE> = Polynomial::new(&[]);
+            let got = Polynomial::evaluate_fft_bit_reversed::<F>(&poly, 1, Some(8)).unwrap();
+            assert_eq!(got, vec![FE::zero(); 8]);
         }
     }
 

--- a/crypto/math/src/tests/fft_tests.rs
+++ b/crypto/math/src/tests/fft_tests.rs
@@ -48,6 +48,7 @@ mod fft_helpers_test {
 mod fft_polynomial_tests {
     use crate::field::traits::IsField;
 
+    use crate::fft::cpu::bit_reversing::in_place_bit_reverse_permute;
     use crate::fft::cpu::roots_of_unity::{
         get_powers_of_primitive_root, get_powers_of_primitive_root_coset,
     };
@@ -225,6 +226,18 @@ mod fft_polynomial_tests {
                 let (poly, new_poly) = gen_fft_interpolate_and_evaluate(poly);
 
                 prop_assert_eq!(poly, new_poly);
+            }
+
+            // Property-based test that ensures evaluate_fft_bit_reversed returns the same
+            // values as evaluate_fft followed by an in-place bit-reverse permutation.
+            #[test]
+            fn test_fft_bit_reversed_matches_evaluate_fft_then_permute(poly in poly(8)
+                                                           .prop_filter("Avoid polynomials of size not power of two",
+                                                                        |poly| poly.coeff_len().is_power_of_two())) {
+                let mut expected = Polynomial::evaluate_fft::<F>(&poly, 1, None).unwrap();
+                in_place_bit_reverse_permute(&mut expected);
+                let got = Polynomial::evaluate_fft_bit_reversed::<F>(&poly, 1, None).unwrap();
+                prop_assert_eq!(got, expected);
             }
 
             #[test]

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crypto::fiat_shamir::is_transcript::IsStarkTranscript;
-use math::fft::cpu::bit_reversing::{in_place_bit_reverse_permute, reverse_index};
+use math::fft::cpu::bit_reversing::reverse_index;
 use math::fft::cpu::bowers_fft::LayerTwiddles;
 use math::fft::errors::FFTError;
 
@@ -1109,9 +1109,12 @@ pub trait IsStarkProver<
         let t_sub = Instant::now();
         let deep_poly =
             Polynomial::interpolate_fft::<Field>(&deep_evals).expect("iFFT should succeed");
-        let mut lde_evals = Polynomial::evaluate_fft::<Field>(&deep_poly, 1, Some(domain_size))
-            .expect("FFT should succeed");
-        in_place_bit_reverse_permute(&mut lde_evals);
+        // FRI commit_phase consumes bit-reversed evaluations natively. Request them
+        // directly from evaluate_fft_bit_reversed to avoid a pair of redundant permutes
+        // (evaluate_fft's internal natural-order permute + an external re-bit-reverse).
+        let lde_evals =
+            Polynomial::evaluate_fft_bit_reversed::<Field>(&deep_poly, 1, Some(domain_size))
+                .expect("FFT should succeed");
         #[cfg(feature = "instruments")]
         let r4_fft_dur = t_sub.elapsed();
 


### PR DESCRIPTION
Optimization extracted from [PR #545](https://github.com/yetanotherco/lambda_vm/pull/545).

The R4 deep-composition LDE ran `evaluate_fft` (ends with a natural-order permute) followed by
`in_place_bit_reverse_permute` to feed FRI's commit phase, which already expects bit-reversed
evaluations. The two permutes cancel out.

This PR adds `Polynomial::evaluate_fft_bit_reversed` (same as `evaluate_fft` but skips the final
permute) and switches the R4 LDE site to use it, dropping both cancelling permutes.