### PR TITLE
cleanup: split page preprocessed-commitment wrapper, fix generator output

### DIFF
--- a/prover/src/bin/compute_static_commitments.rs
+++ b/prover/src/bin/compute_static_commitments.rs
@@ -1,17 +1,17 @@
 //! Prints static `(bitwise, keccak_rc, zero_page)` preprocessed-table commitments
 //! for a fixed set of `blowup_factor` values. The output is pasted into the
-//! `static_commitment` match bodies in
-//! `prover/src/tables/{bitwise,keccak_rc,page}.rs`. The
-//! `static_commitments_tests` test suite pins the values so any drift in
+//! `static_commitment` match bodies in `prover/src/tables/{bitwise,keccak_rc}.rs`
+//! and the `static_zero_page_commitment` match body in `prover/src/tables/page.rs`.
+//! The `static_commitments_tests` test suite pins the values so any drift in
 //! the AIR or FFT pipeline is caught at test time.
 //!
 //! Run with:
 //!     cargo run --bin compute_static_commitments --release
 //!
 //! ⚠️  Do not run this just to silence a failing drift test — see the
-//! "Regenerating" section on `static_commitment` in `bitwise.rs`,
-//! `keccak_rc.rs`, and `page.rs` for when it's actually appropriate to
-//! bless new bytes.
+//! "Regenerating" section on `static_commitment` in `bitwise.rs` /
+//! `keccak_rc.rs` and `static_zero_page_commitment` in `page.rs` for when
+//! it's actually appropriate to bless new bytes.
 
 use lambda_vm_prover::tables::{STATIC_BLOWUP_FACTORS, bitwise, keccak_rc, page};
 use stark::config::Commitment;
@@ -35,8 +35,9 @@ fn format_commitment(commitment: &Commitment) -> String {
 
 fn main() {
     println!(
-        "// Paste these match arms into the `static_commitment` match body\n\
-         // in `prover/src/tables/{{bitwise,keccak_rc,page}}.rs`.\n"
+        "// Paste these match arms into the `static_commitment` match bodies\n\
+         // in `prover/src/tables/{{bitwise,keccak_rc}}.rs` and the\n\
+         // `static_zero_page_commitment` match body in `prover/src/tables/page.rs`.\n"
     );
 
     let zero_page_config = page::PageConfig::zero_init(0);
@@ -60,8 +61,8 @@ fn main() {
              {blowup} => Some({bitwise_fmt}),\n\
              // ---- keccak_rc:\n        \
              {blowup} => Some({keccak_fmt}),\n\
-             // ---- zero_page (page_size = DEFAULT_PAGE_SIZE):\n        \
-             (DEFAULT_PAGE_SIZE, {blowup}) => Some({zero_page_fmt}),\n",
+             // ---- zero_page:\n        \
+             {blowup} => Some({zero_page_fmt}),\n",
             bitwise_fmt = format_commitment(&bitwise),
             keccak_fmt = format_commitment(&keccak_rc),
             zero_page_fmt = format_commitment(&zero_page),

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -343,9 +343,10 @@ impl VmAirs {
     /// is supplied, it is used directly and that page's FFT + Merkle build is
     /// skipped. Pages not in the list — including all zero-init pages and
     /// pages without a match — take the normal compute path (zero-init pages
-    /// hit a compile-time constant via `page::preprocessed_commitment`,
-    /// ELF data pages recompute from the ELF). When `None`, every ELF data
-    /// page recomputes from scratch.
+    /// hit a compile-time constant via
+    /// `page::zero_init_preprocessed_commitment`; ELF data pages recompute
+    /// from the ELF). When `None`, every ELF data page recomputes from
+    /// scratch.
     ///
     /// The trust anchor for both `decode_commitment` and `page_commitments`
     /// is the caller's compiled binary — never accept prover-supplied bytes
@@ -420,8 +421,7 @@ impl VmAirs {
         // when shipped, else a single recompute) rather than per page. Every
         // program has at least one zero-init page (the stack is zero-
         // initialized), so this commitment is always used.
-        let zero_init_commitment =
-            page::preprocessed_commitment(&page::PageConfig::zero_init(0), proof_options);
+        let zero_init_commitment = page::zero_init_preprocessed_commitment(proof_options);
 
         let pages: Vec<_> = page_configs
             .iter()
@@ -433,9 +433,7 @@ impl VmAirs {
                     // by the memory bus constraints.
                     air
                 } else if config.init_values.is_none() {
-                    // Zero-init pages: the shared commitment computed once above
-                    // (via `page::preprocessed_commitment` so the static const-table
-                    // shortcut is used when applicable).
+                    // Zero-init pages: the shared commitment computed once above.
                     air.with_preprocessed(zero_init_commitment, page::NUM_PREPROCESSED_COLS)
                 } else {
                     // ELF data pages: INIT is program-specific, so the commitment is
@@ -446,7 +444,9 @@ impl VmAirs {
                         .iter()
                         .find(|(pb, _)| *pb == config.page_base)
                         .map(|(_, c)| *c)
-                        .unwrap_or_else(|| page::preprocessed_commitment(config, proof_options));
+                        .unwrap_or_else(|| {
+                            page::compute_precomputed_commitment(config, proof_options)
+                        });
                     air.with_preprocessed(commitment, page::NUM_PREPROCESSED_COLS)
                 }
             })
@@ -787,10 +787,10 @@ pub fn verify(vm_proof: &VmProof, elf_bytes: &[u8]) -> Result<bool, Error> {
 /// preprocessed commitments, keyed by `page_base`. For each ELF data page
 /// the verifier constructs, if a matching `(page_base, commitment)` pair is
 /// supplied, the FFT + Merkle build for that page is skipped. Pages without
-/// a match — including all zero-init pages — fall through to
-/// `page::preprocessed_commitment`, which returns a compile-time
-/// constant for zero-init pages and recomputes for ELF data pages. When
-/// `None`, every ELF data page recomputes from scratch.
+/// a match — including all zero-init pages — take the normal compute path
+/// (zero-init pages hit a compile-time constant via
+/// `page::zero_init_preprocessed_commitment`; ELF data pages recompute
+/// from the ELF). When `None`, every ELF data page recomputes from scratch.
 ///
 /// Trust model: both `decode_commitment` and `page_commitments`, when
 /// supplied, must come from the caller's compiled binary (e.g. a

--- a/prover/src/tables/page.rs
+++ b/prover/src/tables/page.rs
@@ -244,7 +244,7 @@ pub fn generate_page_trace(
 /// exist to force a human to ask "why did this change?" before the new
 /// bytes get blessed. Re-pasting on a drift failure silently launders an
 /// unintended table change into the verifier's compiled-in trust anchor.
-fn static_zero_page_commitment(blowup_factor: u8) -> Option<Commitment> {
+pub(crate) fn static_zero_page_commitment(blowup_factor: u8) -> Option<Commitment> {
     match blowup_factor {
         2 => Some([
             0xf9, 0x80, 0x0e, 0x45, 0x72, 0x5a, 0x8e, 0x8e, 0x5e, 0xd7, 0x5b, 0x60, 0xce, 0xd0,
@@ -270,11 +270,9 @@ fn static_zero_page_commitment(blowup_factor: u8) -> Option<Commitment> {
 /// The commitment covers OFFSET (0..page_size-1) and INIT (from config).
 /// Each page may have different INIT data, producing a different commitment.
 ///
-/// Exposed for the `compute_static_commitments` binary and the
-/// drift-detection tests in `static_commitments_tests`. Production callers
-/// should go through [`preprocessed_commitment`] so the static const-table
-/// shortcut is used when applicable.
-#[doc(hidden)]
+/// For zero-init pages, prefer [`zero_init_preprocessed_commitment`], which
+/// returns a compile-time constant for the standard proof options instead
+/// of rebuilding the FFT + Merkle tree.
 pub fn compute_precomputed_commitment(config: &PageConfig, options: &ProofOptions) -> Commitment {
     let page_size = DEFAULT_PAGE_SIZE;
     let num_rows = page_size;
@@ -332,31 +330,29 @@ pub fn compute_precomputed_commitment(config: &PageConfig, options: &ProofOption
     tree.root
 }
 
-/// Returns the preprocessed commitment for a PAGE table.
+/// Returns the zero-init PAGE preprocessed commitment.
 ///
-/// For zero-init pages, looks up `blowup_factor` in
-/// [`static_zero_page_commitment`] when `coset_offset == 3` (the value the
-/// static bytes were generated for); on miss — either a non-3 coset or a
-/// `blowup_factor` outside the shipped match arms — logs a warning and
-/// recomputes from scratch. ELF data pages always recompute (no warning):
-/// their INIT column is program-dependent.
-pub fn preprocessed_commitment(config: &PageConfig, options: &ProofOptions) -> Commitment {
-    if config.init_values.is_none() {
-        if options.coset_offset == 3
-            && let Some(commitment) = static_zero_page_commitment(options.blowup_factor)
-        {
-            return commitment;
-        }
-        log::warn!(
-            "zero-init page preprocessed commitment not static for \
-             (blowup={}, coset={}); falling back to recompute. Add a match \
-             arm to `static_zero_page_commitment` by running \
-             `cargo run --bin compute_static_commitments --release`.",
-            options.blowup_factor,
-            options.coset_offset,
-        );
+/// Looks up `blowup_factor` in [`static_zero_page_commitment`] when
+/// `coset_offset == 3` (the value the static bytes were generated for); on
+/// miss — either a non-3 coset or a `blowup_factor` outside the shipped
+/// match arms — logs a warning and recomputes from scratch. ELF data pages
+/// have program-dependent INIT columns and no static entry; compute their
+/// commitments with [`compute_precomputed_commitment`] directly.
+pub fn zero_init_preprocessed_commitment(options: &ProofOptions) -> Commitment {
+    if options.coset_offset == 3
+        && let Some(commitment) = static_zero_page_commitment(options.blowup_factor)
+    {
+        return commitment;
     }
-    compute_precomputed_commitment(config, options)
+    log::warn!(
+        "zero-init page preprocessed commitment not static for \
+         (blowup={}, coset={}); falling back to recompute. Add a match \
+         arm to `static_zero_page_commitment` by running \
+         `cargo run --bin compute_static_commitments --release`.",
+        options.blowup_factor,
+        options.coset_offset,
+    );
+    compute_precomputed_commitment(&PageConfig::zero_init(0), options)
 }
 
 // =========================================================================

--- a/prover/src/tests/static_commitments_tests.rs
+++ b/prover/src/tests/static_commitments_tests.rs
@@ -1,18 +1,21 @@
 //! Drift-detection and lookup-dispatch tests for the static preprocessed-table
-//! commitments shipped in `bitwise` and `keccak_rc`.
+//! commitments shipped in `bitwise`, `keccak_rc`, and `page` (the shared
+//! zero-init page commitment).
 //!
 //! - The drift tests recompute the commitment for every blowup in
 //!   `STATIC_BLOWUP_FACTORS` (the list shared with the generator binary) and
-//!   compare against the value the table-module's `preprocessed_commitment`
-//!   wrapper returns. This catches AIR or FFT-pipeline drift AND confirms the
-//!   wrapper dispatches through `static_commitment` for the static blowups.
-//! - The non-static-blowup fallback test picks a blowup not in
-//!   `STATIC_BLOWUP_FACTORS` and asserts the wrapper still returns the correct
+//!   compare against the value the table-module's wrapper returns
+//!   (`preprocessed_commitment` for `bitwise`/`keccak_rc`,
+//!   `zero_init_preprocessed_commitment` for `page`). This catches AIR or
+//!   FFT-pipeline drift; the page test additionally pins the static bytes
+//!   against the recompute directly.
+//! - The non-static-blowup fallback tests pick a blowup not in
+//!   `STATIC_BLOWUP_FACTORS` and assert the wrapper still returns the correct
 //!   value via recompute.
 //! - The coset-mismatch tests use `coset_offset != 3` and assert the wrapper
 //!   takes the recompute path (rather than silently returning the coset-3
 //!   static bytes); they're the regression test for the
-//!   `options.coset_offset == 3` gate in `preprocessed_commitment`.
+//!   `options.coset_offset == 3` gate in the wrappers.
 //!
 //! If a drift test fails, regenerate the constants via
 //! `cargo run --bin compute_static_commitments --release`.
@@ -76,29 +79,35 @@ fn keccak_rc_static_matches_recompute_for_all_blowups() {
 /// Drift / dispatch test for the zero-init PAGE static commitments. For every
 /// blowup in `STATIC_BLOWUP_FACTORS`, builds a synthetic zero-init page at
 /// `DEFAULT_PAGE_SIZE` (page_base = 0 — the value doesn't affect the
-/// commitment since OFFSET is page-relative and INIT is uniformly zero) and
-/// asserts that `zero_init_preprocessed_commitment` returns the same value as a
-/// direct `compute_precomputed_commitment`. Catches AIR / FFT-pipeline drift
-/// AND confirms the wrapper dispatches through `static_zero_page_commitment`
-/// for the static blowups. The explicit `is_some` assert inside the loop
-/// guarantees the static arm exists, so equality can't pass trivially via
-/// the fallback recompute path.
+/// commitment since OFFSET is page-relative and INIT is uniformly zero),
+/// recomputes the commitment from scratch, and checks two things:
+///
+/// - the static bytes equal the recompute, read directly from
+///   `static_zero_page_commitment` (panicking if the match arm is missing) —
+///   so byte drift can't be masked by a broken dispatch gate;
+/// - `zero_init_preprocessed_commitment` equals the recompute — the wrapper
+///   returns a correct value whichever path it takes. (The coset-3 gate
+///   itself is covered by the ignored
+///   `page_non_three_coset_recomputes_and_differs_from_static` test.)
 #[test]
 fn zero_page_static_matches_recompute_for_all_blowups() {
     let zero_page_config = page::PageConfig::zero_init(0);
     for &blowup in STATIC_BLOWUP_FACTORS {
         let options = options_for(blowup);
-        assert!(
-            page::static_zero_page_commitment(blowup).is_some(),
-            "no static zero-page match arm shipped for blowup={blowup}",
+        let recomputed = page::compute_precomputed_commitment(&zero_page_config, &options);
+        let Some(static_bytes) = page::static_zero_page_commitment(blowup) else {
+            panic!("no static zero-page match arm shipped for blowup={blowup}");
+        };
+        assert_eq!(
+            static_bytes, recomputed,
+            "static zero-init page commitment drifted for blowup={blowup}; \
+             regenerate constants via \
+             `cargo run --bin compute_static_commitments --release`",
         );
         let from_wrapper = page::zero_init_preprocessed_commitment(&options);
-        let recomputed = page::compute_precomputed_commitment(&zero_page_config, &options);
         assert_eq!(
             from_wrapper, recomputed,
-            "zero-init page commitment drifted (or wrapper dispatch broke) for \
-             blowup={blowup}; regenerate constants via \
-             `cargo run --bin compute_static_commitments --release`",
+            "zero_init_preprocessed_commitment returned a wrong value for blowup={blowup}",
         );
     }
 }

--- a/prover/src/tests/static_commitments_tests.rs
+++ b/prover/src/tests/static_commitments_tests.rs
@@ -77,16 +77,22 @@ fn keccak_rc_static_matches_recompute_for_all_blowups() {
 /// blowup in `STATIC_BLOWUP_FACTORS`, builds a synthetic zero-init page at
 /// `DEFAULT_PAGE_SIZE` (page_base = 0 — the value doesn't affect the
 /// commitment since OFFSET is page-relative and INIT is uniformly zero) and
-/// asserts that `preprocessed_commitment` returns the same value as a
+/// asserts that `zero_init_preprocessed_commitment` returns the same value as a
 /// direct `compute_precomputed_commitment`. Catches AIR / FFT-pipeline drift
 /// AND confirms the wrapper dispatches through `static_zero_page_commitment`
-/// for the static blowups.
+/// for the static blowups. The explicit `is_some` assert inside the loop
+/// guarantees the static arm exists, so equality can't pass trivially via
+/// the fallback recompute path.
 #[test]
 fn zero_page_static_matches_recompute_for_all_blowups() {
     let zero_page_config = page::PageConfig::zero_init(0);
     for &blowup in STATIC_BLOWUP_FACTORS {
         let options = options_for(blowup);
-        let from_wrapper = page::preprocessed_commitment(&zero_page_config, &options);
+        assert!(
+            page::static_zero_page_commitment(blowup).is_some(),
+            "no static zero-page match arm shipped for blowup={blowup}",
+        );
+        let from_wrapper = page::zero_init_preprocessed_commitment(&options);
         let recomputed = page::compute_precomputed_commitment(&zero_page_config, &options);
         assert_eq!(
             from_wrapper, recomputed,
@@ -111,7 +117,7 @@ fn page_non_static_blowup_recomputes_via_fallback() {
     );
     let zero_page_config = page::PageConfig::zero_init(0);
     let options = options_for(NON_STATIC_BLOWUP);
-    let from_wrapper = page::preprocessed_commitment(&zero_page_config, &options);
+    let from_wrapper = page::zero_init_preprocessed_commitment(&options);
     let recomputed = page::compute_precomputed_commitment(&zero_page_config, &options);
     assert_eq!(
         from_wrapper, recomputed,
@@ -120,8 +126,8 @@ fn page_non_static_blowup_recomputes_via_fallback() {
 }
 
 /// Regression test for the `options.coset_offset == 3` gate in
-/// `page::preprocessed_commitment`. With a non-3 coset offset, the wrapper
-/// must NOT return a static value — it must recompute (matching direct
+/// `page::zero_init_preprocessed_commitment`. With a non-3 coset offset, the
+/// wrapper must NOT return a static value — it must recompute (matching direct
 /// compute) and must NOT equal the coset-3 static commitment. Ignored by
 /// default: each blowup at DEFAULT_PAGE_SIZE builds a 2^19-row × 2-col page
 /// LDE, multiple seconds per blowup. Run explicitly when validating the
@@ -134,9 +140,9 @@ fn page_non_three_coset_recomputes_and_differs_from_static() {
         let opts_coset3 = options_with_coset(blowup, STANDARD_COSET);
         let opts_coset7 = options_with_coset(blowup, NON_STANDARD_COSET);
 
-        let from_wrapper_7 = page::preprocessed_commitment(&zero_page_config, &opts_coset7);
+        let from_wrapper_7 = page::zero_init_preprocessed_commitment(&opts_coset7);
         let recomputed_7 = page::compute_precomputed_commitment(&zero_page_config, &opts_coset7);
-        let from_wrapper_3 = page::preprocessed_commitment(&zero_page_config, &opts_coset3);
+        let from_wrapper_3 = page::zero_init_preprocessed_commitment(&opts_coset3);
 
         assert_eq!(
             from_wrapper_7, recomputed_7,


### PR DESCRIPTION
Review follow-ups for #645 (targets `page-preprocessed-commit`, merges into that PR).

## Changes

**1. Fix `compute_static_commitments` zero_page output (bug).** The generator printed `(DEFAULT_PAGE_SIZE, {blowup}) => Some(...)` — a tuple pattern that doesn't compile when pasted into `static_zero_page_commitment`'s `match blowup_factor`, plus a stale `page_size = DEFAULT_PAGE_SIZE` comment. Both leftovers from before #653 removed per-page sizes. Now prints `{blowup} => Some(...)` like the bitwise/keccak arms.

**2. Split the dual-duty page wrapper.** `page::preprocessed_commitment(config, options)` branched on `config.init_values.is_none()` — a question both call sites already knew the answer to. Replaced with:
- `zero_init_preprocessed_commitment(options)` — config-free; static const at (blowup ∈ {2,4,8}, coset 3), warn + recompute otherwise. Mirrors the `bitwise`/`keccak_rc` wrapper shape exactly.
- ELF data pages call `compute_precomputed_commitment(config, options)` directly; its `#[doc(hidden)]` and "go through the wrapper" doc note are removed since direct calls are now the production path.

Behavior-identical: the zero-init path is the old `is_none` branch verbatim, and the ELF path previously fell straight through to `compute_precomputed_commitment` anyway. Each function now has one observable behavior — the warn-on-static-miss can no longer silently depend on which config shape was passed.

**3. Make the drift test's dispatch claim true.** `zero_page_static_matches_recompute_for_all_blowups` claimed to confirm static dispatch, but a deleted match arm would fall back to recompute and pass trivially. It now asserts `static_zero_page_commitment(blowup).is_some()` per blowup (exposed `pub(crate)` for this).

## Checks

- `cargo fmt --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --release -p lambda-vm-prover static_commitments` — 5 passed
- `cargo test --release -p lambda-vm-prover page` — 20 passed
- `cargo test --release -p lambda-vm-prover page_non_three_coset_recomputes_and_differs_from_static -- --ignored` — passed (validates the coset gate + new fallback; the blowup-16 ignored test was skipped as too heavy)