### PR TITLE
continuations (first step): Add epoch split and proving

### DIFF
--- a/executor/src/vm/execution.rs
+++ b/executor/src/vm/execution.rs
@@ -30,6 +30,20 @@ pub struct ExecutionResult {
 /// Size of each log chunk - balances memory usage vs callback overhead
 const CHUNK_SIZE: usize = 100_000;
 
+/// Default number of cycles (instructions) per continuation epoch.
+pub const DEFAULT_EPOCH_SIZE: usize = 100_000;
+
+/// Result of executing one continuation epoch: the logs produced during the
+/// epoch and the VM state at the epoch boundary. The boundary state is the
+/// starting state of the next epoch.
+#[derive(Debug)]
+pub struct EpochExecution {
+    pub logs: Vec<Log>,
+    pub end_pc: u64,
+    pub end_registers: Registers,
+    pub end_memory: Memory,
+}
+
 /// Executor state for chunked execution
 pub struct Executor {
     memory: Memory,
@@ -57,13 +71,19 @@ impl Executor {
 
     /// Resume execution and return next logs. Returns None when program is finished.
     pub fn resume(&mut self) -> Result<Option<&[Log]>, ExecutorError> {
+        self.resume_with_limit(CHUNK_SIZE)
+    }
+
+    /// Resume execution, running at most `limit` cycles, and return the logs
+    /// produced. Returns None when the program is finished.
+    fn resume_with_limit(&mut self, limit: usize) -> Result<Option<&[Log]>, ExecutorError> {
         if self.pc == 0 {
             return Ok(None);
         }
 
         self.logs.clear();
 
-        while self.pc != 0 && self.logs.len() < CHUNK_SIZE {
+        while self.pc != 0 && self.logs.len() < limit {
             if !self.pc.is_multiple_of(4) {
                 return Err(ExecutorError::InstructionAddressMisaligned(self.pc));
             }
@@ -116,6 +136,26 @@ impl Executor {
             logs,
             instructions: self.instructions.into_instruction_map(),
         })
+    }
+
+    /// Run to completion, splitting execution into epochs of at most `epoch_size`
+    /// cycles. Each epoch captures its logs and the VM state at the epoch
+    /// boundary, which is the starting state of the next epoch. Consumes the
+    /// executor.
+    pub fn run_epochs(mut self, epoch_size: usize) -> Result<Vec<EpochExecution>, ExecutorError> {
+        assert!(epoch_size > 0, "epoch_size must be greater than zero");
+
+        let mut epochs = Vec::new();
+        while let Some(logs) = self.resume_with_limit(epoch_size)? {
+            let logs = logs.to_vec();
+            epochs.push(EpochExecution {
+                logs,
+                end_pc: self.pc,
+                end_registers: self.registers.clone(),
+                end_memory: self.memory.clone(),
+            });
+        }
+        Ok(epochs)
     }
 }
 

--- a/executor/src/vm/memory.rs
+++ b/executor/src/vm/memory.rs
@@ -80,6 +80,18 @@ impl Memory {
         entry[(address % 4) as usize] = value;
     }
 
+    /// Iterate over all stored bytes as `(address, value)` pairs. Cells are
+    /// stored as 4-byte words; each word expands into its four byte addresses.
+    /// Used to snapshot memory at an epoch boundary.
+    pub fn iter_bytes(&self) -> impl Iterator<Item = (u64, u8)> + '_ {
+        self.cells.iter().flat_map(|(&addr, bytes)| {
+            bytes
+                .iter()
+                .enumerate()
+                .map(move |(i, &b)| (addr + i as u64, b))
+        })
+    }
+
     pub fn load_word(&self, address: u64) -> Result<u32, MemoryError> {
         if address.is_multiple_of(4) {
             let bytes = self.cells.get(&address).cloned().unwrap_or_default();

--- a/executor/src/vm/memory.rs
+++ b/executor/src/vm/memory.rs
@@ -50,7 +50,7 @@ pub const MAX_PRIVATE_INPUT_SIZE: u64 = 6700000;
 /// Must match `PRIVATE_INPUT_START` in `syscalls/src/syscalls.rs`.
 pub const PRIVATE_INPUT_START_INDEX: u64 = 0xFF000000;
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct Memory {
     cells: U64HashMap<[u8; 4]>,
     /// Bytes committed to public output via `commit_public_output`. The

--- a/executor/src/vm/registers.rs
+++ b/executor/src/vm/registers.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 pub const STACK_TOP: u64 = 0xFFFFFFFFFFFFFFF0; // 64-bit max (Multiple of 16 for RV64 ABI)
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Holds the current value of all 32 registers
 /// Register zero is implicit as it cannot hold any value other than zero
 pub struct Registers([u64; 31]);

--- a/executor/tests/asm.rs
+++ b/executor/tests/asm.rs
@@ -923,3 +923,44 @@ fn test_keccak() {
     assert_eq!(result.return_values.memory_values, expected_bytes);
     assert_eq!(result.return_values.register_values.0, 0);
 }
+
+#[test]
+fn test_run_epochs_splits_execution_into_n_cycle_epochs() {
+    let elf_data = std::fs::read("./program_artifacts/asm/basic_program.elf").unwrap();
+    let program = Elf::load(&elf_data).unwrap();
+
+    // Reference: full single-pass run.
+    let full = Executor::new(&program, vec![]).unwrap().run().unwrap();
+
+    // Pick an epoch size that splits this program into a few epochs, whatever
+    // its exact length.
+    let total_cycles = full.logs.len();
+    assert!(total_cycles >= 2);
+    let epoch_size = (total_cycles / 3).max(1);
+
+    let epochs = Executor::new(&program, vec![])
+        .unwrap()
+        .run_epochs(epoch_size)
+        .unwrap();
+
+    // The program is long enough to span several epochs.
+    assert!(epochs.len() >= 2);
+
+    // Concatenated epoch logs reproduce the full run's instruction stream.
+    let concat: Vec<u64> = epochs
+        .iter()
+        .flat_map(|e| e.logs.iter().map(|l| l.current_pc))
+        .collect();
+    let expected: Vec<u64> = full.logs.iter().map(|l| l.current_pc).collect();
+    assert_eq!(concat, expected);
+
+    // Every epoch except the last runs exactly `epoch_size` cycles.
+    for epoch in &epochs[..epochs.len() - 1] {
+        assert_eq!(epoch.logs.len(), epoch_size);
+    }
+    let last = epochs.last().unwrap();
+    assert!(!last.logs.is_empty() && last.logs.len() <= epoch_size);
+
+    // The program finished, so the final epoch's boundary pc is 0.
+    assert_eq!(last.end_pc, 0);
+}

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -349,6 +349,7 @@ impl VmAirs {
     /// rejected, never silently accepted: it either mismatches the prover's
     /// committed precomputed root (an explicit verifier check) or yields
     /// diverging Fiat-Shamir challenges.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         elf: &Elf,
         proof_options: &ProofOptions,
@@ -357,6 +358,7 @@ impl VmAirs {
         table_counts: &TableCounts,
         decode_commitment: Option<Commitment>,
         include_halt: bool,
+        register_init: Option<&std::collections::HashMap<u64, u32>>,
     ) -> Self {
         let cpus: Vec<_> = (0..table_counts.cpu)
             .map(|i| create_cpu_air(proof_options).with_name(&format!("CPU[{}]", i)))
@@ -407,8 +409,11 @@ impl VmAirs {
             tables::keccak_rc::preprocessed_commitment(proof_options),
             tables::keccak_rc::NUM_PRECOMPUTED_COLS,
         );
+        let register_init = register_init
+            .cloned()
+            .unwrap_or_else(|| register::register_init_from_entry_point(elf.entry_point));
         let register = create_register_air(proof_options).with_preprocessed(
-            register::preprocessed_commitment(proof_options, elf.entry_point),
+            register::preprocessed_commitment(proof_options, &register_init),
             register::NUM_PREPROCESSED_COLS,
         );
         let pages: Vec<_> = page_configs
@@ -673,6 +678,7 @@ pub fn prove_with_options_and_inputs(
         &table_counts,
         None,
         true,
+        None,
     );
 
     #[cfg(feature = "instruments")]
@@ -818,6 +824,7 @@ pub fn verify_with_options(
         &vm_proof.table_counts,
         decode_commitment,
         true,
+        None,
     );
 
     // Recompute the COMMIT output bus offset from VmProof.public_output.

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -212,6 +212,9 @@ pub(crate) struct VmAirs {
     pub register: VmAir,
     pub pages: Vec<VmAir>,
     pub memw_registers: Vec<VmAir>,
+    /// Whether the HALT table participates in this proof. False for intermediate
+    /// continuation epochs, which do not terminate the program.
+    pub include_halt: bool,
 }
 
 impl VmAirs {
@@ -220,13 +223,15 @@ impl VmAirs {
         let mut pairs: Vec<AirTracePair<'a>> = vec![
             (&self.bitwise, &mut traces.bitwise, &()),
             (&self.decode, &mut traces.decode, &()),
-            (&self.halt, &mut traces.halt, &()),
             (&self.commit, &mut traces.commit, &()),
             (&self.keccak, &mut traces.keccak, &()),
             (&self.keccak_rnd, &mut traces.keccak_rnd, &()),
             (&self.keccak_rc, &mut traces.keccak_rc, &()),
             (&self.register, &mut traces.register, &()),
         ];
+        if self.include_halt {
+            pairs.push((&self.halt, &mut traces.halt, &()));
+        }
 
         for (air, trace) in self.cpus.iter().zip(traces.cpus.iter_mut()) {
             pairs.push((air, trace, &()));
@@ -278,13 +283,15 @@ impl VmAirs {
         let mut refs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> = vec![
             &self.bitwise,
             &self.decode,
-            &self.halt,
             &self.commit,
             &self.keccak,
             &self.keccak_rnd,
             &self.keccak_rc,
             &self.register,
         ];
+        if self.include_halt {
+            refs.push(&self.halt);
+        }
 
         for air in &self.cpus {
             refs.push(air);
@@ -349,6 +356,7 @@ impl VmAirs {
         page_configs: &[crate::tables::page::PageConfig],
         table_counts: &TableCounts,
         decode_commitment: Option<Commitment>,
+        include_halt: bool,
     ) -> Self {
         let cpus: Vec<_> = (0..table_counts.cpu)
             .map(|i| create_cpu_air(proof_options).with_name(&format!("CPU[{}]", i)))
@@ -448,6 +456,7 @@ impl VmAirs {
             register,
             pages,
             memw_registers,
+            include_halt,
         }
     }
 }
@@ -663,6 +672,7 @@ pub fn prove_with_options_and_inputs(
         &traces.page_configs,
         &table_counts,
         None,
+        true,
     );
 
     #[cfg(feature = "instruments")]
@@ -807,6 +817,7 @@ pub fn verify_with_options(
         &page_configs,
         &vm_proof.table_counts,
         decode_commitment,
+        true,
     );
 
     // Recompute the COMMIT output bus offset from VmProof.public_output.

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -165,6 +165,9 @@ pub enum Error {
     Prover(String),
     /// Proof contains invalid table_counts (e.g. zero for a required table)
     InvalidTableCounts(String),
+    /// A non-final continuation epoch contains the program-terminating
+    /// instruction. The terminating instruction must be in the final epoch.
+    HaltInNonFinalEpoch,
 }
 
 impl fmt::Display for Error {
@@ -178,6 +181,12 @@ impl fmt::Display for Error {
             Error::Execution(msg) => write!(f, "execution error: {msg}"),
             Error::Prover(msg) => write!(f, "proving error: {msg}"),
             Error::InvalidTableCounts(msg) => write!(f, "invalid table_counts: {msg}"),
+            Error::HaltInNonFinalEpoch => {
+                write!(
+                    f,
+                    "the program-terminating instruction must be in the final epoch"
+                )
+            }
         }
     }
 }

--- a/prover/src/tables/register.rs
+++ b/prover/src/tables/register.rs
@@ -165,7 +165,11 @@ pub(crate) fn register_init_from_snapshot(registers: &Registers, pc: u64) -> Has
         init.insert(base, (value & 0xFFFF_FFFF) as u32);
         init.insert(base + 1, (value >> 32) as u32);
     }
-    init.insert(508, 0); // x254 synthetic commit index
+    // x254 synthetic commit index. NAIVE LIMITATION: hardcoded to 0, which is
+    // only correct for an epoch with no preceding COMMIT. The commit index is
+    // not carried across epochs, so this is unsound for programs that COMMIT
+    // across an epoch boundary — deferred to the cross-epoch soundness work.
+    init.insert(508, 0);
     init.insert(510, (pc & 0xFFFF_FFFF) as u32);
     init.insert(511, (pc >> 32) as u32);
     init

--- a/prover/src/tables/register.rs
+++ b/prover/src/tables/register.rs
@@ -28,6 +28,9 @@ use stark::proof::options::ProofOptions;
 use stark::prover::evaluate_polynomial_on_lde_domain;
 use stark::trace::{TraceTable, columns2rows};
 
+#[cfg(test)]
+use executor::vm::registers::Registers;
+
 use super::page::STACK_TOP;
 use super::types::{BusId, FE, GoldilocksExtension, GoldilocksField};
 
@@ -116,6 +119,10 @@ fn register_word_address_list() -> [u64; NUM_REGISTER_ADDRESSES] {
 
 /// Compute the initial value for a register Word address.
 ///
+/// This is the **program-start** register image, so it only applies to the first
+/// continuation epoch (or a whole-program run). Later epochs start mid-execution
+/// and supply their own boundary register snapshot instead.
+///
 /// - SP (x2) words at offset 4,5 hold STACK_TOP
 /// - x254 at offset 508 is the synthetic commit index, initialized to 0
 /// - PC (x255) words at offset 510,511 hold entry_point
@@ -130,6 +137,40 @@ fn init_value_for_address(word_addr: u64, entry_point: u64) -> u32 {
     }
 }
 
+/// Build the register init map (word address -> initial value) for a program
+/// starting at `entry_point` (the program-start register image). A continuation
+/// epoch would instead supply its boundary register snapshot.
+pub(crate) fn register_init_from_entry_point(entry_point: u64) -> HashMap<u64, u32> {
+    register_word_address_list()
+        .iter()
+        .map(|&addr| (addr, init_value_for_address(addr, entry_point)))
+        .collect()
+}
+
+/// Build the register init map from an epoch's boundary register snapshot: the
+/// executor `Registers` (x1-x31, including SP) plus the program counter (x255).
+/// x0 and the synthetic commit index (x254) are zero in the naive version.
+///
+/// Only used by tests until a production per-epoch prover wires it in.
+#[cfg(test)]
+pub(crate) fn register_init_from_snapshot(registers: &Registers, pc: u64) -> HashMap<u64, u32> {
+    let mut init = HashMap::new();
+    for reg in 0u8..32 {
+        let value = if reg == 0 {
+            0
+        } else {
+            registers.read(reg as u32).unwrap_or(0)
+        };
+        let base = (reg as u64) * 2;
+        init.insert(base, (value & 0xFFFF_FFFF) as u32);
+        init.insert(base + 1, (value >> 32) as u32);
+    }
+    init.insert(508, 0); // x254 synthetic commit index
+    init.insert(510, (pc & 0xFFFF_FFFF) as u32);
+    init.insert(511, (pc >> 32) as u32);
+    init
+}
+
 /// Generates the REGISTER trace table.
 ///
 /// Creates a table with NUM_REGISTER_ADDRESSES rows.
@@ -139,14 +180,15 @@ fn init_value_for_address(word_addr: u64, entry_point: u64) -> u32 {
 /// ## Arguments
 ///
 /// * `final_state` - Map from register Word address to final (timestamp, value)
-/// * `entry_point` - ELF entry point (initial PC value for x255)
+/// * `init` - Map from register Word address to initial value (program-start
+///   image, or an epoch's boundary register snapshot)
 ///
 /// ## Returns
 ///
 /// The trace table for registers.
 pub fn generate_register_trace(
     final_state: &FinalRegisterStateMap,
-    entry_point: u64,
+    init: &HashMap<u64, u32>,
 ) -> TraceTable<GoldilocksField, GoldilocksExtension> {
     let num_rows = NUM_REGISTER_ADDRESSES.next_power_of_two();
     let mut data = vec![FE::zero(); num_rows * cols::NUM_COLUMNS];
@@ -158,7 +200,7 @@ pub fn generate_register_trace(
         // Offset = actual Word address in register space
         data[base + cols::OFFSET] = FE::from(word_addr);
 
-        let init_value = init_value_for_address(word_addr, entry_point);
+        let init_value = init.get(&word_addr).copied().unwrap_or(0);
         data[base + cols::INIT] = FE::from(init_value as u64);
 
         // Final state: if accessed use final, otherwise use initial (timestamp 1)
@@ -194,7 +236,10 @@ pub fn generate_register_trace(
 /// Program-dependent: x255 (PC) init = entry_point.
 /// OFFSET encodes the Word address (0..63 for x0-x31, 508 for x254, 510-511 for x255).
 /// INIT holds the initial value (SP=STACK_TOP, PC=entry_point, rest=0).
-pub fn compute_precomputed_commitment(options: &ProofOptions, entry_point: u64) -> Commitment {
+pub fn compute_precomputed_commitment(
+    options: &ProofOptions,
+    init: &HashMap<u64, u32>,
+) -> Commitment {
     let num_rows = NUM_REGISTER_ADDRESSES.next_power_of_two();
     let addr_list = register_word_address_list();
 
@@ -204,7 +249,7 @@ pub fn compute_precomputed_commitment(options: &ProofOptions, entry_point: u64) 
     for i in 0..NUM_REGISTER_ADDRESSES {
         let word_addr = addr_list[i];
         offset_col[i] = FE::from(word_addr);
-        init_col[i] = FE::from(init_value_for_address(word_addr, entry_point) as u64);
+        init_col[i] = FE::from(init.get(&word_addr).copied().unwrap_or(0) as u64);
     }
 
     let columns = [offset_col, init_col];
@@ -240,8 +285,8 @@ pub fn compute_precomputed_commitment(options: &ProofOptions, entry_point: u64) 
 /// Returns the preprocessed commitment for the REGISTER table.
 ///
 /// Program-dependent (entry_point varies per ELF), so not globally cached.
-pub fn preprocessed_commitment(options: &ProofOptions, entry_point: u64) -> Commitment {
-    compute_precomputed_commitment(options, entry_point)
+pub fn preprocessed_commitment(options: &ProofOptions, init: &HashMap<u64, u32>) -> Commitment {
+    compute_precomputed_commitment(options, init)
 }
 
 // =========================================================================

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -163,6 +163,24 @@ impl RegisterState {
         }
     }
 
+    /// Seed register state from a register init map (word address -> value), so
+    /// the first access in a continuation epoch reads the epoch's boundary
+    /// register values as `old_value`. All initial timestamps are 1, matching the
+    /// REGISTER table's init token. Mirrors `MemoryState::from_image`.
+    fn from_init_map(init: &HashMap<u64, u32>) -> Self {
+        let word = |addr: u64| init.get(&addr).copied().unwrap_or(0) as u64;
+        let mut regs = [(0u64, 1u64); 32];
+        for reg in 0..32u64 {
+            let base = reg * 2;
+            regs[reg as usize] = (word(base) | (word(base + 1) << 32), 1);
+        }
+        Self {
+            regs,
+            index_register: (init.get(&508).copied().unwrap_or(0), 1),
+            pc_register: (word(510) | (word(511) << 32), 1),
+        }
+    }
+
     /// Read a register. Returns (value, last_write_timestamp).
     fn read(&self, reg: u8) -> RegisterCell {
         self.regs[reg as usize]
@@ -2205,7 +2223,7 @@ fn build_traces(
     ops: CollectedOps,
     initial_image: Option<&HashMap<u64, u8>>,
     memory_state: &MemoryState,
-    entry_point: u64,
+    register_init: &HashMap<u64, u32>,
     decode_trace: TraceTable<GoldilocksField, GoldilocksExtension>,
     decode_pc_to_row: HashMap<u64, usize>,
     register_state: RegisterState,
@@ -2404,7 +2422,7 @@ fn build_traces(
                         Some(image) => generate_page_tables(image, memory_state, private_input),
                         None => (Vec::new(), Vec::new()),
                     },
-                    || register::generate_register_trace(&register_final_state, entry_point),
+                    || register::generate_register_trace(&register_final_state, register_init),
                 )
             },
             || halt::generate_halt_trace(halt_timestamp),
@@ -2428,7 +2446,7 @@ fn build_traces(
                 page_configs = Vec::new();
             }
         }
-        register_trace = register::generate_register_trace(&register_final_state, entry_point);
+        register_trace = register::generate_register_trace(&register_final_state, register_init);
         halt_trace = halt::generate_halt_trace(halt_timestamp);
     }
 
@@ -3060,9 +3078,11 @@ impl Traces {
         #[cfg(feature = "disk-spill")] storage_mode: StorageMode,
     ) -> Result<Self, Error> {
         let initial_image = build_initial_image(elf, private_input);
+        let register_init = register::register_init_from_entry_point(elf.entry_point);
         Self::from_image_and_logs(
             elf,
             &initial_image,
+            &register_init,
             logs,
             max_rows,
             private_input,
@@ -3076,15 +3096,19 @@ impl Traces {
     /// initial-memory image (the epoch's starting memory) rather than the ELF
     /// image. `elf` is still used for the program code (DECODE) and entry point.
     ///
+    /// `register_init` is the epoch's starting register image (word address ->
+    /// value): the program-start image for the first epoch, or an epoch's boundary
+    /// register snapshot for later epochs. It seeds both `RegisterState` (for
+    /// first-access old values) and the REGISTER table's init column.
+    ///
     /// `is_final` marks the last epoch: it applies HALT finalization (zeroize
     /// registers, require the terminating ECALL). Intermediate epochs (`false`)
     /// skip HALT and keep their boundary register/memory state.
-    ///
-    /// Note (naive continuations): register init still comes from the entry
-    /// point (zeros). Chaining register state across epochs is not handled here.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_image_and_logs(
         elf: &Elf,
         initial_image: &HashMap<u64, u8>,
+        register_init: &HashMap<u64, u32>,
         logs: &[Log],
         max_rows: &super::MaxRowsConfig,
         private_input: &[u8],
@@ -3103,7 +3127,7 @@ impl Traces {
 
         // Phase 2: Collect + route all ops
         let mut memory_state = MemoryState::from_image(initial_image);
-        let mut register_state = RegisterState::new(elf.entry_point);
+        let mut register_state = RegisterState::from_init_map(register_init);
         let (memw_ops, load_ops, lt_ops, shift_ops, bitwise_ops, commit_ops, keccak_ops) =
             collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
 
@@ -3125,7 +3149,7 @@ impl Traces {
             ops,
             Some(initial_image),
             &memory_state,
-            elf.entry_point,
+            register_init,
             decode_trace,
             decode_pc_to_row,
             register_state,
@@ -3154,6 +3178,7 @@ impl Traces {
         // Phase 2: Collect + route all ops
         let mut memory_state = MemoryState::new();
         let entry_point = cpu_ops.first().map_or(0, |op| op.decode.pc);
+        let register_init = register::register_init_from_entry_point(entry_point);
         let mut register_state = RegisterState::new(entry_point);
         let (memw_ops, load_ops, lt_ops, shift_ops, bitwise_ops, commit_ops, keccak_ops) =
             collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
@@ -3179,7 +3204,7 @@ impl Traces {
             ops,
             None,
             &memory_state,
-            entry_point,
+            &register_init,
             decode_trace,
             decode_pc_to_row,
             register_state,

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -3115,6 +3115,14 @@ impl Traces {
         is_final: bool,
         #[cfg(feature = "disk-spill")] storage_mode: StorageMode,
     ) -> Result<Self, Error> {
+        // A non-final epoch must not contain the program-terminating instruction
+        // (next_pc == 0). Otherwise the CPU sends an ECALL bus token with no HALT
+        // table to receive it (HALT is excluded when !is_final), producing an
+        // unverifiable proof. Fail explicitly instead.
+        if !is_final && logs.iter().any(|log| log.next_pc == 0) {
+            return Err(Error::HaltInNonFinalEpoch);
+        }
+
         // Phase 0: ELF → DECODE + instructions
         // IMPORTANT: Use generate_decode_trace (same as compute_precomputed_commitment)
         // so the DECODE trace row ordering matches the AIR's hardcoded commitment.

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -82,25 +82,16 @@ impl MemoryState {
         }
     }
 
-    /// Initialize memory state from ELF segments.
+    /// Initialize memory state from a pre-built initial-memory image.
     ///
-    /// Pre-populates all ELF bytes with timestamp=0 so that when MEMW first
+    /// Pre-populates all starting bytes with timestamp=0 so that when MEMW first
     /// accesses an address, it gets the correct initial value for `old_value`.
     /// This is required for the Memory bus to balance (MEMW-M1 must match PAGE-C3).
-    fn from_elf(elf: &Elf) -> Self {
-        let mut cells = HashMap::new();
-        for segment in &elf.data {
-            for (i, &word) in segment.values.iter().enumerate() {
-                let word_addr = segment.base_addr.wrapping_add(i as u64 * 4);
-                // Split 32-bit word into 4 bytes (little-endian)
-                for byte_offset in 0..4u64 {
-                    let byte_addr = word_addr.wrapping_add(byte_offset);
-                    let byte_value = ((word >> (byte_offset * 8)) & 0xFF) as u8;
-                    // Initial state: value from ELF, timestamp=0
-                    cells.insert(byte_addr, (byte_value, 0));
-                }
-            }
-        }
+    fn from_image(image: &HashMap<u64, u8>) -> Self {
+        let cells = image
+            .iter()
+            .map(|(&addr, &value)| (addr, (value, 0)))
+            .collect();
         Self { cells }
     }
 
@@ -114,18 +105,6 @@ impl MemoryState {
         let mask = !(page_size - 1);
         let pages: HashSet<u64> = self.cells.keys().map(|&a| a & mask).collect();
         pages.len() as u64
-    }
-
-    /// Pre-populate the private input memory region at `PRIVATE_INPUT_START_INDEX`.
-    fn add_private_input(&mut self, private_input: &[u8]) {
-        if private_input.is_empty() {
-            return;
-        }
-        use executor::vm::memory::PRIVATE_INPUT_START_INDEX;
-        let start = PRIVATE_INPUT_START_INDEX;
-        for (i, &b) in private_input_bytes(private_input).iter().enumerate() {
-            self.cells.insert(start + i as u64, (b, 0));
-        }
     }
 
     /// Read a byte from memory. Returns (value, timestamp) or (0, 0) if never written.
@@ -1482,50 +1461,55 @@ fn private_input_bytes(private_input: &[u8]) -> Vec<u8> {
         .collect()
 }
 
-fn build_init_page_data(elf: &Elf, private_input: &[u8]) -> HashMap<u64, Vec<u8>> {
-    use executor::vm::memory::PRIVATE_INPUT_START_INDEX;
-    let page_size = page::DEFAULT_PAGE_SIZE;
-    let mut init_page_data: HashMap<u64, Vec<u8>> = HashMap::new();
+/// Build the initial-memory image (byte address -> value) from the ELF segments
+/// and the private-input region. Single source of "what memory starts as", read
+/// by both `MemoryState` seeding and PAGE/bitwise init.
+fn build_initial_image(elf: &Elf, private_input: &[u8]) -> HashMap<u64, u8> {
+    let mut image: HashMap<u64, u8> = HashMap::new();
     for segment in &elf.data {
         for (i, &word) in segment.values.iter().enumerate() {
-            let word_addr = segment.base_addr + (i as u64 * 4);
+            let word_addr = segment.base_addr.wrapping_add(i as u64 * 4);
             for byte_offset in 0..4u64 {
-                let byte_addr = word_addr + byte_offset;
+                let byte_addr = word_addr.wrapping_add(byte_offset);
                 let byte_value = ((word >> (byte_offset * 8)) & 0xFF) as u8;
-                let page_base = page::page_base_for_address(byte_addr, page_size);
-                let offset = page::offset_in_page(byte_addr, page_size);
-                let page_data = init_page_data
-                    .entry(page_base)
-                    .or_insert_with(|| vec![0u8; page_size]);
-                page_data[offset] = byte_value;
+                image.insert(byte_addr, byte_value);
             }
         }
     }
     if !private_input.is_empty() {
+        use executor::vm::memory::PRIVATE_INPUT_START_INDEX;
         for (i, &b) in private_input_bytes(private_input).iter().enumerate() {
-            let addr = PRIVATE_INPUT_START_INDEX + i as u64;
-            let page_base = page::page_base_for_address(addr, page_size);
-            let offset = page::offset_in_page(addr, page_size);
-            let page_data = init_page_data
-                .entry(page_base)
-                .or_insert_with(|| vec![0u8; page_size]);
-            page_data[offset] = b;
+            image.insert(PRIVATE_INPUT_START_INDEX + i as u64, b);
         }
+    }
+    image
+}
+
+/// Bucket an initial-memory image into per-page byte arrays for PAGE init columns.
+fn build_init_page_data(image: &HashMap<u64, u8>) -> HashMap<u64, Vec<u8>> {
+    let page_size = page::DEFAULT_PAGE_SIZE;
+    let mut init_page_data: HashMap<u64, Vec<u8>> = HashMap::new();
+    for (&addr, &value) in image {
+        let page_base = page::page_base_for_address(addr, page_size);
+        let offset = page::offset_in_page(addr, page_size);
+        let page_data = init_page_data
+            .entry(page_base)
+            .or_insert_with(|| vec![0u8; page_size]);
+        page_data[offset] = value;
     }
     init_page_data
 }
 
 fn collect_bitwise_from_page(
-    elf: &Elf,
+    image: &HashMap<u64, u8>,
     memory_state: &MemoryState,
-    private_input: &[u8],
 ) -> Vec<BitwiseOperation> {
     use std::collections::BTreeSet;
 
     let page_size = page::DEFAULT_PAGE_SIZE;
     let mut bitwise_ops = Vec::new();
 
-    let elf_page_data = build_init_page_data(elf, private_input);
+    let init_page_data = build_init_page_data(image);
 
     // Derive ALL page bases from memory_state (includes ELF + runtime pages)
     let mut page_bases: BTreeSet<u64> = BTreeSet::new();
@@ -1542,7 +1526,7 @@ fn collect_bitwise_from_page(
 
     // For each page and each byte, add ARE_BYTES lookups for init and fini
     for &page_base in &page_bases {
-        let init_data = elf_page_data.get(&page_base);
+        let init_data = init_page_data.get(&page_base);
 
         for offset in 0..page_size {
             let addr = page_base + offset as u64;
@@ -1922,7 +1906,7 @@ pub(crate) fn collect_bitwise_from_keccak(keccak_ops: &[KeccakOperation]) -> Vec
 /// every address accessed during execution (ELF init + runtime stores/loads).
 /// ELF pages get their init data from the binary; all others are zero-init.
 fn generate_page_tables(
-    elf: &Elf,
+    image: &HashMap<u64, u8>,
     memory_state: &MemoryState,
     private_input: &[u8],
 ) -> (
@@ -1933,8 +1917,8 @@ fn generate_page_tables(
 
     let page_size = page::DEFAULT_PAGE_SIZE;
 
-    // Collect init data from ELF segments + private input region
-    let init_page_data = build_init_page_data(elf, private_input);
+    // Per-page init bytes from the initial-memory image.
+    let init_page_data = build_init_page_data(image);
 
     // Derive ALL page bases from memory_state (includes ELF + runtime pages)
     let mut page_bases: BTreeSet<u64> = BTreeSet::new();
@@ -2208,12 +2192,13 @@ fn collect_all_ops(
 
 /// Phases 3-5: From routed ops, produce all traces and assemble `Traces`.
 ///
-/// `elf` controls PAGE table generation: `Some(elf)` generates real PAGE tables
-/// and PAGE bitwise lookups; `None` produces empty page tables.
+/// `initial_image` controls PAGE table generation: `Some(image)` generates real
+/// PAGE tables and PAGE bitwise lookups seeded from the initial-memory image;
+/// `None` produces empty page tables.
 #[allow(clippy::too_many_arguments)]
 fn build_traces(
     ops: CollectedOps,
-    elf: Option<&Elf>,
+    initial_image: Option<&HashMap<u64, u8>>,
     memory_state: &MemoryState,
     entry_point: u64,
     decode_trace: TraceTable<GoldilocksField, GoldilocksExtension>,
@@ -2257,8 +2242,8 @@ fn build_traces(
     // MEMW_R sends IS_HALFWORD[timestamp_0 - old_timestamp_lo - 1]
     bitwise_ops.extend(collect_bitwise_from_memw_register(&memw_register_ops));
     // PAGE tables do a batched ARE_BYTES[init, fini] lookup per row (C1+C2)
-    if let Some(elf) = elf {
-        bitwise_ops.extend(collect_bitwise_from_page(elf, memory_state, private_input));
+    if let Some(image) = initial_image {
+        bitwise_ops.extend(collect_bitwise_from_page(image, memory_state));
     }
 
     let public_output_bytes: Vec<u8> = commit_ops
@@ -2403,8 +2388,8 @@ fn build_traces(
         let ((pages_val, register_val), halt_val) = rayon::join(
             || {
                 rayon::join(
-                    || match elf {
-                        Some(elf) => generate_page_tables(elf, memory_state, private_input),
+                    || match initial_image {
+                        Some(image) => generate_page_tables(image, memory_state, private_input),
                         None => (Vec::new(), Vec::new()),
                     },
                     || register::generate_register_trace(&register_final_state, entry_point),
@@ -2420,9 +2405,9 @@ fn build_traces(
     }
     #[cfg(not(feature = "parallel"))]
     {
-        match elf {
-            Some(elf) => {
-                let (p, c) = generate_page_tables(elf, memory_state, private_input);
+        match initial_image {
+            Some(image) => {
+                let (p, c) = generate_page_tables(image, memory_state, private_input);
                 pages = p;
                 page_configs = c;
             }
@@ -2547,8 +2532,7 @@ pub fn count_table_lengths(
     let decode_rows = (instructions.len() as u64 + 1).next_power_of_two().max(2);
 
     // Memory + register state for partition predicates that need timestamps.
-    let mut memory_state = MemoryState::from_elf(elf);
-    memory_state.add_private_input(private_input);
+    let mut memory_state = MemoryState::from_image(&build_initial_image(elf, private_input));
     let mut register_state = RegisterState::new(elf.entry_point);
 
     // Raw counts (pre-chunking + pre-padding).
@@ -2946,7 +2930,7 @@ impl Traces {
         use std::collections::BTreeSet;
 
         let page_size = page::DEFAULT_PAGE_SIZE;
-        let init_page_data = build_init_page_data(elf, &[]);
+        let init_page_data = build_init_page_data(&build_initial_image(elf, &[]));
 
         let page_bases: BTreeSet<u64> = init_page_data.keys().copied().collect();
 
@@ -3074,8 +3058,8 @@ impl Traces {
         let cpu_ops = collect_cpu_ops(logs, &instructions)?;
 
         // Phase 2: Collect + route all ops
-        let mut memory_state = MemoryState::from_elf(elf);
-        memory_state.add_private_input(private_input);
+        let initial_image = build_initial_image(elf, private_input);
+        let mut memory_state = MemoryState::from_image(&initial_image);
         let mut register_state = RegisterState::new(elf.entry_point);
         let (memw_ops, load_ops, lt_ops, shift_ops, bitwise_ops, commit_ops, keccak_ops) =
             collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
@@ -3095,7 +3079,7 @@ impl Traces {
         // Phases 3-5
         build_traces(
             ops,
-            Some(elf),
+            Some(&initial_image),
             &memory_state,
             elf.entry_point,
             decode_trace,

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -1464,7 +1464,7 @@ fn private_input_bytes(private_input: &[u8]) -> Vec<u8> {
 /// Build the initial-memory image (byte address -> value) from the ELF segments
 /// and the private-input region. Single source of "what memory starts as", read
 /// by both `MemoryState` seeding and PAGE/bitwise init.
-fn build_initial_image(elf: &Elf, private_input: &[u8]) -> HashMap<u64, u8> {
+pub(crate) fn build_initial_image(elf: &Elf, private_input: &[u8]) -> HashMap<u64, u8> {
     let mut image: HashMap<u64, u8> = HashMap::new();
     for segment in &elf.data {
         for (i, &word) in segment.values.iter().enumerate() {
@@ -3047,6 +3047,32 @@ impl Traces {
         private_input: &[u8],
         #[cfg(feature = "disk-spill")] storage_mode: StorageMode,
     ) -> Result<Self, Error> {
+        let initial_image = build_initial_image(elf, private_input);
+        Self::from_image_and_logs(
+            elf,
+            &initial_image,
+            logs,
+            max_rows,
+            private_input,
+            #[cfg(feature = "disk-spill")]
+            storage_mode,
+        )
+    }
+
+    /// Build traces for one execution epoch starting from an explicit
+    /// initial-memory image (the epoch's starting memory) rather than the ELF
+    /// image. `elf` is still used for the program code (DECODE) and entry point.
+    ///
+    /// Note (naive continuations): register init still comes from the entry
+    /// point (zeros). Chaining register state across epochs is not handled here.
+    pub fn from_image_and_logs(
+        elf: &Elf,
+        initial_image: &HashMap<u64, u8>,
+        logs: &[Log],
+        max_rows: &super::MaxRowsConfig,
+        private_input: &[u8],
+        #[cfg(feature = "disk-spill")] storage_mode: StorageMode,
+    ) -> Result<Self, Error> {
         // Phase 0: ELF → DECODE + instructions
         // IMPORTANT: Use generate_decode_trace (same as compute_precomputed_commitment)
         // so the DECODE trace row ordering matches the AIR's hardcoded commitment.
@@ -3058,8 +3084,7 @@ impl Traces {
         let cpu_ops = collect_cpu_ops(logs, &instructions)?;
 
         // Phase 2: Collect + route all ops
-        let initial_image = build_initial_image(elf, private_input);
-        let mut memory_state = MemoryState::from_image(&initial_image);
+        let mut memory_state = MemoryState::from_image(initial_image);
         let mut register_state = RegisterState::new(elf.entry_point);
         let (memw_ops, load_ops, lt_ops, shift_ops, bitwise_ops, commit_ops, keccak_ops) =
             collect_ops_from_cpu(&cpu_ops, &mut memory_state, &mut register_state);
@@ -3079,7 +3104,7 @@ impl Traces {
         // Phases 3-5
         build_traces(
             ops,
-            Some(&initial_image),
+            Some(initial_image),
             &memory_state,
             elf.entry_point,
             decode_trace,

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -2098,11 +2098,16 @@ fn collect_all_ops(
     commit_ops: Vec<CommitOperation>,
     keccak_ops: Vec<KeccakOperation>,
     register_state: &mut RegisterState,
+    is_final: bool,
 ) -> CollectedOps {
     // HALT finalization: 33 register MEMW operations at timestamp u64::MAX.
     // Must come before Phase 3 (LT from MEMW) so HALT ops get timestamp checks.
-    let halt_memw_ops = collect_halt_ops(register_state);
-    memw_ops.extend(halt_memw_ops);
+    // Only the final epoch terminates; intermediate epochs keep their boundary
+    // register state (no zeroizing) so it can seed the next epoch.
+    if is_final {
+        let halt_memw_ops = collect_halt_ops(register_state);
+        memw_ops.extend(halt_memw_ops);
+    }
 
     // Route MEMW_R (register fast-path) first, then MEMW_A (aligned), rest → MEMW.
     // Order matters: register ops would also pass is_aligned_op, so check first.
@@ -2207,6 +2212,7 @@ fn build_traces(
     max_rows: &super::MaxRowsConfig,
     #[cfg(feature = "disk-spill")] storage_mode: StorageMode,
     private_input: &[u8],
+    is_final: bool,
 ) -> Result<Traces, Error> {
     let CollectedOps {
         cpu_ops,
@@ -2268,13 +2274,19 @@ fn build_traces(
     // PHASE 5: Generate final traces (parallelized)
     // =====================================================================
 
-    // Extract halt timestamp from the last ECALL instruction
-    let halt_op = cpu_ops
-        .iter()
-        .rev()
-        .find(|op| op.decode.op_ecall)
-        .ok_or(Error::MissingHaltEcall)?;
-    let halt_timestamp = halt_op.timestamp;
+    // Final epoch terminates on the program's ECALL. Intermediate epochs do not
+    // halt, so fall back to the last cycle's timestamp (placeholder: proving an
+    // intermediate epoch needs proper epoch-boundary finalization, not HALT).
+    let halt_timestamp = if is_final {
+        cpu_ops
+            .iter()
+            .rev()
+            .find(|op| op.decode.op_ecall)
+            .ok_or(Error::MissingHaltEcall)?
+            .timestamp
+    } else {
+        cpu_ops.last().map(|op| op.timestamp).unwrap_or(0)
+    };
 
     let cpus = chunk_and_generate(
         &cpu_ops,
@@ -3054,6 +3066,7 @@ impl Traces {
             logs,
             max_rows,
             private_input,
+            true,
             #[cfg(feature = "disk-spill")]
             storage_mode,
         )
@@ -3063,6 +3076,10 @@ impl Traces {
     /// initial-memory image (the epoch's starting memory) rather than the ELF
     /// image. `elf` is still used for the program code (DECODE) and entry point.
     ///
+    /// `is_final` marks the last epoch: it applies HALT finalization (zeroize
+    /// registers, require the terminating ECALL). Intermediate epochs (`false`)
+    /// skip HALT and keep their boundary register/memory state.
+    ///
     /// Note (naive continuations): register init still comes from the entry
     /// point (zeros). Chaining register state across epochs is not handled here.
     pub fn from_image_and_logs(
@@ -3071,6 +3088,7 @@ impl Traces {
         logs: &[Log],
         max_rows: &super::MaxRowsConfig,
         private_input: &[u8],
+        is_final: bool,
         #[cfg(feature = "disk-spill")] storage_mode: StorageMode,
     ) -> Result<Self, Error> {
         // Phase 0: ELF → DECODE + instructions
@@ -3099,6 +3117,7 @@ impl Traces {
             commit_ops,
             keccak_ops,
             &mut register_state,
+            is_final,
         );
 
         // Phases 3-5
@@ -3114,6 +3133,7 @@ impl Traces {
             #[cfg(feature = "disk-spill")]
             storage_mode,
             private_input,
+            is_final,
         )
     }
 
@@ -3148,6 +3168,7 @@ impl Traces {
             commit_ops,
             keccak_ops,
             &mut register_state,
+            true,
         );
 
         // DECODE (from_elf_and_logs does this in Phase 0; same result either way)
@@ -3166,6 +3187,7 @@ impl Traces {
             #[cfg(feature = "disk-spill")]
             StorageMode::Ram,
             &[],
+            true,
         )
     }
 

--- a/prover/src/tests/decode_tests.rs
+++ b/prover/src/tests/decode_tests.rs
@@ -1051,6 +1051,7 @@ fn test_decode_soundness_same_elf_accepted() {
         &traces.page_configs,
         &table_counts,
         None,
+        true,
     );
 
     let proof = multi_prove_ram(
@@ -1068,6 +1069,7 @@ fn test_decode_soundness_same_elf_accepted() {
         &traces.page_configs,
         &table_counts,
         None,
+        true,
     );
     let verifier_air_refs = verifier_airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);

--- a/prover/src/tests/decode_tests.rs
+++ b/prover/src/tests/decode_tests.rs
@@ -1052,6 +1052,7 @@ fn test_decode_soundness_same_elf_accepted() {
         &table_counts,
         None,
         true,
+        None,
     );
 
     let proof = multi_prove_ram(
@@ -1070,6 +1071,7 @@ fn test_decode_soundness_same_elf_accepted() {
         &table_counts,
         None,
         true,
+        None,
     );
     let verifier_air_refs = verifier_airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -60,6 +60,7 @@ fn prove_and_verify_vm_minimal(elf: &Elf, traces: &mut Traces) -> bool {
         &table_counts,
         None,
         true,
+        None,
     );
 
     // Build air_trace_pairs for all tables
@@ -111,6 +112,7 @@ fn prove_vm_minimal(elf_bytes: &[u8], private_inputs: &[u8], max_rows: &MaxRowsC
         &table_counts,
         None,
         true,
+        None,
     );
     let runtime_page_ranges = traces.runtime_page_ranges();
     let proof = multi_prove_ram(
@@ -151,6 +153,7 @@ fn verify_vm_minimal(vm_proof: &VmProof, elf_bytes: &[u8]) -> bool {
         &vm_proof.table_counts,
         None,
         true,
+        None,
     );
     let air_refs = airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);
@@ -1168,6 +1171,7 @@ fn test_prove_elfs_test_commit_4_wrong_pages_rejected() {
         &table_counts,
         None,
         true,
+        None,
     );
     let proof = multi_prove_ram(
         prover_airs.air_trace_pairs(&mut traces),
@@ -1185,6 +1189,7 @@ fn test_prove_elfs_test_commit_4_wrong_pages_rejected() {
         &table_counts,
         None,
         true,
+        None,
     );
     let verifier_air_refs = verifier_airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);
@@ -1916,6 +1921,7 @@ fn test_deep_stack_runtime_pages_roundtrip() {
         &table_counts,
         None,
         true,
+        None,
     );
     let proof = multi_prove_ram(
         prover_airs.air_trace_pairs(&mut traces),
@@ -1932,6 +1938,7 @@ fn test_deep_stack_runtime_pages_roundtrip() {
         &table_counts,
         None,
         true,
+        None,
     );
     let verifier_air_refs = verifier_airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);
@@ -1982,6 +1989,7 @@ fn test_deep_stack_missing_pages_rejected() {
         &table_counts,
         None,
         true,
+        None,
     );
     let proof = multi_prove_ram(
         prover_airs.air_trace_pairs(&mut traces),
@@ -1998,6 +2006,7 @@ fn test_deep_stack_missing_pages_rejected() {
         &table_counts,
         None,
         true,
+        None,
     );
     let verifier_air_refs = verifier_airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);
@@ -2083,6 +2092,7 @@ fn test_heap_alloc_runtime_pages_roundtrip() {
         &table_counts,
         None,
         true,
+        None,
     );
     let proof = multi_prove_ram(
         prover_airs.air_trace_pairs(&mut traces),
@@ -2099,6 +2109,7 @@ fn test_heap_alloc_runtime_pages_roundtrip() {
         &table_counts,
         None,
         true,
+        None,
     );
     let verifier_air_refs = verifier_airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);
@@ -2245,7 +2256,16 @@ fn test_crafted_zero_count_proof_must_not_verify() {
         branch: 0,
         memw_register: 0,
     };
-    let airs = VmAirs::new(&elf, &proof_options, true, &[], &zero_counts, None, true);
+    let airs = VmAirs::new(
+        &elf,
+        &proof_options,
+        true,
+        &[],
+        &zero_counts,
+        None,
+        true,
+        None,
+    );
 
     let verifier_air_refs = airs.air_refs();
     assert_eq!(verifier_air_refs.len(), 8);
@@ -2700,11 +2720,14 @@ fn test_prove_first_epoch_without_halt() {
         .unwrap();
     assert!(epochs.len() >= 2);
 
-    // Epoch 0's starting memory is the ELF image; it does not halt (is_final=false).
+    // Epoch 0's starting memory/registers are the program-start image; it does
+    // not halt (is_final=false).
     let image = build_initial_image(&elf, &[]);
+    let register_init = crate::tables::register::register_init_from_entry_point(elf.entry_point);
     let mut traces = Traces::from_image_and_logs(
         &elf,
         &image,
+        &register_init,
         &epochs[0].logs,
         &MaxRowsConfig::default(),
         &[],
@@ -2724,6 +2747,7 @@ fn test_prove_first_epoch_without_halt() {
         &table_counts,
         None,
         false,
+        None,
     );
 
     let multi_proof = multi_prove_ram(
@@ -2749,5 +2773,90 @@ fn test_prove_first_epoch_without_halt() {
             &expected_bus_balance,
         ),
         "first epoch (HALT excluded) failed to verify"
+    );
+}
+
+/// Prove and verify a NON-first continuation epoch (epoch 1) in isolation. Its
+/// starting memory and registers come from epoch 0's boundary snapshot, and it
+/// does not terminate (HALT excluded).
+#[test]
+fn test_prove_second_epoch_from_snapshot() {
+    use crate::compute_expected_commit_bus_balance;
+    use crate::tables::register;
+    use crate::test_utils::asm_elf_bytes;
+
+    let _ = env_logger::builder().is_test(true).try_init();
+    let elf_bytes = asm_elf_bytes("basic_program");
+    let elf = Elf::load(&elf_bytes).unwrap();
+
+    // Split so epoch 1 is an intermediate epoch (not first, not last).
+    let total = Executor::new(&elf, vec![])
+        .unwrap()
+        .run()
+        .unwrap()
+        .logs
+        .len();
+    let epoch_size = (total / 3).max(1);
+    let epochs = Executor::new(&elf, vec![])
+        .unwrap()
+        .run_epochs(epoch_size)
+        .unwrap();
+    assert!(epochs.len() >= 3, "need an intermediate epoch 1");
+
+    // Epoch 1 starts from epoch 0's ending memory + register snapshot.
+    let image: std::collections::HashMap<u64, u8> = epochs[0].end_memory.iter_bytes().collect();
+    let register_init =
+        register::register_init_from_snapshot(&epochs[0].end_registers, epochs[0].end_pc);
+
+    let mut traces = Traces::from_image_and_logs(
+        &elf,
+        &image,
+        &register_init,
+        &epochs[1].logs,
+        &MaxRowsConfig::default(),
+        &[],
+        false,
+        #[cfg(feature = "disk-spill")]
+        stark::storage_mode::StorageMode::Ram,
+    )
+    .unwrap();
+
+    let proof_options = ProofOptions::default_test_options();
+    let table_counts = traces.table_counts();
+    // The REGISTER commitment is built from this epoch's boundary register init.
+    let airs = VmAirs::new(
+        &elf,
+        &proof_options,
+        true,
+        &traces.page_configs,
+        &table_counts,
+        None,
+        false,
+        Some(&register_init),
+    );
+
+    let multi_proof = multi_prove_ram(
+        airs.air_trace_pairs(&mut traces),
+        &mut DefaultTranscript::<E>::new(&[]),
+    )
+    .expect("second epoch failed to prove");
+
+    let mut replay = DefaultTranscript::<E>::new(&[]);
+    let expected_bus_balance = compute_expected_commit_bus_balance(
+        &airs.air_refs(),
+        &multi_proof,
+        &traces.public_output_bytes,
+        &mut replay,
+    )
+    .expect("fingerprint collision in test");
+
+    assert!(
+        Verifier::multi_verify(
+            &airs.air_refs(),
+            &multi_proof,
+            &mut DefaultTranscript::<E>::new(&[]),
+            &expected_bus_balance,
+        ),
+        "second epoch (register init from snapshot) failed to verify"
     );
 }

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -59,6 +59,7 @@ fn prove_and_verify_vm_minimal(elf: &Elf, traces: &mut Traces) -> bool {
         &traces.page_configs,
         &table_counts,
         None,
+        true,
     );
 
     // Build air_trace_pairs for all tables
@@ -109,6 +110,7 @@ fn prove_vm_minimal(elf_bytes: &[u8], private_inputs: &[u8], max_rows: &MaxRowsC
         &traces.page_configs,
         &table_counts,
         None,
+        true,
     );
     let runtime_page_ranges = traces.runtime_page_ranges();
     let proof = multi_prove_ram(
@@ -148,6 +150,7 @@ fn verify_vm_minimal(vm_proof: &VmProof, elf_bytes: &[u8]) -> bool {
         &page_configs,
         &vm_proof.table_counts,
         None,
+        true,
     );
     let air_refs = airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);
@@ -1164,6 +1167,7 @@ fn test_prove_elfs_test_commit_4_wrong_pages_rejected() {
         &traces.page_configs,
         &table_counts,
         None,
+        true,
     );
     let proof = multi_prove_ram(
         prover_airs.air_trace_pairs(&mut traces),
@@ -1180,6 +1184,7 @@ fn test_prove_elfs_test_commit_4_wrong_pages_rejected() {
         &wrong_configs,
         &table_counts,
         None,
+        true,
     );
     let verifier_air_refs = verifier_airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);
@@ -1910,6 +1915,7 @@ fn test_deep_stack_runtime_pages_roundtrip() {
         &traces.page_configs,
         &table_counts,
         None,
+        true,
     );
     let proof = multi_prove_ram(
         prover_airs.air_trace_pairs(&mut traces),
@@ -1925,6 +1931,7 @@ fn test_deep_stack_runtime_pages_roundtrip() {
         &verifier_configs,
         &table_counts,
         None,
+        true,
     );
     let verifier_air_refs = verifier_airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);
@@ -1974,6 +1981,7 @@ fn test_deep_stack_missing_pages_rejected() {
         &traces.page_configs,
         &table_counts,
         None,
+        true,
     );
     let proof = multi_prove_ram(
         prover_airs.air_trace_pairs(&mut traces),
@@ -1989,6 +1997,7 @@ fn test_deep_stack_missing_pages_rejected() {
         &wrong_configs,
         &table_counts,
         None,
+        true,
     );
     let verifier_air_refs = verifier_airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);
@@ -2073,6 +2082,7 @@ fn test_heap_alloc_runtime_pages_roundtrip() {
         &traces.page_configs,
         &table_counts,
         None,
+        true,
     );
     let proof = multi_prove_ram(
         prover_airs.air_trace_pairs(&mut traces),
@@ -2088,6 +2098,7 @@ fn test_heap_alloc_runtime_pages_roundtrip() {
         &verifier_configs,
         &table_counts,
         None,
+        true,
     );
     let verifier_air_refs = verifier_airs.air_refs();
     let mut replay_transcript = DefaultTranscript::<E>::new(&[]);
@@ -2234,7 +2245,7 @@ fn test_crafted_zero_count_proof_must_not_verify() {
         branch: 0,
         memw_register: 0,
     };
-    let airs = VmAirs::new(&elf, &proof_options, true, &[], &zero_counts, None);
+    let airs = VmAirs::new(&elf, &proof_options, true, &[], &zero_counts, None, true);
 
     let verifier_air_refs = airs.air_refs();
     assert_eq!(verifier_air_refs.len(), 8);
@@ -2659,5 +2670,84 @@ fn test_count_elements_nonzero() {
     assert!(
         aux > 0,
         "total_auxiliary_field_elements should be nonzero (got {aux})"
+    );
+}
+
+/// Prove and verify the FIRST continuation epoch in isolation. Epoch 0 starts
+/// from the program's initial memory/registers (so its init is correct) and does
+/// not terminate, so it is proven with the HALT table excluded (`include_halt = false`).
+#[test]
+fn test_prove_first_epoch_without_halt() {
+    use crate::compute_expected_commit_bus_balance;
+    use crate::tables::trace_builder::build_initial_image;
+    use crate::test_utils::asm_elf_bytes;
+
+    let _ = env_logger::builder().is_test(true).try_init();
+    let elf_bytes = asm_elf_bytes("basic_program");
+    let elf = Elf::load(&elf_bytes).unwrap();
+
+    // Split so epoch 0 is intermediate (the program spans more than one epoch).
+    let total = Executor::new(&elf, vec![])
+        .unwrap()
+        .run()
+        .unwrap()
+        .logs
+        .len();
+    let epoch_size = (total / 3).max(1);
+    let epochs = Executor::new(&elf, vec![])
+        .unwrap()
+        .run_epochs(epoch_size)
+        .unwrap();
+    assert!(epochs.len() >= 2);
+
+    // Epoch 0's starting memory is the ELF image; it does not halt (is_final=false).
+    let image = build_initial_image(&elf, &[]);
+    let mut traces = Traces::from_image_and_logs(
+        &elf,
+        &image,
+        &epochs[0].logs,
+        &MaxRowsConfig::default(),
+        &[],
+        false,
+        #[cfg(feature = "disk-spill")]
+        stark::storage_mode::StorageMode::Ram,
+    )
+    .unwrap();
+
+    let proof_options = ProofOptions::default_test_options();
+    let table_counts = traces.table_counts();
+    let airs = VmAirs::new(
+        &elf,
+        &proof_options,
+        true,
+        &traces.page_configs,
+        &table_counts,
+        None,
+        false,
+    );
+
+    let multi_proof = multi_prove_ram(
+        airs.air_trace_pairs(&mut traces),
+        &mut DefaultTranscript::<E>::new(&[]),
+    )
+    .expect("first epoch failed to prove");
+
+    let mut replay = DefaultTranscript::<E>::new(&[]);
+    let expected_bus_balance = compute_expected_commit_bus_balance(
+        &airs.air_refs(),
+        &multi_proof,
+        &traces.public_output_bytes,
+        &mut replay,
+    )
+    .expect("fingerprint collision in test");
+
+    assert!(
+        Verifier::multi_verify(
+            &airs.air_refs(),
+            &multi_proof,
+            &mut DefaultTranscript::<E>::new(&[]),
+            &expected_bus_balance,
+        ),
+        "first epoch (HALT excluded) failed to verify"
     );
 }

--- a/prover/src/tests/register_tests.rs
+++ b/prover/src/tests/register_tests.rs
@@ -17,7 +17,7 @@ fn test_register_base_address() {
 fn test_generate_register_trace_empty() {
     let entry_point = 0x1000u64;
     let final_state = FinalRegisterStateMap::new();
-    let trace = generate_register_trace(&final_state, entry_point);
+    let trace = generate_register_trace(&final_state, &register_init_from_entry_point(entry_point));
 
     // Should have power-of-2 rows >= 67 (x0-x31, x254, x255)
     assert!(trace.num_rows() >= NUM_REGISTER_ADDRESSES);
@@ -66,7 +66,7 @@ fn test_generate_register_trace_with_access() {
         },
     );
 
-    let trace = generate_register_trace(&final_state, entry_point);
+    let trace = generate_register_trace(&final_state, &register_init_from_entry_point(entry_point));
 
     // Row 10 (address 10) should have the final state
     assert_eq!(*trace.main_table.get(10, cols::OFFSET), FE::from(10u64));

--- a/prover/src/tests/trace_builder_tests.rs
+++ b/prover/src/tests/trace_builder_tests.rs
@@ -849,9 +849,12 @@ fn test_from_image_and_logs_matches_from_elf_and_logs() {
     .unwrap();
 
     let image = build_initial_image(&program, &[]);
+    let register_init =
+        crate::tables::register::register_init_from_entry_point(program.entry_point);
     let from_image = Traces::from_image_and_logs(
         &program,
         &image,
+        &register_init,
         &logs,
         &max_rows,
         &[],
@@ -931,17 +934,27 @@ fn test_build_traces_for_all_epochs() {
     let last = epochs.len() - 1;
 
     for (i, epoch) in epochs.iter().enumerate() {
-        // Epoch 0 starts from the ELF image; later epochs from the previous
-        // epoch's ending memory snapshot.
-        let image: HashMap<u64, u8> = if i == 0 {
-            build_initial_image(&program, &[])
+        // Epoch 0 starts from the program-start image; later epochs from the
+        // previous epoch's ending memory + register snapshot.
+        let (image, register_init): (HashMap<u64, u8>, HashMap<u64, u32>) = if i == 0 {
+            (
+                build_initial_image(&program, &[]),
+                crate::tables::register::register_init_from_entry_point(program.entry_point),
+            )
         } else {
-            epochs[i - 1].end_memory.iter_bytes().collect()
+            (
+                epochs[i - 1].end_memory.iter_bytes().collect(),
+                crate::tables::register::register_init_from_snapshot(
+                    &epochs[i - 1].end_registers,
+                    epochs[i - 1].end_pc,
+                ),
+            )
         };
 
         let traces = Traces::from_image_and_logs(
             &program,
             &image,
+            &register_init,
             &epoch.logs,
             &max_rows,
             &[],

--- a/prover/src/tests/trace_builder_tests.rs
+++ b/prover/src/tests/trace_builder_tests.rs
@@ -970,3 +970,55 @@ fn test_build_traces_for_all_epochs() {
         );
     }
 }
+
+/// A non-final epoch carrying the program-terminating instruction is rejected
+/// (rather than silently producing an unverifiable proof).
+#[test]
+fn test_terminating_epoch_rejected_when_not_final() {
+    use crate::tables::MaxRowsConfig;
+    use crate::tables::register::register_init_from_snapshot;
+    use crate::test_utils::asm_elf_bytes;
+    use executor::elf::Elf;
+    use executor::vm::execution::Executor;
+    use std::collections::HashMap;
+
+    let elf_bytes = asm_elf_bytes("basic_program");
+    let program = Elf::load(&elf_bytes).unwrap();
+
+    let total = Executor::new(&program, vec![])
+        .unwrap()
+        .run()
+        .unwrap()
+        .logs
+        .len();
+    let epoch_size = (total / 3).max(1);
+    let epochs = Executor::new(&program, vec![])
+        .unwrap()
+        .run_epochs(epoch_size)
+        .unwrap();
+    assert!(epochs.len() >= 2);
+
+    // The last epoch holds the terminating instruction; building it as a
+    // non-final epoch (is_final = false) must error.
+    let last = epochs.len() - 1;
+    let image: HashMap<u64, u8> = epochs[last - 1].end_memory.iter_bytes().collect();
+    let register_init =
+        register_init_from_snapshot(&epochs[last - 1].end_registers, epochs[last - 1].end_pc);
+
+    let result = Traces::from_image_and_logs(
+        &program,
+        &image,
+        &register_init,
+        &epochs[last].logs,
+        &MaxRowsConfig::default(),
+        &[],
+        false,
+        #[cfg(feature = "disk-spill")]
+        stark::storage_mode::StorageMode::Ram,
+    );
+
+    assert!(
+        matches!(result, Err(crate::Error::HaltInNonFinalEpoch)),
+        "expected HaltInNonFinalEpoch error for a non-final terminating epoch"
+    );
+}

--- a/prover/src/tests/trace_builder_tests.rs
+++ b/prover/src/tests/trace_builder_tests.rs
@@ -822,3 +822,83 @@ mod routing_tests {
         );
     }
 }
+
+/// `from_image_and_logs` is a faithful generalization of `from_elf_and_logs`:
+/// fed the ELF-derived image, it must produce identical traces.
+#[test]
+fn test_from_image_and_logs_matches_from_elf_and_logs() {
+    use crate::tables::MaxRowsConfig;
+    use crate::tables::trace_builder::build_initial_image;
+    use crate::test_utils::asm_elf_bytes;
+    use executor::elf::Elf;
+    use executor::vm::execution::Executor;
+
+    let elf_bytes = asm_elf_bytes("basic_program");
+    let program = Elf::load(&elf_bytes).unwrap();
+    let logs = Executor::new(&program, vec![])
+        .unwrap()
+        .run()
+        .unwrap()
+        .logs;
+    let max_rows = MaxRowsConfig::default();
+
+    let from_elf = Traces::from_elf_and_logs(
+        &program,
+        &logs,
+        &max_rows,
+        &[],
+        #[cfg(feature = "disk-spill")]
+        stark::storage_mode::StorageMode::Ram,
+    )
+    .unwrap();
+
+    let image = build_initial_image(&program, &[]);
+    let from_image = Traces::from_image_and_logs(
+        &program,
+        &image,
+        &logs,
+        &max_rows,
+        &[],
+        #[cfg(feature = "disk-spill")]
+        stark::storage_mode::StorageMode::Ram,
+    )
+    .unwrap();
+
+    assert_eq!(
+        from_elf.total_field_elements(),
+        from_image.total_field_elements()
+    );
+    assert_eq!(
+        format!("{:?}", from_elf.table_counts()),
+        format!("{:?}", from_image.table_counts())
+    );
+}
+
+/// A memory snapshot at an epoch boundary converts into a non-empty initial
+/// image (the input `from_image_and_logs` consumes for the next epoch).
+#[test]
+fn test_epoch_end_memory_converts_to_image() {
+    use crate::test_utils::asm_elf_bytes;
+    use executor::elf::Elf;
+    use executor::vm::execution::Executor;
+    use std::collections::HashMap;
+
+    let elf_bytes = asm_elf_bytes("basic_program");
+    let program = Elf::load(&elf_bytes).unwrap();
+
+    let total = Executor::new(&program, vec![])
+        .unwrap()
+        .run()
+        .unwrap()
+        .logs
+        .len();
+    let epoch_size = (total / 3).max(1);
+    let epochs = Executor::new(&program, vec![])
+        .unwrap()
+        .run_epochs(epoch_size)
+        .unwrap();
+    assert!(epochs.len() >= 2);
+
+    let image: HashMap<u64, u8> = epochs[0].end_memory.iter_bytes().collect();
+    assert!(!image.is_empty());
+}

--- a/prover/src/tests/trace_builder_tests.rs
+++ b/prover/src/tests/trace_builder_tests.rs
@@ -835,11 +835,7 @@ fn test_from_image_and_logs_matches_from_elf_and_logs() {
 
     let elf_bytes = asm_elf_bytes("basic_program");
     let program = Elf::load(&elf_bytes).unwrap();
-    let logs = Executor::new(&program, vec![])
-        .unwrap()
-        .run()
-        .unwrap()
-        .logs;
+    let logs = Executor::new(&program, vec![]).unwrap().run().unwrap().logs;
     let max_rows = MaxRowsConfig::default();
 
     let from_elf = Traces::from_elf_and_logs(
@@ -859,6 +855,7 @@ fn test_from_image_and_logs_matches_from_elf_and_logs() {
         &logs,
         &max_rows,
         &[],
+        true,
         #[cfg(feature = "disk-spill")]
         stark::storage_mode::StorageMode::Ram,
     )
@@ -901,4 +898,62 @@ fn test_epoch_end_memory_converts_to_image() {
 
     let image: HashMap<u64, u8> = epochs[0].end_memory.iter_bytes().collect();
     assert!(!image.is_empty());
+}
+
+/// Every epoch builds traces: intermediate epochs (`is_final = false`) skip HALT
+/// and start from the previous epoch's memory; the last epoch terminates.
+#[test]
+fn test_build_traces_for_all_epochs() {
+    use crate::tables::MaxRowsConfig;
+    use crate::tables::trace_builder::build_initial_image;
+    use crate::test_utils::asm_elf_bytes;
+    use executor::elf::Elf;
+    use executor::vm::execution::Executor;
+    use std::collections::HashMap;
+
+    let elf_bytes = asm_elf_bytes("basic_program");
+    let program = Elf::load(&elf_bytes).unwrap();
+
+    let total = Executor::new(&program, vec![])
+        .unwrap()
+        .run()
+        .unwrap()
+        .logs
+        .len();
+    let epoch_size = (total / 3).max(1);
+    let epochs = Executor::new(&program, vec![])
+        .unwrap()
+        .run_epochs(epoch_size)
+        .unwrap();
+    assert!(epochs.len() >= 2);
+
+    let max_rows = MaxRowsConfig::default();
+    let last = epochs.len() - 1;
+
+    for (i, epoch) in epochs.iter().enumerate() {
+        // Epoch 0 starts from the ELF image; later epochs from the previous
+        // epoch's ending memory snapshot.
+        let image: HashMap<u64, u8> = if i == 0 {
+            build_initial_image(&program, &[])
+        } else {
+            epochs[i - 1].end_memory.iter_bytes().collect()
+        };
+
+        let traces = Traces::from_image_and_logs(
+            &program,
+            &image,
+            &epoch.logs,
+            &max_rows,
+            &[],
+            i == last,
+            #[cfg(feature = "disk-spill")]
+            stark::storage_mode::StorageMode::Ram,
+        )
+        .unwrap_or_else(|e| panic!("epoch {i} (is_final={}) failed to build: {e:?}", i == last));
+
+        assert!(
+            traces.table_counts().cpu > 0,
+            "epoch {i} produced an empty CPU trace"
+        );
+    }
 }


### PR DESCRIPTION
## Description 

First step toward continuations (proving arbitrarily long executions by splitting them into epochs. This lands the foundation; cross-epoch soundness is a follow-up.

- `Executor::run_epochs(n)` splits execution into epochs of N cycles, capturing each epoch's boundary state (pc, registers, memory).
- `Traces::from_image_and_logs` builds one epoch's traces from an explicit starting memory + register image (the first epoch from the ELF, later epochs from the previous epoch's snapshot).
- HALT is applied only to the final epoch (`is_final` / `VmAirs.include_halt`); intermediate epochs keep their boundary state.
- `VmAirs::new` takes an optional `register_init` so an epoch's REGISTER commitment can use its boundary register snapshot.
- Each epoch can be proven and verified in isolation (tests for the first and a non-first epoch).