### PR TITLE
Robustness + review fixes for nightly bench sysroot

### DIFF
--- a/.github/workflows/bench-vs-nightly.yml
+++ b/.github/workflows/bench-vs-nightly.yml
@@ -59,7 +59,8 @@ jobs:
           # and was never fully provisioned (missing libc headers → c-kzg failed to find
           # stdlib.h). `make` (via SYSROOT_DIR ?=) picks this up and passes it as clang's
           # --sysroot, so the guest ELF rebuild self-provisions with no sudo, and the
-          # extracted sysroot is cached in $HOME across nightly runs.
+          # extracted sysroot persists in $HOME across runs on the persistent
+          # self-hosted runner (no actions/cache step is involved).
           export SYSROOT_DIR="$HOME/.lambda-vm-sysroot"
           bash ./bench_vs/run_ethrex.sh \
             --report-dir bench_vs_artifacts \
@@ -85,5 +86,5 @@ jobs:
       - name: Fail if ethrex benchmark failed
         if: always() && steps.ethrex_bench.outcome == 'failure'
         run: |
-          echo "::error::ethrex block benchmark step failed — see the 'Run ethrex block benchmarks' step logs"
+          echo "::error::ethrex block benchmark step failed - see the 'Run ethrex block benchmarks' step logs"
           exit 1

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,11 @@ RV64_TARGET_SPEC=$(CURDIR)/executor/programs/riscv64im-lambda-vm-elf.json
 .PHONY: test prepare-test-data prepare-sysroot
 
 prepare-test-data:
-	@if [ ! -f "$(ETHREX_FILE)" ]; then \
+	@set -e; \
+	if [ ! -f "$(ETHREX_FILE)" ]; then \
 		echo "Downloading ethrex_hoodi.bin..."; \
-		curl -L "$(ETHREX_URL)" -o "$(ETHREX_FILE)"; \
+		curl -fL --proto '=https' "$(ETHREX_URL)" -o "$(ETHREX_FILE)" \
+			|| { rm -f "$(ETHREX_FILE)"; exit 1; }; \
 	else \
 		echo "ethrex_hoodi.bin already exists"; \
 	fi
@@ -83,31 +85,32 @@ prepare-test-data:
 # especially via the sudo fallback. This is typo/misconfig prevention, NOT a security
 # boundary — a caller that controls SYSROOT_DIR can still point it at any */lambda-vm-sysroot.
 prepare-sysroot:
-	@if [ -f "$(SYSROOT_DIR)/include/stdlib.h" ] && [ -d "$(SYSROOT_DIR)/lib" ]; then \
+	@set -e; \
+	if [ -f "$(SYSROOT_DIR)/include/stdlib.h" ] && [ -d "$(SYSROOT_DIR)/lib" ]; then \
 		echo "Sysroot already exists at $(SYSROOT_DIR)"; \
 	else \
 		case "$$(basename "$(SYSROOT_DIR)")" in \
 			lambda-vm-sysroot|.lambda-vm-sysroot) : ;; \
-			*) echo "prepare-sysroot: refusing to (sudo) rm -rf SYSROOT_DIR=$(SYSROOT_DIR) — expected a path ending in lambda-vm-sysroot or .lambda-vm-sysroot"; exit 1 ;; \
+			*) echo "prepare-sysroot: refusing to (sudo) rm -rf SYSROOT_DIR=$(SYSROOT_DIR) - expected a path ending in lambda-vm-sysroot or .lambda-vm-sysroot"; exit 1 ;; \
 		esac; \
 		echo "Provisioning sysroot at $(SYSROOT_DIR) (downloading lambda-vm-sysroot-rv64im.tar.gz)..."; \
-		curl -fL "$(SYSROOT_URL)" -o "$(SYSROOT_TARBALL)"; \
+		rm -f "$(SYSROOT_TARBALL)"; \
+		curl -fL --proto '=https' "$(SYSROOT_URL)" -o "$(SYSROOT_TARBALL)" \
+			|| { rm -f "$(SYSROOT_TARBALL)"; exit 1; }; \
 		echo "Extracting sysroot to $(SYSROOT_DIR)..."; \
 		if mkdir -p "$(SYSROOT_DIR)" 2>/dev/null && [ -w "$(SYSROOT_DIR)" ]; then \
 			rm -rf "$(SYSROOT_DIR)" && mkdir -p "$(SYSROOT_DIR)" \
-				&& tar -xzf "$(SYSROOT_TARBALL)" -C "$(SYSROOT_DIR)" --strip-components=1 \
+				&& tar -xzf "$(SYSROOT_TARBALL)" -C "$(SYSROOT_DIR)" --strip-components=1 --no-same-owner \
 				|| { rm -rf "$(SYSROOT_DIR)" "$(SYSROOT_TARBALL)"; exit 1; }; \
 		else \
 			echo "$(SYSROOT_DIR) is not writable; using sudo."; \
 			echo "Tip: re-run with SYSROOT_DIR=\$$HOME/.lambda-vm-sysroot to avoid sudo."; \
 			sudo rm -rf "$(SYSROOT_DIR)" && sudo mkdir -p "$(SYSROOT_DIR)" \
-				&& sudo tar -xzf "$(SYSROOT_TARBALL)" -C "$(SYSROOT_DIR)" --strip-components=1 \
+				&& sudo tar -xzf "$(SYSROOT_TARBALL)" -C "$(SYSROOT_DIR)" --strip-components=1 --no-same-owner \
 				|| { sudo rm -rf "$(SYSROOT_DIR)"; rm -f "$(SYSROOT_TARBALL)"; exit 1; }; \
 		fi; \
-		rm "$(SYSROOT_TARBALL)"; \
+		rm -f "$(SYSROOT_TARBALL)"; \
 	fi
-# Note: the tarball rm above only runs on success — each error handler
-# cleans up the tarball itself before `exit 1`.
 
 compile-programs-asm:
 	@mkdir -p $(ASM_ARTIFACTS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ ETHREX_URL := https://lambda.alignedlayer.com/ethrex_hoodi.bin
 # Override with: make ... SYSROOT_DIR=$HOME/.lambda-vm-sysroot
 # to install the sysroot in a user-writable location and avoid sudo.
 SYSROOT_DIR ?= /opt/lambda-vm-sysroot
+# Fixed, global path: prepare-sysroot assumes a single writer at a time. The recipe
+# `rm -f`s this before downloading, so a stale tarball can't be extracted — but two
+# concurrent `make prepare-sysroot` on one host would race on it. The current CI runs
+# no concurrent jobs sharing a SYSROOT_DIR; revisit (e.g. mktemp/flock) if that changes.
 SYSROOT_TARBALL := /tmp/lambda-vm-sysroot-rv64im.tar.gz
 SYSROOT_URL := https://lambda.alignedlayer.com/lambda-vm-sysroot-rv64im.tar.gz
 # CFLAGS for ckzg / ethrex guest programs: overrides the hardcoded `/opt/lambda-vm-sysroot`

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Some of the tests require linking with C libraries.
 The easiest way is to let `make` do it:
 
 ```sh
+SYSROOT_DIR=$HOME/.lambda-vm-sysroot make prepare-sysroot  # recommended: user-writable, no sudo
 make prepare-sysroot                                       # installs to /opt (uses sudo)
-SYSROOT_DIR=$HOME/.lambda-vm-sysroot make prepare-sysroot  # user-writable, no sudo
 ```
 
 Or do it manually:


### PR DESCRIPTION
Follow-up review fixes layered on top of #675 (targets `fix/nightly-bench-sysroot`, not `main`). Found via a multi-agent review of #675; the headline bug was reproduced against the real recipe.

## Fixed

### 1. Failed download was not fatal — could silently extract a stale sysroot (Medium, reproduced)
`prepare-sysroot`'s recipe had no `set -e`, and the `curl -fL … -o "$(SYSROOT_TARBALL)"` line ended with `;` instead of being chained into the extraction. So when `curl` failed, control fell through to the `tar` step.

- In the common case `tar` chokes on the missing/partial tarball and the `|| { … exit 1; }` handler aborts — but with a misleading "Extracting…" message.
- **The bad case (reproduced):** `SYSROOT_TARBALL` is a *fixed* `/tmp` path. If a tarball is already there (left by an interrupted prior run, since the success-path `rm` never executed), a failed `curl` falls through, `tar` extracts the **stale** tarball, and **`make` exits 0**. The next run then sees `include/stdlib.h` and treats the sysroot as complete.

Repro before the fix (connection-failing URL + pre-existing tarball): `make` returned **0** and provisioned a stale sysroot. After the fix: `make` aborts (exit 2), no sysroot is created, and the stale tarball is removed.

**Fix:** add `set -e`, `rm -f "$(SYSROOT_TARBALL)"` before downloading (kills the stale-tarball case and the predictable-path reuse), and make the download explicitly fatal (`curl … || { rm -f …; exit 1; }`). Same fix applied to `prepare-test-data`, which had the identical download-fall-through pattern.

### 2. Download/extraction hardening (defense-in-depth)
- `curl --proto '=https'` — `-L` follows redirects; this prevents a redirect from downgrading to plain `http`.
- `tar … --no-same-owner` — relevant in the `sudo` (root) extraction branch so archive-specified ownership isn't restored.

> Note: this does **not** add tarball checksum verification. That's the larger pre-existing supply-chain gap (an unauthenticated tarball is used as the compiler `--sysroot` and linked into guest ELFs), but pinning a SHA-256 needs a maintainer-blessed known-good hash and would break CI on legitimate tarball updates, so it's left as a tracked follow-up.

### 3. Comment / doc fixes
- **`bench-vs-nightly.yml`:** the comment claimed the sysroot "is cached in `$HOME` across nightly runs," but there is no `actions/cache` step — it persists only because the self-hosted runner's filesystem is persistent. Reworded so it doesn't imply a cache key/restore mechanism.
- Removed the now-stale `# Note: the tarball rm above only runs on success…` comment (no longer accurate after adding the pre-download `rm -f` and switching the final `rm` to `rm -f`).
- `rm` → `rm -f` for the success-path tarball cleanup (consistent with the error handlers; won't error if already gone).
- ASCII `-` instead of an em-dash in the `::error::` output (greppability / repo consistency).
- **README:** lead with the recommended user-writable (no-sudo) `SYSROOT_DIR=$HOME/...` invocation instead of the `/opt` + sudo one.

## Verified
- **Failure aborts:** failed `curl` + pre-existing tarball → `make` exits non-zero, no sysroot created, stale tarball removed (was exit 0 before).
- **Happy path:** real HTTPS provision against the actual `SYSROOT_URL` → exit 0, `include/stdlib.h` + `lib/` present, tarball cleaned up.
- **Idempotent:** re-run on a complete sysroot prints "already exists" and performs no download.

## Considered but intentionally not changed
- **Concurrency / locking** around `rm -rf` + extract: safe within a single `make -j` (Make builds the shared `prepare-sysroot` prereq once); only at risk if two *separate* `make` processes share one `SYSROOT_DIR`, which the current CI does not do. Not worth the complexity.
- **Stronger partial-sysroot guard** (e.g. probing a specific `lib/*.a`): skipped to avoid hard-coding a library filename that could be wrong and cause endless re-provisioning. The `include/stdlib.h` check already fixes the reported failure.
- **`infra/provision.sh` provisions a complete `/opt` sysroot**, which appears to contradict the #675 root-cause note ("never fully provisioned"). Left for the author to reconcile — changing the provisioner needs knowledge of how the bench runner is actually set up.