### PR TITLE
docs: add roadmap link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ A verifiable virtual machine developed in collaboration with [Lambdaclass](https
 
 This open-source zkVM lets users prove the correct execution of a program over a given input stream. The current implementation generates base proofs using STARKs over the Goldilocks field, with 128 bits of security and LogUp as the lookup argument linking tables.
 
-Proof accelerators, GPU support, and proof compression are under development.
+Proof accelerators, GPU support, and proof compression are under development; see the [Roadmap](#roadmap) for the full plan and how the pieces fit together.
 
 > ⚠️ **This project is under active development and experimentation — do not use in production.**
+
+## Roadmap
+
+The **[public roadmap](https://yetanotherco.github.io/lambda_vm_roadmap/)** lays out what's in progress and what's planned, along with the ordering and dependencies between those workstreams.
 
 ## Getting Started
 


### PR DESCRIPTION
Adds a short **Roadmap** section near the top of the README linking the public roadmap site (https://yetanotherco.github.io/lambda_vm_roadmap/), and ties the existing "under development" line to it.

README only, no code changes.