### PR TITLE
fix(ethrex): reconcile KZG docs, clarify pin, wire empty fixture, mar…

### DIFF
--- a/bench_vs/README_ethrex.md
+++ b/bench_vs/README_ethrex.md
@@ -10,8 +10,8 @@ different block inputs:
 | 1 transaction (plain ETH transfer) | `executor/tests/ethrex_simple_tx.bin` | ~4.4M |
 
 Each input is a serialized `ProgramInput` (the block + its execution witness,
-rkyv-encoded) for the ethrex commit pinned in
-`executor/programs/rust/ethrex/Cargo.lock`. The guest reads it via
+rkyv-encoded) for the ethrex commit pinned (as `rev`) in
+`executor/programs/rust/ethrex/Cargo.toml`. The guest reads it via
 `get_private_input()` and runs ethrex's `execution_program`.
 
 The timing window is **single-shot end-to-end prove** (ELF load + execution +
@@ -90,7 +90,7 @@ What the build needs:
   `rust-src` (the Makefile pins it; builds the guest via `-Z build-std`).
 - **clang + lld** for ethrex's C dependencies.
 - **Network**, the first time: cargo fetches `guest_program` from
-  `github.com/lambdaclass/ethrex.git` (commit pinned in the guest `Cargo.lock`).
+  `github.com/lambdaclass/ethrex.git` (commit pinned as `rev` in the guest `Cargo.toml`).
 - **`SYSROOT_DIR` must match** between `prepare-sysroot` and the build.
 
 The guest source is `executor/programs/rust/ethrex/` (an 11-line `main.rs` that

--- a/executor/programs/rust/ethrex/Cargo.toml
+++ b/executor/programs/rust/ethrex/Cargo.toml
@@ -7,10 +7,13 @@ edition = "2024"
 
 [dependencies]
 lambda-vm-syscalls = { path = "../../../../syscalls" }
-# Pinned to the open LambdaVM-backend PR branch (feat/lambdavm-prover-backend)
-# until it merges to ethrex `main`; then re-pin to the merge commit. The
-# `lambdavm` feature provides `crypto::lambdavm::LambdaVmCrypto` (keccak via our
-# precompile syscall, the rest via pure-Rust crates incl. kzg-rs).
+# Pinned by immutable `rev` to a commit on the open LambdaVM-backend PR branch
+# (feat/lambdavm-prover-backend) of ethrex; re-pin to the merge commit once it
+# lands on ethrex `main`. The `lambdavm` feature provides
+# `crypto::lambdavm::LambdaVmCrypto` (keccak via our precompile syscall; ECDSA
+# and BN254 via pure-Rust crates). KZG is NOT linked under this feature (no
+# kzg-rs/c-kzg in the guest Cargo.lock), so the point-evaluation precompile
+# (0x0a) is unsupported — see src/main.rs.
 ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "156cb8d6a3974f411d71622eecd1b249ee37ff1c", package = "ethrex-guest-program", default-features = false, features = ["lambdavm"] }
 # Exact pin: must match the fixture writer (tooling/ethrex-fixtures) and the
 # executor test reader so the rkyv ProgramInput layout stays consistent.

--- a/executor/programs/rust/ethrex/src/main.rs
+++ b/executor/programs/rust/ethrex/src/main.rs
@@ -12,7 +12,10 @@ pub fn main() {
     // `ethrex_crypto::keccak::keccak_hash` fn, which still runs software keccak on
     // riscv64, so the precompile only covers trait-routed keccak today. ECDSA and
     // BN254 use pure-Rust crates; KZG is unimplemented under the `lambdavm`
-    // feature, so blob (EIP-4844) transactions are not supported.
+    // feature: blob (EIP-4844) transactions still execute (stateless block
+    // execution does not verify blob proofs), but a contract call to the
+    // point-evaluation precompile (0x0a) fails closed (reverts) instead of
+    // returning a result.
     let crypto = Arc::new(LambdaVmCrypto);
     let output = execution_program(input, crypto).unwrap();
     lambda_vm_syscalls::syscalls::commit(&output.encode());

--- a/executor/tests/rust.rs
+++ b/executor/tests/rust.rs
@@ -321,6 +321,27 @@ fn test_ethrex_simple_tx() {
     );
 }
 
+/// Executes a stateless ethrex block with NO transactions (empty block).
+/// Execution only — no proving. Pins the committed `ethrex_empty_block.bin`
+/// fixture into the default suite so its rkyv `ProgramInput` layout (the 0-tx
+/// edge case) is exercised and stays consistent with the guest across ethrex
+/// rev bumps. Mirrors `test_ethrex_simple_tx`; see `tests/README.md`.
+#[test]
+fn test_ethrex_empty_block() {
+    use ethrex_guest_program::crypto::NativeCrypto;
+    use ethrex_guest_program::l1::{ProgramInput, execution_program};
+    use rkyv::rancor::Error;
+    use std::sync::Arc;
+    let inputs = std::fs::read("tests/ethrex_empty_block.bin").unwrap();
+    let input = rkyv::from_bytes::<ProgramInput, Error>(&inputs).unwrap();
+    let output = execution_program(input, Arc::new(NativeCrypto)).unwrap();
+    run_program_and_check_public_output(
+        "./program_artifacts/rust/ethrex.elf",
+        output.encode(),
+        inputs,
+    );
+}
+
 #[ignore = "Ignored until the vm is fast enough to run this test"]
 #[test]
 fn test_ckzg() {

--- a/tooling/ethrex-fixtures/.gitignore
+++ b/tooling/ethrex-fixtures/.gitignore
@@ -1,0 +1,3 @@
+/target
+# Transient in-memory store path created by the generator (see src/main.rs).
+.ethrex-fixtures-tmp/

--- a/tooling/ethrex-fixtures/src/main.rs
+++ b/tooling/ethrex-fixtures/src/main.rs
@@ -7,6 +7,10 @@
 //!   cargo run -- 1  ../../executor/tests/ethrex_simple_tx.bin
 //!   cargo run -- 10 ../../executor/tests/ethrex_10_transfers.bin
 //!
+//! TODO(ethrex-integration, PR #666): TEMPORARY. Delete this whole crate once
+//! the LambdaVM-backend ethrex PR lands on ethrex `main` and fixtures are
+//! generated via `ethrex-replay custom block` instead.
+//!
 //! Pinned to the same ethrex rev as the guest, so the rkyv `ProgramInput`
 //! layout matches what the guest deserializes.
 


### PR DESCRIPTION
…k temp tool

Addresses review findings on PR #666:
- Cargo.toml: the comment claimed the lambdavm feature provides KZG 'incl. kzg-rs', but the guest Cargo.lock has no kzg/c-kzg — KZG is NOT linked. Remove the false claim; state 0x0a is unsupported (consistent with main.rs) and clarify the dep is an immutable rev pin (not a moving branch).
- main.rs: make the KZG note precise — blob txs still execute (stateless block execution doesn't verify blob proofs); only the point-eval precompile (0x0a) fails closed/reverts.
- rust.rs: add test_ethrex_empty_block so the committed ethrex_empty_block.bin fixture (previously read by no test) exercises the 0-tx rkyv layout and the guest==host path; mirrors test_ethrex_simple_tx.
- tooling/ethrex-fixtures: add a grep-able TODO marking the crate temporary (delete once ethrex-replay replaces it), and a .gitignore for the stray .ethrex-fixtures-tmp store dir + target/.
- bench README: point at the canonical 'rev' in Cargo.toml, not the lockfile.