### PR TITLE
Fix ethrex fixture reproducibility

### DIFF
--- a/.github/workflows/bench-vs-nightly.yml
+++ b/.github/workflows/bench-vs-nightly.yml
@@ -47,19 +47,12 @@ jobs:
             --report-dir bench_vs_artifacts \
             --no-color
 
-      - name: Restore cached ethrex.elf (TEMPORARY — until /opt/lambda-vm-sysroot is provisioned on the bench runner)
-        continue-on-error: true
-        run: |
-          mkdir -p executor/program_artifacts/rust
-          cp /home/app/cached_artifacts/ethrex.elf executor/program_artifacts/rust/ethrex.elf
-          ls -la executor/program_artifacts/rust/ethrex.elf
-          sha256sum executor/program_artifacts/rust/ethrex.elf
-
       - name: Run ethrex block benchmarks
         continue-on-error: true
         run: |
           bash ./bench_vs/run_ethrex.sh \
             --report-dir bench_vs_artifacts \
+            --rebuild-elf \
             --no-color
 
       - name: Upload nightly benchmark artifact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +442,21 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "2.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
  "serde",
 ]
 
@@ -1083,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "ethrex-blockchain"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bytes",
  "ethrex-common",
@@ -1104,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "ethrex-common"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1135,8 +1162,10 @@ dependencies = [
 [[package]]
 name = "ethrex-crypto"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
+ "c-kzg",
+ "kzg-rs",
  "thiserror 2.0.17",
  "tiny-keccak",
 ]
@@ -1144,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "ethrex-l2-common"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1168,7 +1197,7 @@ dependencies = [
 [[package]]
 name = "ethrex-levm"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1200,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "ethrex-metrics"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "ethrex-common",
  "serde",
@@ -1212,7 +1241,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rlp"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1226,7 +1255,7 @@ dependencies = [
 [[package]]
 name = "ethrex-storage"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1249,17 +1278,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethrex-threadpool"
-version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
-dependencies = [
- "crossbeam",
-]
-
-[[package]]
 name = "ethrex-trie"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1268,7 +1289,6 @@ dependencies = [
  "ethereum-types",
  "ethrex-crypto",
  "ethrex-rlp",
- "ethrex-threadpool",
  "hex",
  "lazy_static",
  "rkyv",
@@ -1283,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "ethrex-vm"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bincode",
  "bytes",
@@ -1296,6 +1316,7 @@ dependencies = [
  "ethrex-rlp",
  "ethrex-trie",
  "lazy_static",
+ "rayon",
  "rkyv",
  "serde",
  "thiserror 2.0.17",
@@ -1497,6 +1518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,7 +1537,7 @@ dependencies = [
 [[package]]
 name = "guest_program"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?branch=crypto-default-features#3a4527330ae522f9a84b4bbb0e8d2ed8c8c6ebe9"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bincode",
  "bytes",
@@ -1628,7 +1655,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2246,6 +2273,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
 ]
 
 [[package]]
@@ -3433,6 +3470,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "tikv-jemalloc-ctl"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3878,7 +3924,7 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core",
  "windows-targets",
 ]
 
@@ -3888,23 +3934,10 @@ version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
  "windows-targets",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
 ]
 
 [[package]]
@@ -3919,32 +3952,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3964,24 +3975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/bench_vs/run_ethrex.sh
+++ b/bench_vs/run_ethrex.sh
@@ -109,7 +109,7 @@ cargo build --release -p cli --manifest-path "$ROOT_DIR/Cargo.toml" 2>&1 | tail 
 
 if $REBUILD_ELF; then
     echo -e "${GREEN}[Lambda VM] Rebuilding ethrex guest ELF...${NC}"
-    make -B -C "$ROOT_DIR" executor/program_artifacts/rust/ethrex.elf 2>&1 | tail -5
+    make -B -C "$ROOT_DIR" executor/program_artifacts/rust/ethrex.elf
 elif [ -f "$ETHREX_ELF" ]; then
     echo -e "${YELLOW}[Lambda VM] Using pre-existing ethrex.elf at $ETHREX_ELF${NC}"
 else

--- a/bench_vs/run_ethrex.sh
+++ b/bench_vs/run_ethrex.sh
@@ -6,7 +6,7 @@
 # Add a block by appending a "label|input_basename" entry to BLOCKS — the input
 # file must live in executor/tests/.
 #
-# Usage: ./bench_vs/run_ethrex.sh [--report-dir DIR] [--no-color]
+# Usage: ./bench_vs/run_ethrex.sh [--report-dir DIR] [--rebuild-elf] [--no-color]
 #
 # Prerequisites:
 #   - Lambda VM CLI build dependencies available
@@ -20,6 +20,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMP_DIR="/tmp/bench_ethrex"
 REPORT_DIR=""
 NO_COLOR=false
+REBUILD_ELF=false
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -45,8 +46,12 @@ while [[ $# -gt 0 ]]; do
             NO_COLOR=true
             shift
             ;;
+        --rebuild-elf)
+            REBUILD_ELF=true
+            shift
+            ;;
         -h|--help)
-            echo "Usage: $0 [--report-dir DIR] [--no-color]"
+            echo "Usage: $0 [--report-dir DIR] [--rebuild-elf] [--no-color]"
             exit 0
             ;;
         *)
@@ -102,7 +107,10 @@ echo ""
 echo -e "${GREEN}[Lambda VM] Building CLI...${NC}"
 cargo build --release -p cli --manifest-path "$ROOT_DIR/Cargo.toml" 2>&1 | tail -5
 
-if [ -f "$ETHREX_ELF" ]; then
+if $REBUILD_ELF; then
+    echo -e "${GREEN}[Lambda VM] Rebuilding ethrex guest ELF...${NC}"
+    make -B -C "$ROOT_DIR" executor/program_artifacts/rust/ethrex.elf 2>&1 | tail -5
+elif [ -f "$ETHREX_ELF" ]; then
     echo -e "${YELLOW}[Lambda VM] Using pre-existing ethrex.elf at $ETHREX_ELF${NC}"
 else
     echo -e "${GREEN}[Lambda VM] Building ethrex guest ELF...${NC}"

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
-guest-program = { git = "https://github.com/lambdaclass/ethrex.git", package="guest_program", default-features = false, branch = "crypto-default-features" }
+guest-program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "a9de3e8b405dbf406cac31b930fd1ffdc216a429", package="guest_program", default-features = false, features = ["c-kzg"] }

--- a/executor/programs/rust/ethrex/Cargo.lock
+++ b/executor/programs/rust/ethrex/Cargo.lock
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "ethrex-blockchain"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bytes",
  "ethrex-common",
@@ -960,7 +960,7 @@ dependencies = [
 [[package]]
 name = "ethrex-common"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1002,7 +1002,7 @@ dependencies = [
 [[package]]
 name = "ethrex-l2-common"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "ethrex-levm"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1058,7 +1058,7 @@ dependencies = [
 [[package]]
 name = "ethrex-metrics"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "ethrex-common",
  "serde",
@@ -1070,7 +1070,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rlp"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1084,7 +1084,7 @@ dependencies = [
 [[package]]
 name = "ethrex-storage"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1109,7 +1109,7 @@ dependencies = [
 [[package]]
 name = "ethrex-trie"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1132,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "ethrex-vm"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bincode",
  "bytes",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "guest_program"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=a9de3e8b405dbf406cac31b930fd1ffdc216a429#a9de3e8b405dbf406cac31b930fd1ffdc216a429"
 dependencies = [
  "bincode",
  "bytes",

--- a/executor/programs/rust/ethrex/Cargo.toml
+++ b/executor/programs/rust/ethrex/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 lambda-vm-syscalls = { path = "../../../../syscalls" }
-guest-program = { git = "https://github.com/lambdaclass/ethrex.git", package="guest_program", default-features = false, features=["c-kzg"] }
+guest-program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "a9de3e8b405dbf406cac31b930fd1ffdc216a429", package="guest_program", default-features = false, features=["c-kzg"] }
 rkyv = { version = "0.8.10", features = ["std", "unaligned"] }
 c-kzg = { version = "2.1.1", features = ["eip-7594"] }
 
@@ -20,4 +20,3 @@ c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "c-kzg/v2.1.1-riscz
 # guest target; native builds keep the vendored asm. See patches/ethrex-crypto/.
 [patch."https://github.com/lambdaclass/ethrex.git"]
 ethrex-crypto = { path = "patches/ethrex-crypto" }
-

--- a/executor/tests/README.md
+++ b/executor/tests/README.md
@@ -24,8 +24,6 @@ ethrex_simple_tx.bin
   contents: stateless ethrex block with one plain ETH transfer transaction
 ```
 
-The original generation command for these blobs is not encoded in this
-repository. Do not update the ethrex revision or replace these fixtures without
-also recording the command/tool, chain config or genesis, transaction contents,
-and resulting fixture hashes here. Prefer adding an in-repo generator before
-introducing additional ethrex fixtures.
+The original generation command for these blobs is not recorded in this
+repository. A follow-up should add an in-repo crate for generating custom ethrex
+block fixtures.

--- a/executor/tests/README.md
+++ b/executor/tests/README.md
@@ -1,0 +1,31 @@
+# Executor Test Fixtures
+
+## Ethrex private inputs
+
+The `ethrex_*.bin` files are rkyv-serialized `guest_program::input::ProgramInput`
+values consumed by `executor/programs/rust/ethrex`.
+
+The ethrex guest and the native test reference are pinned to:
+
+```text
+https://github.com/lambdaclass/ethrex.git
+a9de3e8b405dbf406cac31b930fd1ffdc216a429
+```
+
+Known fixtures:
+
+```text
+ethrex_empty_block.bin
+  sha256: 06626a051c07844570feae3cc6dc3831e0143ca81dbb1a56d4bf4e195c0b9411
+  contents: stateless ethrex empty block ProgramInput
+
+ethrex_simple_tx.bin
+  sha256: 82998bea989ed4aa98b4f4b1476a7d0a4828a4f446cd7edff670418ba330e94b
+  contents: stateless ethrex block with one plain ETH transfer transaction
+```
+
+The original generation command for these blobs is not encoded in this
+repository. Do not update the ethrex revision or replace these fixtures without
+also recording the command/tool, chain config or genesis, transaction contents,
+and resulting fixture hashes here. Prefer adding an in-repo generator before
+introducing additional ethrex fixtures.

--- a/executor/tests/rust.rs
+++ b/executor/tests/rust.rs
@@ -293,10 +293,9 @@ fn test_ethrex() {
 }
 
 /// Executes a stateless ethrex block containing a single (plain ETH transfer)
-/// transaction. Execution only — no proving — against main's software-keccak
-/// `ethrex.elf`. The fixture is a serialized `ProgramInput` for the ethrex
-/// commit pinned in this crate's Cargo.lock. The VM's public output is checked
-/// against a native run of `execution_program`, mirroring `test_ethrex`.
+/// transaction. Execution only — no proving — against the ethrex guest ELF
+/// built from the same pinned ethrex revision as the native reference. The
+/// fixture is a serialized `ProgramInput`; see `tests/README.md` for provenance.
 #[test]
 fn test_ethrex_simple_tx() {
     use guest_program::{execution::execution_program, input::ProgramInput};


### PR DESCRIPTION
## Summary
- pin the ethrex guest and executor native reference to the same upstream revision
- document ethrex private-input fixture hashes and provenance expectations
- force nightly ethrex benchmarks to rebuild the guest ELF instead of using the unmanaged runner cache

## Verification
- cargo metadata --manifest-path executor/programs/rust/ethrex/Cargo.toml --locked --no-deps
- cargo metadata --locked --no-deps
- bash -n bench_vs/run_ethrex.sh
- cargo test -p executor --test rust test_ethrex_simple_tx --no-run