### PR TITLE
fix bench

### DIFF
--- a/bench_vs/lambda/fibonacci/src/main.rs
+++ b/bench_vs/lambda/fibonacci/src/main.rs
@@ -14,9 +14,16 @@ fn panic(_info: &PanicInfo) -> ! {
 }
 
 fn read_n() -> u64 {
+    // Layout matches `syscalls::get_private_input`: 4-byte LE length prefix at
+    // PRIVATE_INPUT_START, payload at +4. We only need the first 8 bytes (u64).
     let mut n_bytes = [0u8; 8];
-    let input_data = (PRIVATE_INPUT_START + 4) as *const u8;
 
+    debug_assert!(
+        unsafe { core::ptr::read_volatile(PRIVATE_INPUT_START as *const u32) } >= 8,
+        "private input too short to contain a u64"
+    );
+
+    let input_data = (PRIVATE_INPUT_START + 4) as *const u8;
     for (i, byte) in n_bytes.iter_mut().enumerate() {
         *byte = unsafe { core::ptr::read_volatile(input_data.add(i)) };
     }

--- a/bench_vs/lambda/fibonacci/src/main.rs
+++ b/bench_vs/lambda/fibonacci/src/main.rs
@@ -4,7 +4,7 @@
 use core::arch::asm;
 use core::panic::PanicInfo;
 
-const SYSCALL_GET_PRIVATE_INPUTS: u64 = 4;
+const PRIVATE_INPUT_START: usize = 0xFF000000;
 const SYSCALL_COMMIT: u64 = 64;
 const SYSCALL_HALT: u64 = 93;
 
@@ -14,18 +14,13 @@ fn panic(_info: &PanicInfo) -> ! {
 }
 
 fn read_n() -> u64 {
-    let mut input = [0u8; 12];
+    let mut n_bytes = [0u8; 8];
+    let input_data = (PRIVATE_INPUT_START + 4) as *const u8;
 
-    unsafe {
-        asm!(
-            "ecall",
-            in("a0") input.as_mut_ptr(),
-            in("a7") SYSCALL_GET_PRIVATE_INPUTS,
-        );
+    for (i, byte) in n_bytes.iter_mut().enumerate() {
+        *byte = unsafe { core::ptr::read_volatile(input_data.add(i)) };
     }
 
-    let mut n_bytes = [0u8; 8];
-    n_bytes.copy_from_slice(&input[4..12]);
     u64::from_le_bytes(n_bytes)
 }
 

--- a/bench_vs/lambda/fibonacci/src/main.rs
+++ b/bench_vs/lambda/fibonacci/src/main.rs
@@ -24,9 +24,7 @@ fn read_n() -> u64 {
     );
 
     let input_data = (PRIVATE_INPUT_START + 4) as *const u8;
-    for (i, byte) in n_bytes.iter_mut().enumerate() {
-        *byte = unsafe { core::ptr::read_volatile(input_data.add(i)) };
-    }
+    n_bytes.copy_from_slice(unsafe { core::slice::from_raw_parts(input_data, 8) });
 
     u64::from_le_bytes(n_bytes)
 }


### PR DESCRIPTION
This PR updates the Fibonacci benchmark guest to read private input from the VM memory-mapped input region instead of using the obsolete syscall 4. This fixes the benchmark cycle-count pre-pass failing with UnknownSyscall(4)