### PR TITLE
perf: parallelize FRI fold with Rayon

### DIFF
--- a/crypto/stark/src/fri/fri_functions.rs
+++ b/crypto/stark/src/fri/fri_functions.rs
@@ -5,6 +5,14 @@ use math::field::{
     element::FieldElement,
     traits::{IsFFTField, IsField, IsSubFieldOf},
 };
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+/// Minimum number of elements for parallel FRI fold. Below this threshold
+/// the overhead of Rayon dispatch exceeds the benefit.
+#[cfg(feature = "parallel")]
+const FRI_FOLD_PARALLEL_THRESHOLD: usize = 4096;
+
 /// Evaluation-form FRI fold: given evaluations in bit-reversed order where
 /// consecutive pairs (2j, 2j+1) are conjugates (p(x_j), p(-x_j)), compute
 /// the folded evaluations: (lo + hi) + inv_twiddle[j] * zeta * (lo - hi)
@@ -12,12 +20,35 @@ use math::field::{
 ///
 /// After folding, the N/2 results are evaluations on the squared coset
 /// in bit-reversed order, preserving conjugate pairing for the next fold.
-pub fn fold_evaluations_in_place<F: IsSubFieldOf<E>, E: IsField>(
+pub fn fold_evaluations_in_place<F, E>(
     evals: &mut Vec<FieldElement<E>>,
     zeta: &FieldElement<E>,
     inv_twiddles: &[FieldElement<F>],
-) {
+) where
+    F: IsSubFieldOf<E> + Send + Sync,
+    E: IsField + Send + Sync,
+    FieldElement<E>: Send + Sync,
+    FieldElement<F>: Send + Sync,
+{
     let half = evals.len() / 2;
+
+    #[cfg(feature = "parallel")]
+    if half >= FRI_FOLD_PARALLEL_THRESHOLD {
+        // Parallel: compute folded values into a new buffer to avoid
+        // read/write aliasing on the same slice.
+        let folded: Vec<FieldElement<E>> = evals
+            .par_chunks_exact(2)
+            .zip(inv_twiddles.par_iter())
+            .map(|(pair, tw)| {
+                let sum = &pair[0] + &pair[1];
+                let diff = &pair[0] - &pair[1];
+                &sum + &(tw * &(zeta * &diff))
+            })
+            .collect();
+        *evals = folded;
+        return;
+    }
+
     for j in 0..half {
         let lo = &evals[2 * j];
         let hi = &evals[2 * j + 1];

--- a/crypto/stark/src/fri/mod.rs
+++ b/crypto/stark/src/fri/mod.rs
@@ -19,7 +19,7 @@ use self::fri_functions::{
 /// FRI commit phase from pre-computed bit-reversed evaluations.
 /// skipping the initial FFT. Use this when the caller already has the evaluation
 /// vector (e.g. from a fused LDE pipeline).
-pub fn commit_phase_from_evaluations<F: IsFFTField + IsSubFieldOf<E>, E: IsField>(
+pub fn commit_phase_from_evaluations<F: IsFFTField + IsSubFieldOf<E> + Send + Sync, E: IsField + Send + Sync>(
     number_layers: usize,
     mut evals: Vec<FieldElement<E>>,
     transcript: &mut impl IsStarkTranscript<E, F>,


### PR DESCRIPTION
## Summary

- Parallelize `fold_evaluations_in_place` using `par_chunks_exact(2)` + `par_iter` for layers with >= 4096 elements
- Falls back to sequential for small final layers where Rayon overhead dominates
- Each FRI fold iteration is embarrassingly parallel — the output at position j depends only on inputs at 2j, 2j+1 and the j-th twiddle factor

## Benchmark results

**fib_iterative_4M, PARALLEL_TABLES=1, 5 samples:**

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Wall clock (median) | 38.6s | 36.8s | **-4.7%** |
| CV | 2.3% | 2.2% | — |
| R4 fri::commit_phase (instruments) | 3.83s | 2.92s | **-23.8%** |
| Heap | 26,498 MB | 26,242 MB | -256 MB |

Verification: baseline verifier accepts the proof.

## Test plan

- [x] `cargo test --release -p stark` (124/124 pass)
- [x] Proof verified by baseline verifier binary
- [ ] `/bench` on CI runner