### PR TITLE
Fix ethrex benchmark docs and fixture hygiene

### DIFF
--- a/bench_vs/README_ethrex.md
+++ b/bench_vs/README_ethrex.md
@@ -61,14 +61,10 @@ BLOCKS=(
 
 ### Daily run
 The nightly workflow `.github/workflows/bench-vs-nightly.yml` calls
-`run_ethrex.sh` and posts results to Slack via
+`run_ethrex.sh --rebuild-elf` and posts results to Slack via
 `.github/scripts/publish_bench_vs.sh`. Because the script is data-driven, any
 block added to `BLOCKS` is picked up automatically; to also show it in the
 Slack post, add a line in `publish_bench_vs.sh` (see the `ethrex_line` helper).
-
-> Note: the nightly currently copies a **cached** `ethrex.elf` onto the runner
-> (a temporary step until the sysroot is provisioned there). Refresh that cache
-> when the guest or its ethrex dependency changes.
 
 ---
 
@@ -78,7 +74,7 @@ Slack post, add a line in `publish_bench_vs.sh` (see the `ethrex_line` helper).
 fixtures (`*.bin`) are small and committed.
 
 ```bash
-# One-time: fetch the RV64 sysroot (needed for ethrex's C deps: c-kzg, etc.)
+# One-time: fetch the RV64 sysroot used by the guest build.
 make prepare-sysroot SYSROOT_DIR=$HOME/.lambda-vm-sysroot
 
 # Build just the ethrex guest ELF (or `make compile-programs-rust` for all):
@@ -89,9 +85,9 @@ What the build needs:
 - **Toolchains:** `1.94.0` stable (workspace) + `nightly-2026-02-01` with
   `rust-src` (the Makefile pins it; builds the guest via `-Z build-std`).
 - **clang + lld** for ethrex's C dependencies.
-- **Network**, the first time: cargo fetches `guest_program` from
+- **Network**, the first time: cargo fetches `ethrex-guest-program` from
   `github.com/lambdaclass/ethrex.git` (commit pinned as `rev` in the guest `Cargo.toml`).
 - **`SYSROOT_DIR` must match** between `prepare-sysroot` and the build.
 
-The guest source is `executor/programs/rust/ethrex/` (an 11-line `main.rs` that
+The guest source is `executor/programs/rust/ethrex/` (a small `main.rs` that
 reads the private input, calls `execution_program`, and commits the output).

--- a/executor/.gitignore
+++ b/executor/.gitignore
@@ -1,2 +1,3 @@
 /target
 /program_artifacts/rust
+/tests/ethrex_hoodi.bin

--- a/infra/provision.sh
+++ b/infra/provision.sh
@@ -175,7 +175,7 @@ ufw default allow outgoing
 ufw allow 22/tcp
 ufw --force enable
 
-# --- 12. /etc/environment + locale ------------------------------------------
+# --- 11. /etc/environment + locale ------------------------------------------
 log "writing /etc/environment"
 cat > /etc/environment <<'EOF'
 LANG=en_US.UTF-8
@@ -186,7 +186,7 @@ LC_CTYPE=en_US.UTF-8
 EOF
 locale-gen en_US.UTF-8
 
-# --- 13. sshd hardening (last; reload won't drop existing session) ----------
+# --- 12. sshd hardening (last; reload won't drop existing session) ----------
 log "writing /etc/ssh/sshd_config.d/99-hardening.conf"
 cat > /etc/ssh/sshd_config.d/99-hardening.conf <<'EOF'
 PermitRootLogin no


### PR DESCRIPTION
### Summary
- update the ethrex benchmark README to match the current rebuild flow and guest package naming
- ignore the retired `ethrex_hoodi.bin` fixture so stale local copies are not accidentally committed
- fix `infra/provision.sh` section numbering after the removed fixture-download step

### Verification
- `git diff --check`
- `git check-ignore -v executor/tests/ethrex_hoodi.bin`

Also updated PR #666 description to note that KZG point-evaluation (`0x0a`) is unsupported under the temporary LambdaVM guest integration.