### PR TITLE
refactor: compute the zero-init page commitment once (step 2)

### DIFF
--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -403,6 +403,14 @@ impl VmAirs {
             register::preprocessed_commitment(proof_options, elf.entry_point),
             register::NUM_PREPROCESSED_COLS,
         );
+        // Every zero-init page shares one preprocessed commitment: OFFSET is
+        // page-relative and INIT is all-zero, so it depends only on the proof
+        // options. Compute it once here rather than once per zero-init page.
+        // Every program has at least one zero-init page (the stack is
+        // zero-initialized), so this commitment is always used.
+        let zero_init_commitment =
+            page::compute_precomputed_commitment(&page::PageConfig::zero_init(0), proof_options);
+
         let pages: Vec<_> = page_configs
             .iter()
             .map(|config| {
@@ -411,11 +419,14 @@ impl VmAirs {
                     // The verifier doesn't see the init values; correctness is enforced
                     // by the memory bus constraints.
                     create_page_air(proof_options, config.page_base)
+                } else if config.init_values.is_none() {
+                    // Zero-init pages: the shared commitment computed once above.
+                    create_page_air(proof_options, config.page_base)
+                        .with_preprocessed(zero_init_commitment, page::NUM_PREPROCESSED_COLS)
                 } else {
-                    // ELF and zero-init pages: OFFSET + INIT are preprocessed.
-                    // The verifier independently recomputes the commitment from public data.
+                    // ELF data pages: INIT is program-specific, so recompute per page.
                     create_page_air(proof_options, config.page_base).with_preprocessed(
-                        page::precomputed_commitment_cached(config, proof_options),
+                        page::compute_precomputed_commitment(config, proof_options),
                         page::NUM_PREPROCESSED_COLS,
                     )
                 }

--- a/prover/src/tables/page.rs
+++ b/prover/src/tables/page.rs
@@ -31,7 +31,6 @@
 //! | PAGE-C4    | Memory  | `[0, address, timestamp, fini]` | 1 (sender) |
 
 use std::collections::HashMap;
-use std::sync::OnceLock;
 
 use math::fft::bit_reversing::in_place_bit_reverse_permute;
 use math::polynomial::Polynomial;
@@ -215,13 +214,6 @@ pub fn generate_page_trace(
 // Preprocessed commitment
 // =========================================================================
 
-/// Cached commitment for zero-initialized 4KB pages.
-/// All zero-init pages of the same size have identical OFFSET and INIT columns.
-///
-/// INVARIANT: All callers within a process must use identical `ProofOptions`.
-/// The cache is keyed only by page content, not by options.
-static ZERO_PAGE_4K_COMMITMENT: OnceLock<Commitment> = OnceLock::new();
-
 /// Computes the Merkle root commitment over the LDE of PAGE precomputed columns.
 ///
 /// The commitment covers OFFSET (0..page_size-1) and INIT (from config).
@@ -281,18 +273,6 @@ pub fn compute_precomputed_commitment(config: &PageConfig, options: &ProofOption
     let tree = BatchedMerkleTree::<GoldilocksField>::build(&lde_rows)
         .expect("Failed to build Merkle tree for page LDE");
     tree.root
-}
-
-/// Returns the preprocessed commitment for a PAGE table, with caching for zero-init pages.
-///
-/// Zero-init pages of DEFAULT_PAGE_SIZE share a cached commitment.
-/// ELF data pages compute their commitment fresh.
-pub fn precomputed_commitment_cached(config: &PageConfig, options: &ProofOptions) -> Commitment {
-    if config.init_values.is_none() {
-        *ZERO_PAGE_4K_COMMITMENT.get_or_init(|| compute_precomputed_commitment(config, options))
-    } else {
-        compute_precomputed_commitment(config, options)
-    }
 }
 
 // =========================================================================


### PR DESCRIPTION
**Stacked on #653** (single global page size). Review/merge that first; this PR's diff is only the step-2 change.

## What
Compute the zero-init page preprocessed commitment **once per `VmAirs` construction** and share it across all zero-init pages, replacing the process-global `ZERO_PAGE_4K_COMMITMENT` `OnceLock`.

## Why this is safe (non-cryptographic)
Every zero-init page (stack/heap/BSS) has the *identical* commitment — OFFSET is page-relative and INIT is all-zero, so it depends only on the proof options (page size is the global `DEFAULT_PAGE_SIZE` after #653). The verifier still **derives the value itself from public data**, exactly as before — committed bytes are bit-identical, trust model unchanged. This is a pure optimization + cleanup, deliberately landed *before* the cryptographic step.

## Also fixes a latent bug
The removed `OnceLock` cached keyed only by page *content*, not by `(blowup, coset)` — so a process verifying at more than one blowup would reuse the first blowup's root and falsely reject later proofs. (Masked today because `verify()` pins blowup=2.) The per-construction compute uses the actual options.

## Explicitly NOT here (→ step 3, the cryptographic step)
- No compile-time static const (trust anchor).
- No verifier-provided `page_commitments` injection.
ELF data pages still recompute per page.

## Testing
`cargo test --release -p lambda-vm-prover` → **384 passed, 0 failed**. fmt + clippy clean.