### PR TITLE
ci: seed ELF caches on main for merge-queue hits

### DIFF
--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -286,3 +286,50 @@ jobs:
             --test-threads=1 \
             -E 'test(test_prove_elfs_all_instructions_64_full)' \
             --run-ignored ignored-only
+
+  # Seed ELF caches on refs/heads/main so merge-queue runs can restore them.
+  # GitHub Actions caches are branch-scoped: merge_group branches can only read
+  # caches from their base branch (main). The test jobs above are skipped on
+  # push-to-main (already validated by the merge queue), so without this job
+  # no ELF cache is ever saved on main and every merge-queue entry recompiles.
+  seed-elf-cache:
+    name: Seed ELF cache
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Cache compiled ASM ELF artifacts
+        id: cache-asm-elfs
+        uses: actions/cache@v4
+        with:
+          path: executor/program_artifacts/asm
+          key: asm-elf-artifacts-${{ hashFiles('executor/programs/asm/**') }}
+
+      - name: Install clang and lld
+        if: steps.cache-asm-elfs.outputs.cache-hit != 'true'
+        run: sudo apt-get update && sudo apt-get install -y clang lld
+
+      - name: Compile ASM programs to ELF
+        if: steps.cache-asm-elfs.outputs.cache-hit != 'true'
+        run: make compile-programs-asm
+
+      - name: Cache compiled Rust ELF artifacts and build cache
+        id: cache-rust-elfs
+        uses: actions/cache@v4
+        with:
+          path: |
+            executor/program_artifacts/rust
+            executor/shared_target
+          key: rust-elf-artifacts-${{ hashFiles('executor/programs/rust/**', 'executor/programs/riscv64im-lambda-vm-elf.json', 'syscalls/**', 'Makefile') }}
+          restore-keys: |
+            rust-elf-artifacts-
+
+      - name: Setup Rust Environment
+        if: steps.cache-rust-elfs.outputs.cache-hit != 'true'
+        uses: ./.github/actions/setup-rust
+
+      - name: Compile Rust programs to ELF
+        if: steps.cache-rust-elfs.outputs.cache-hit != 'true'
+        run: make compile-programs-rust


### PR DESCRIPTION
GitHub Actions caches are branch-scoped: merge_group branches can only read caches from main. The test jobs are skipped on push-to-main (already validated by the merge queue), so no ELF cache was ever saved on refs/heads/main — causing every merge-queue entry to recompile ASM and Rust programs from scratch.

Add a lightweight seed-elf-cache job that runs only on push-to-main. On cache hit it finishes in ~10s (checkout + cache check). On miss it compiles and saves, using the same cache keys as the existing jobs.