### PR TITLE
refactor: single global page size (remove PageConfig.page_size)

### DIFF
--- a/prover/src/tables/page.rs
+++ b/prover/src/tables/page.rs
@@ -106,10 +106,9 @@ pub type FinalStateMap = HashMap<u64, FinalByteState>;
 pub struct PageConfig {
     /// Base address of this page (must be page-aligned).
     pub page_base: u64,
-    /// Size of the page in bytes (must be power of 2).
-    pub page_size: usize,
-    /// Initial values for each byte in the page.
-    /// If None, all bytes are zero-initialized.
+    /// Initial values for the page. If None, all bytes are zero-initialized.
+    /// May be shorter than `DEFAULT_PAGE_SIZE`; any missing trailing bytes are
+    /// treated as zero. (All pages are `DEFAULT_PAGE_SIZE`; see that constant.)
     pub init_values: Option<Vec<u8>>,
     /// Whether this page holds private input data.
     /// Private-input pages are NOT preprocessed — the verifier does not see
@@ -120,38 +119,32 @@ pub struct PageConfig {
 
 impl PageConfig {
     /// Create a zero-initialized page.
-    pub fn zero_init(page_base: u64, page_size: usize) -> Self {
+    pub fn zero_init(page_base: u64) -> Self {
         Self {
             page_base,
-            page_size,
             init_values: None,
             is_private_input: false,
         }
     }
 
-    /// Create a page with initial values from ELF data.
-    pub fn with_data(page_base: u64, page_size: usize, data: Vec<u8>) -> Self {
-        assert!(data.len() <= page_size, "Data exceeds page size");
-        let mut init_values = data;
-        init_values.resize(page_size, 0); // Pad with zeros
+    /// Create a page with initial values from ELF data. `data` may be shorter
+    /// than the page; the trace/commitment math treats trailing bytes as zero.
+    pub fn with_data(page_base: u64, data: Vec<u8>) -> Self {
+        assert!(data.len() <= DEFAULT_PAGE_SIZE, "Data exceeds page size");
         Self {
             page_base,
-            page_size,
-            init_values: Some(init_values),
+            init_values: Some(data),
             is_private_input: false,
         }
     }
 
     /// Create a page with initial values from private input data.
     /// These pages are NOT preprocessed — the verifier never sees the init values.
-    pub fn with_private_input(page_base: u64, page_size: usize, data: Vec<u8>) -> Self {
-        assert!(data.len() <= page_size, "Data exceeds page size");
-        let mut init_values = data;
-        init_values.resize(page_size, 0);
+    pub fn with_private_input(page_base: u64, data: Vec<u8>) -> Self {
+        assert!(data.len() <= DEFAULT_PAGE_SIZE, "Data exceeds page size");
         Self {
             page_base,
-            page_size,
-            init_values: Some(init_values),
+            init_values: Some(data),
             is_private_input: true,
         }
     }
@@ -175,11 +168,9 @@ pub fn generate_page_trace(
     config: &PageConfig,
     final_state: &FinalStateMap,
 ) -> TraceTable<GoldilocksField, GoldilocksExtension> {
-    let page_size = config.page_size;
+    let page_size = DEFAULT_PAGE_SIZE;
     let page_base = config.page_base;
 
-    // Page size must be power of 2
-    assert!(page_size.is_power_of_two(), "Page size must be power of 2");
     // Page base must be page-aligned
     assert!(
         page_base.is_multiple_of(page_size as u64),
@@ -196,13 +187,12 @@ pub fn generate_page_trace(
         // Offset (preprocessed) - address is virtual: page_base + offset
         data[base + cols::OFFSET] = FE::from(offset as u64);
 
-        // Initial value
-        // Safety: init_vals.len() == page_size (guaranteed by with_data resize)
-        let init_value = if let Some(ref init_vals) = config.init_values {
-            init_vals[offset]
-        } else {
-            0 // Zero-initialized
-        };
+        // Initial value (init_values may be shorter than the page → trailing zeros)
+        let init_value = config
+            .init_values
+            .as_ref()
+            .and_then(|v| v.get(offset).copied())
+            .unwrap_or(0);
         data[base + cols::INIT] = FE::from(init_value as u64);
 
         // Final state: if accessed use final, otherwise use initial
@@ -237,9 +227,7 @@ static ZERO_PAGE_4K_COMMITMENT: OnceLock<Commitment> = OnceLock::new();
 /// The commitment covers OFFSET (0..page_size-1) and INIT (from config).
 /// Each page may have different INIT data, producing a different commitment.
 pub fn compute_precomputed_commitment(config: &PageConfig, options: &ProofOptions) -> Commitment {
-    let page_size = config.page_size;
-    assert!(page_size.is_power_of_two(), "Page size must be power of 2");
-
+    let page_size = DEFAULT_PAGE_SIZE;
     let num_rows = page_size;
 
     // Precomputed columns: OFFSET and INIT.
@@ -257,11 +245,12 @@ pub fn compute_precomputed_commitment(config: &PageConfig, options: &ProofOption
 
     for i in 0..page_size {
         offset_col[i] = FE::from(i as u64);
-        init_col[i] = if let Some(ref init_vals) = config.init_values {
-            FE::from(init_vals[i] as u64)
-        } else {
-            FE::zero()
-        };
+        let init_byte = config
+            .init_values
+            .as_ref()
+            .and_then(|v| v.get(i).copied())
+            .unwrap_or(0);
+        init_col[i] = FE::from(init_byte as u64);
     }
 
     let columns = [offset_col, init_col];
@@ -299,7 +288,7 @@ pub fn compute_precomputed_commitment(config: &PageConfig, options: &ProofOption
 /// Zero-init pages of DEFAULT_PAGE_SIZE share a cached commitment.
 /// ELF data pages compute their commitment fresh.
 pub fn precomputed_commitment_cached(config: &PageConfig, options: &ProofOptions) -> Commitment {
-    if config.init_values.is_none() && config.page_size == DEFAULT_PAGE_SIZE {
+    if config.init_values.is_none() {
         *ZERO_PAGE_4K_COMMITMENT.get_or_init(|| compute_precomputed_commitment(config, options))
     } else {
         compute_precomputed_commitment(config, options)
@@ -414,19 +403,11 @@ pub fn bus_interactions(page_base: u64) -> Vec<BusInteraction> {
 // =========================================================================
 
 /// Compute the page base address for a given byte address.
-pub fn page_base_for_address(addr: u64, page_size: usize) -> u64 {
-    debug_assert!(
-        page_size.is_power_of_two(),
-        "page_size must be a power of 2"
-    );
-    addr & !(page_size as u64 - 1)
+pub fn page_base_for_address(addr: u64) -> u64 {
+    addr & !(DEFAULT_PAGE_SIZE as u64 - 1)
 }
 
 /// Compute the offset within a page for a given byte address.
-pub fn offset_in_page(addr: u64, page_size: usize) -> usize {
-    debug_assert!(
-        page_size.is_power_of_two(),
-        "page_size must be a power of 2"
-    );
-    (addr & (page_size as u64 - 1)) as usize
+pub fn offset_in_page(addr: u64) -> usize {
+    (addr & (DEFAULT_PAGE_SIZE as u64 - 1)) as usize
 }

--- a/prover/src/tables/page.rs
+++ b/prover/src/tables/page.rs
@@ -106,9 +106,9 @@ pub type FinalStateMap = HashMap<u64, FinalByteState>;
 pub struct PageConfig {
     /// Base address of this page (must be page-aligned).
     pub page_base: u64,
-    /// Initial values for the page. If None, all bytes are zero-initialized.
-    /// May be shorter than `DEFAULT_PAGE_SIZE`; any missing trailing bytes are
-    /// treated as zero. (All pages are `DEFAULT_PAGE_SIZE`; see that constant.)
+    /// Initial byte values; `None` means an all-zero page.
+    /// `Some(v)` is not padded, so `v.len()` may be smaller than the page
+    /// (`DEFAULT_PAGE_SIZE`); any offset at or past `v.len()` is read as zero.
     pub init_values: Option<Vec<u8>>,
     /// Whether this page holds private input data.
     /// Private-input pages are NOT preprocessed — the verifier does not see

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -1492,8 +1492,8 @@ fn build_init_page_data(elf: &Elf, private_input: &[u8]) -> HashMap<u64, Vec<u8>
             for byte_offset in 0..4u64 {
                 let byte_addr = word_addr + byte_offset;
                 let byte_value = ((word >> (byte_offset * 8)) & 0xFF) as u8;
-                let page_base = page::page_base_for_address(byte_addr, page_size);
-                let offset = page::offset_in_page(byte_addr, page_size);
+                let page_base = page::page_base_for_address(byte_addr);
+                let offset = page::offset_in_page(byte_addr);
                 let page_data = init_page_data
                     .entry(page_base)
                     .or_insert_with(|| vec![0u8; page_size]);
@@ -1504,8 +1504,8 @@ fn build_init_page_data(elf: &Elf, private_input: &[u8]) -> HashMap<u64, Vec<u8>
     if !private_input.is_empty() {
         for (i, &b) in private_input_bytes(private_input).iter().enumerate() {
             let addr = PRIVATE_INPUT_START_INDEX + i as u64;
-            let page_base = page::page_base_for_address(addr, page_size);
-            let offset = page::offset_in_page(addr, page_size);
+            let page_base = page::page_base_for_address(addr);
+            let offset = page::offset_in_page(addr);
             let page_data = init_page_data
                 .entry(page_base)
                 .or_insert_with(|| vec![0u8; page_size]);
@@ -1530,7 +1530,7 @@ fn collect_bitwise_from_page(
     // Derive ALL page bases from memory_state (includes ELF + runtime pages)
     let mut page_bases: BTreeSet<u64> = BTreeSet::new();
     for &addr in memory_state.cells.keys() {
-        page_bases.insert(page::page_base_for_address(addr, page_size));
+        page_bases.insert(page::page_base_for_address(addr));
     }
 
     // Build final state map from memory_state
@@ -1931,15 +1931,13 @@ fn generate_page_tables(
 ) {
     use std::collections::BTreeSet;
 
-    let page_size = page::DEFAULT_PAGE_SIZE;
-
     // Collect init data from ELF segments + private input region
     let init_page_data = build_init_page_data(elf, private_input);
 
     // Derive ALL page bases from memory_state (includes ELF + runtime pages)
     let mut page_bases: BTreeSet<u64> = BTreeSet::new();
     for &addr in memory_state.cells.keys() {
-        page_bases.insert(page::page_base_for_address(addr, page_size));
+        page_bases.insert(page::page_base_for_address(addr));
     }
 
     // Build final state map from memory_state
@@ -1958,7 +1956,7 @@ fn generate_page_tables(
         use executor::vm::memory::PRIVATE_INPUT_START_INDEX;
         let total_bytes = 4 + private_input.len(); // length prefix + data
         (0..total_bytes)
-            .map(|i| page::page_base_for_address(PRIVATE_INPUT_START_INDEX + i as u64, page_size))
+            .map(|i| page::page_base_for_address(PRIVATE_INPUT_START_INDEX + i as u64))
             .collect()
     } else {
         std::collections::BTreeSet::new()
@@ -1967,11 +1965,11 @@ fn generate_page_tables(
     for &page_base in &page_bases {
         let config = if private_input_page_bases.contains(&page_base) {
             let init_data = init_page_data.get(&page_base).cloned().unwrap_or_default();
-            PageConfig::with_private_input(page_base, page_size, init_data)
+            PageConfig::with_private_input(page_base, init_data)
         } else if let Some(init_data) = init_page_data.get(&page_base) {
-            PageConfig::with_data(page_base, page_size, init_data.clone())
+            PageConfig::with_data(page_base, init_data.clone())
         } else {
-            PageConfig::zero_init(page_base, page_size)
+            PageConfig::zero_init(page_base)
         };
 
         let trace = page::generate_page_trace(&config, &final_state);
@@ -2945,7 +2943,6 @@ impl Traces {
     pub fn page_configs_from_elf(elf: &Elf) -> Vec<PageConfig> {
         use std::collections::BTreeSet;
 
-        let page_size = page::DEFAULT_PAGE_SIZE;
         let init_page_data = build_init_page_data(elf, &[]);
 
         let page_bases: BTreeSet<u64> = init_page_data.keys().copied().collect();
@@ -2954,9 +2951,9 @@ impl Traces {
             .into_iter()
             .map(|base| {
                 if let Some(init_data) = init_page_data.get(&base) {
-                    PageConfig::with_data(base, page_size, init_data.clone())
+                    PageConfig::with_data(base, init_data.clone())
                 } else {
-                    PageConfig::zero_init(base, page_size)
+                    PageConfig::zero_init(base)
                 }
             })
             .collect()
@@ -2981,21 +2978,17 @@ impl Traces {
         for r in runtime_page_ranges {
             let (base, count) = (r.base, r.count);
             for i in 0..count {
-                configs.push(PageConfig::zero_init(
-                    base + i * page_size as u64,
-                    page_size,
-                ));
+                configs.push(PageConfig::zero_init(base + i * page_size as u64));
             }
         }
 
         // Add private-input pages (non-preprocessed, verifier doesn't know init values)
         if num_private_input_pages > 0 {
             use executor::vm::memory::PRIVATE_INPUT_START_INDEX;
-            let first_page_base = page::page_base_for_address(PRIVATE_INPUT_START_INDEX, page_size);
+            let first_page_base = page::page_base_for_address(PRIVATE_INPUT_START_INDEX);
             for i in 0..num_private_input_pages {
                 configs.push(PageConfig {
                     page_base: first_page_base + i as u64 * page_size as u64,
-                    page_size,
                     init_values: None, // Verifier doesn't know these
                     is_private_input: true,
                 });

--- a/prover/src/tables/trace_builder.rs
+++ b/prover/src/tables/trace_builder.rs
@@ -1547,8 +1547,9 @@ fn collect_bitwise_from_page(
         for offset in 0..page_size {
             let addr = page_base + offset as u64;
 
-            // Get init value (from ELF or 0)
-            let init = init_data.map_or(0u8, |data| data[offset]);
+            // Get init value (from ELF or 0). `.get().unwrap_or(0)` to match the
+            // relaxed `init_values` contract: a shorter vec reads as trailing zeros.
+            let init = init_data.map_or(0u8, |data| data.get(offset).copied().unwrap_or(0));
 
             // Get fini value (from final_state or init if never accessed)
             let fini = final_state.get(&addr).map_or(init, |state| state.value);

--- a/prover/src/tests/page_tests.rs
+++ b/prover/src/tests/page_tests.rs
@@ -5,71 +5,97 @@ use crate::tables::types::*;
 
 #[test]
 fn test_page_base_for_address() {
-    let page_size = 4096;
-    assert_eq!(page_base_for_address(0x1000, page_size), 0x1000);
-    assert_eq!(page_base_for_address(0x1001, page_size), 0x1000);
-    assert_eq!(page_base_for_address(0x1FFF, page_size), 0x1000);
-    assert_eq!(page_base_for_address(0x2000, page_size), 0x2000);
+    // DEFAULT_PAGE_SIZE = 1 << 18 = 0x40000
+    assert_eq!(page_base_for_address(0x00000), 0x00000);
+    assert_eq!(page_base_for_address(0x1000), 0x00000); // 0x1000 < 0x40000
+    assert_eq!(page_base_for_address(0x3FFFF), 0x00000); // last byte of first page
+    assert_eq!(page_base_for_address(0x40000), 0x40000); // start of second page
+    assert_eq!(page_base_for_address(0x40001), 0x40000); // one byte into second page
 }
 
 #[test]
 fn test_offset_in_page() {
-    let page_size = 4096;
-    assert_eq!(offset_in_page(0x1000, page_size), 0);
-    assert_eq!(offset_in_page(0x1001, page_size), 1);
-    assert_eq!(offset_in_page(0x1FFF, page_size), 4095);
-    assert_eq!(offset_in_page(0x2000, page_size), 0);
+    // DEFAULT_PAGE_SIZE = 0x40000
+    assert_eq!(offset_in_page(0x00000), 0);
+    assert_eq!(offset_in_page(0x1000), 0x1000); // 4096
+    assert_eq!(offset_in_page(0x3FFFF), 0x3FFFF); // last offset in first page
+    assert_eq!(offset_in_page(0x40000), 0); // start of second page → offset 0
+    assert_eq!(offset_in_page(0x40001), 1); // one byte into second page
 }
 
 #[test]
 fn test_generate_page_trace_zero_init() {
-    let config = PageConfig::zero_init(0x1000, 16); // Small page for testing
+    // Use 0 as page_base (aligned to DEFAULT_PAGE_SIZE = 256KB)
+    let config = PageConfig::zero_init(0);
     let final_state = FinalStateMap::new();
 
     let trace = generate_page_trace(&config, &final_state);
 
-    assert_eq!(trace.num_rows(), 16);
+    // Trace must have DEFAULT_PAGE_SIZE rows
+    assert_eq!(trace.num_rows(), DEFAULT_PAGE_SIZE);
 
-    // Check first row (address is virtual: 0x1000 + offset)
+    // Sample: first row
     assert_eq!(*trace.main_table.get(0, cols::OFFSET), FE::zero());
     assert_eq!(*trace.main_table.get(0, cols::INIT), FE::zero());
     assert_eq!(*trace.main_table.get(0, cols::FINI), FE::zero());
     assert_eq!(*trace.main_table.get(0, cols::TIMESTAMP_LO), FE::zero());
 
-    // Check last row (address is virtual: 0x1000 + 15 = 0x100F)
-    assert_eq!(*trace.main_table.get(15, cols::OFFSET), FE::from(15u64));
-    assert_eq!(*trace.main_table.get(15, cols::INIT), FE::zero());
+    // Sample: some middle row (offset 42)
+    assert_eq!(*trace.main_table.get(42, cols::OFFSET), FE::from(42u64));
+    assert_eq!(*trace.main_table.get(42, cols::INIT), FE::zero());
+    assert_eq!(*trace.main_table.get(42, cols::FINI), FE::zero());
+
+    // Sample: last row
+    let last = DEFAULT_PAGE_SIZE - 1;
+    assert_eq!(
+        *trace.main_table.get(last, cols::OFFSET),
+        FE::from(last as u64)
+    );
+    assert_eq!(*trace.main_table.get(last, cols::INIT), FE::zero());
+    assert_eq!(*trace.main_table.get(last, cols::FINI), FE::zero());
 }
 
 #[test]
 fn test_generate_page_trace_with_data() {
+    // Use 0 as page_base (aligned to DEFAULT_PAGE_SIZE = 256KB)
     let data = vec![0x01, 0x02, 0x03, 0x04];
-    let config = PageConfig::with_data(0x2000, 16, data);
+    let config = PageConfig::with_data(0, data);
     let final_state = FinalStateMap::new();
 
     let trace = generate_page_trace(&config, &final_state);
 
-    // Check initial values from data
+    // Trace must have DEFAULT_PAGE_SIZE rows
+    assert_eq!(trace.num_rows(), DEFAULT_PAGE_SIZE);
+
+    // Check initial values from data (first 4 bytes)
     assert_eq!(*trace.main_table.get(0, cols::INIT), FE::from(0x01u64));
     assert_eq!(*trace.main_table.get(1, cols::INIT), FE::from(0x02u64));
     assert_eq!(*trace.main_table.get(2, cols::INIT), FE::from(0x03u64));
     assert_eq!(*trace.main_table.get(3, cols::INIT), FE::from(0x04u64));
-    // Rest should be zero (padding)
+    // Bytes past the supplied data should be zero (trailing zeros)
     assert_eq!(*trace.main_table.get(4, cols::INIT), FE::zero());
+    assert_eq!(*trace.main_table.get(100, cols::INIT), FE::zero());
 
     // Without accesses, fini should equal init
     assert_eq!(*trace.main_table.get(0, cols::FINI), FE::from(0x01u64));
+    assert_eq!(*trace.main_table.get(3, cols::FINI), FE::from(0x04u64));
+    assert_eq!(*trace.main_table.get(4, cols::FINI), FE::zero());
+
+    // OFFSET column must equal row index
+    assert_eq!(*trace.main_table.get(0, cols::OFFSET), FE::from(0u64));
+    assert_eq!(*trace.main_table.get(3, cols::OFFSET), FE::from(3u64));
 }
 
 #[test]
 fn test_generate_page_trace_with_accesses() {
+    // Use 0 as page_base (aligned to DEFAULT_PAGE_SIZE = 256KB)
     let data = vec![0xAA, 0xBB];
-    let config = PageConfig::with_data(0x3000, 16, data);
+    let config = PageConfig::with_data(0, data);
 
     let mut final_state = FinalStateMap::new();
-    // Address 0x3000 was written with value 0xFF at timestamp 100
+    // Address 0 (= page_base + offset 0) was written with value 0xFF at timestamp 100
     final_state.insert(
-        0x3000,
+        0,
         FinalByteState {
             timestamp: 100,
             value: 0xFF,
@@ -78,7 +104,7 @@ fn test_generate_page_trace_with_accesses() {
 
     let trace = generate_page_trace(&config, &final_state);
 
-    // Row 0: address 0x3000 - was accessed
+    // Row 0: address 0 (offset 0) - was accessed
     assert_eq!(*trace.main_table.get(0, cols::INIT), FE::from(0xAAu64));
     assert_eq!(*trace.main_table.get(0, cols::FINI), FE::from(0xFFu64));
     assert_eq!(
@@ -86,15 +112,24 @@ fn test_generate_page_trace_with_accesses() {
         FE::from(100u64)
     );
 
-    // Row 1: address 0x3001 - not accessed, fini = init
+    // Row 1: address 1 (offset 1) - not accessed, fini = init = 0xBB
     assert_eq!(*trace.main_table.get(1, cols::INIT), FE::from(0xBBu64));
     assert_eq!(*trace.main_table.get(1, cols::FINI), FE::from(0xBBu64));
     assert_eq!(*trace.main_table.get(1, cols::TIMESTAMP_LO), FE::zero());
+
+    // Row 2: not in data, not accessed — init=0, fini=0
+    assert_eq!(*trace.main_table.get(2, cols::INIT), FE::zero());
+    assert_eq!(*trace.main_table.get(2, cols::FINI), FE::zero());
+    assert_eq!(*trace.main_table.get(2, cols::TIMESTAMP_LO), FE::zero());
+
+    // OFFSET column must equal row index
+    assert_eq!(*trace.main_table.get(0, cols::OFFSET), FE::from(0u64));
+    assert_eq!(*trace.main_table.get(1, cols::OFFSET), FE::from(1u64));
 }
 
 #[test]
 fn test_bus_interactions() {
-    let interactions = bus_interactions(0x1000); // page_base
+    let interactions = bus_interactions(0); // page_base = 0
     assert_eq!(interactions.len(), 3); // C1+C2 (batched ARE_BYTES), C3, C4
 }
 

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -1721,7 +1721,7 @@ fn test_debug_memory_tokens_sb_sh() {
         .enumerate()
     {
         let page_base = page_config.page_base;
-        let page_size = page_config.page_size;
+        let page_size = crate::tables::page::DEFAULT_PAGE_SIZE;
         let page_lo = page_base & 0xFFFF_FFFF;
         let page_hi = page_base >> 32;
         let trace_rows = page_trace.num_rows();
@@ -1800,8 +1800,8 @@ fn test_debug_memory_tokens_sb_sh() {
     println!("\n=== ARE_BYTES Lookup Counts (from PAGE tables) ===");
     let mut page_pair_counts: HashMap<(u8, u8), u64> = HashMap::new();
     let total_page_rows: usize = traces.pages.iter().map(|p| p.num_rows()).sum();
-    for (page_idx, page_trace) in traces.pages.iter().enumerate() {
-        let page_size = traces.page_configs[page_idx].page_size;
+    for page_trace in traces.pages.iter() {
+        let page_size = crate::tables::page::DEFAULT_PAGE_SIZE;
         for row in 0..page_trace.num_rows().min(page_size) {
             let init = page_trace.main_table.get(row, page_cols::INIT).to_raw() as u8;
             let fini = page_trace.main_table.get(row, page_cols::FINI).to_raw() as u8;


### PR DESCRIPTION
## What
Make the memory page size a single global constant (`page::DEFAULT_PAGE_SIZE`) instead of a per-`PageConfig` field. Mixed page sizes are now structurally inexpressible.

## Why
`PageConfig.page_size` was false flexibility: every production builder set it to `DEFAULT_PAGE_SIZE`, and the address→page math (`page_base_for_address`, `runtime_page_ranges`) already assumed one global size — only unit tests varied it. Removing the field drops a misleading knob and guarantees uniform pages by construction.

## Changes
- `PageConfig` drops the `page_size` field; `zero_init` / `with_data` / `with_private_input` lose the size argument.
- `with_data` / `with_private_input` no longer pad `init_values`; `generate_page_trace` and `compute_precomputed_commitment` read it via `.get(i).unwrap_or(0)`, so a short `init_values` is treated as trailing zeros.
- `page_base_for_address(addr)` / `offset_in_page(addr)` are const-based.
- Callers in `trace_builder.rs` updated; page unit tests assert at `DEFAULT_PAGE_SIZE`.

## Tuning
To experiment with a different page size, change `DEFAULT_PAGE_SIZE` (and regenerate static commitments) — no parameter threading required.