### PR TITLE
fix(ci): stop AI review matrix from self-cancelling on bot comments

### DIFF
--- a/.github/workflows/pr_ai_review.yaml
+++ b/.github/workflows/pr_ai_review.yaml
@@ -6,11 +6,20 @@ on:
   pull_request:
     types: [labeled]
 
-# One review at a time per PR; a re-trigger cancels the in-flight run so rapid
-# re-labels/comments can't race and post duplicate report comments.
+# One review at a time per PR; a genuine re-request cancels the in-flight run so
+# rapid re-labels/`/ai-review` comments can't race and post duplicate reports.
+#
+# cancel-in-progress is gated on the trigger being a REAL request. The native
+# claude-review job posts its report as a GitHub App comment (claude[bot]), and
+# App-token comments DO fire issue_comment events (unlike github-actions[bot]
+# comments, which GitHub suppresses). Since concurrency is evaluated before any
+# job-level `if:`, an unconditional cancel let that bot comment spawn a run that
+# skipped every job yet still cancelled the original mid-flight — killing the
+# slower matrix lanes while only the fastest (minimax) survived into the report.
+# Gating the cancel means such non-command comments queue-and-skip instead.
 concurrency:
   group: ai-review-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/ai-review')) }}
 
 # Default least-privilege: read-only. Only the jobs that need to write (final-report
 # posts the comment; the native reviews) request write/id-token at the job level.


### PR DESCRIPTION
## Problem

On PRs that run the AI review matrix, only the **minimax** lane shows up in the posted report — `glm`, `kimi`, and `nemotron` go missing. They aren't failing; they're being **cancelled mid-run**.

### Root cause: concurrency self-cancellation

The workflow triggers on `issue_comment: [created]` and declares:

```yaml
concurrency:
  group: ai-review-${{ ... pr number ... }}
  cancel-in-progress: true
```

The native `claude-review` job posts its report as a PR comment using the **Claude GitHub App token (`claude[bot]`)**. App-token comments **do** fire `issue_comment` events — unlike `github-actions[bot]` comments posted with the default `GITHUB_TOKEN`, which GitHub deliberately suppresses from re-triggering workflows. (That's why the Codex comment, posted as `github-actions[bot]`, is harmless, but the Claude comment is not.)

GitHub evaluates `concurrency` **before** any job-level `if:`. So when `claude[bot]` posts, a second run spawns, grabs the same `ai-review-<pr>` concurrency group, and **cancels the original in-flight run** — even though that second run then skips every job (its `prepare` `if:` is false because the comment isn't `/ai-review`).

`candidates` and `final-report` are gated with `if: always()`, so they still run after the cancellation — against the only lane artifact that finished uploading: **minimax**. Result: a partial report with one lane.

### Observed timeline (PR #666, run `27779290641`)

| time (UTC) | event |
|------------|-------|
| 18:01:26 | `/ai-review` comment → run starts |
| 18:01:51 | all 4 lanes start |
| 18:05:23 | minimax lane finishes (fastest) |
| 18:06:04 | `claude[bot]` posts review comment |
| 18:06:14 | second run starts, triggered by that comment (`27779568174`, all jobs `skipped`) |
| 18:06:31 | glm / kimi / nemotron lanes **cancelled** (still running) |
| 18:07:18 | `final-report` posts a report containing **only minimax** |

This only surfaced after the matrix was added: pre-matrix there was no long-running lane in flight when the bot comment landed, so nothing got cancelled.

## Fix

Gate `cancel-in-progress` on the trigger being a **genuine request** — a label event or an actual `/ai-review` command comment:

```yaml
concurrency:
  group: ai-review-${{ github.event.pull_request.number || github.event.issue.number }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/ai-review')) }}
```

- Preserves the original intent: a rapid second `/ai-review` or re-label still cancels the duplicate in-flight run.
- A bot/non-command comment now produces a run that **queues and skips** instead of cancelling an active review, so the full matrix runs to completion.

Must land on `main`, since `issue_comment` runs always use the workflow file from the default branch.
