### PR TITLE
chore(loc): exclude fuzz and guest programs from LOC count

### DIFF
--- a/tooling/loc/src/main.rs
+++ b/tooling/loc/src/main.rs
@@ -16,6 +16,11 @@ const EXCLUDED: &[&str] = &[
     "*bench*",
     "*benches*",
     "*examples*",
+    // Non-production code: fuzz harnesses and the RISC-V guest programs
+    // executed/proven by the zkVM (test fixtures, not the zkVM itself).
+    "*fuzz*",
+    "*programs*",
+    "*program_artifacts*",
 ];
 
 /// Directories counted separately (not as crates).


### PR DESCRIPTION
The loc tool counted executor/programs (RISC-V guest test programs) as production code. Add *fuzz*, *programs* and *program_artifacts* to the EXCLUDED patterns.

This removes 502 LOC of guest test programs (executor/programs/rust/*, 30 files) from the reported total (32,937 -> 32,435). Fuzz harnesses already scored 0 because fuzz_targets/ coincidentally matched *target*; they are now excluded explicitly so a harness placed elsewhere under crypto/math/fuzz/ is not counted either.