### PR TITLE
Add 16M to nightly bench vs SP1 and improve results description

### DIFF
--- a/.github/scripts/publish_bench_vs.sh
+++ b/.github/scripts/publish_bench_vs.sh
@@ -81,4 +81,4 @@ fi
 
 curl -X POST "$WEBHOOK_URL" \
     -H 'Content-Type: application/json; charset=utf-8' \
-    --data '{"blocks":[{"type":"header","text":{"type":"plain_text","text":"Lambda VM vs SP1 v6 - Nightly Benchmark"}},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"'"$RESULTS_MRKDWN"'"}}'"$PROJ_SECTION"']}'
+    --data '{"blocks":[{"type":"header","text":{"type":"plain_text","text":"Lambda VM vs SP1 v6 - Nightly Benchmark"}},{"type":"context","elements":[{"type":"mrkdwn","text":"*Program:* Fibonacci  ·  *Device:* CPU"}]},{"type":"divider"},{"type":"section","text":{"type":"mrkdwn","text":"'"$RESULTS_MRKDWN"'"}}'"$PROJ_SECTION"']}'

--- a/.github/workflows/bench-vs-nightly.yml
+++ b/.github/workflows/bench-vs-nightly.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run nightly benchmark
         run: |
           bash ./bench_vs/run.sh \
-            --steps 1000000 2000000 4000000 8000000 \
+            --steps 1000000 2000000 4000000 8000000 16000000 \
             --report-dir bench_vs_artifacts \
             --no-color
 


### PR DESCRIPTION
Benchmark now runs Fibonacci of 16M steps to compare against SP1.
The PR also adds to the Slack post that the benchmarks are executed using CPU and the program is Fibonacci.