### PR TITLE
Refresh ethrex fixture checksums during regen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: deps deps-linux deps-macos compile-programs-asm compile-programs-rust compile-bench \
 compile-programs clean-asm clean-rust clean-bench clean-shared clean test test-asm test-no-compile \
 test-asm-no-compile test-rust test-rust-no-compile test-executor flamegraph-prover \
-test-fast test-prover test-prover-all test-disk-spill test-math-cuda test-cuda-integration bench-math-cuda bench-prover bench-prover-cuda build check clippy fmt lint regen-ethrex-fixtures
+test-fast test-prover test-prover-all test-disk-spill test-math-cuda test-cuda-integration \
+bench-math-cuda bench-prover bench-prover-cuda build check clippy fmt lint regen-ethrex-fixtures \
+update-ethrex-fixture-checksums check-ethrex-fixture-checksums
 
 UNAME := $(shell uname)
 
@@ -158,12 +160,19 @@ test-flamegraph:
 	cargo test -p executor --test flamegraph
 
 # Regenerate the committed ethrex block fixtures (see tooling/ethrex-fixtures).
-# Run after bumping the ethrex rev; then refresh checksums in executor/tests/README.md.
+# Run after bumping the ethrex rev; README checksums are refreshed automatically.
 regen-ethrex-fixtures:
 	cd tooling/ethrex-fixtures && \
 		cargo run --release -- 0  ../../executor/tests/ethrex_empty_block.bin && \
 		cargo run --release -- 1  ../../executor/tests/ethrex_simple_tx.bin && \
 		cargo run --release -- 10 ../../executor/tests/ethrex_10_transfers.bin
+	$(MAKE) update-ethrex-fixture-checksums
+
+update-ethrex-fixture-checksums:
+	python3 tooling/ethrex-fixtures/update_readme_checksums.py
+
+check-ethrex-fixture-checksums:
+	python3 tooling/ethrex-fixtures/update_readme_checksums.py --check
 
 test: compile-programs
 	cargo test

--- a/executor/tests/README.md
+++ b/executor/tests/README.md
@@ -29,8 +29,9 @@ cargo run --release -- 10 ../../executor/tests/ethrex_10_transfers.bin  # 10 tra
 ```
 
 To regenerate after an ethrex rev bump, update the `rev` in
-`tooling/ethrex-fixtures/Cargo.toml` (and the guest's), rerun the commands above,
-and refresh the checksums below.
+`tooling/ethrex-fixtures/Cargo.toml` (and the guest's), then run
+`make regen-ethrex-fixtures` from the repo root. The target rebuilds the
+committed fixtures and refreshes the checksums below.
 
 Known fixtures:
 

--- a/tooling/ethrex-fixtures/README.md
+++ b/tooling/ethrex-fixtures/README.md
@@ -50,8 +50,9 @@ cargo run --release -- 10 ../../executor/tests/ethrex_10_transfers.bin
 cargo run --release -- 50 /tmp/ethrex_50_transfers.bin
 ```
 
-After regenerating any committed fixture, refresh its checksum in
-`executor/tests/README.md`.
+For committed fixtures, prefer `make regen-ethrex-fixtures` from the repo root;
+it regenerates the standard fixtures and refreshes
+`executor/tests/README.md` checksums.
 
 > Note: bigger blocks cost ~4M cycles per transfer (software ecrecover
 > dominates), so they execute fine but may be too heavy to *prove* on a typical

--- a/tooling/ethrex-fixtures/src/main.rs
+++ b/tooling/ethrex-fixtures/src/main.rs
@@ -2,7 +2,7 @@
 //! lambda-vm prover/benchmarks — in-memory, offline, deterministic.
 //!
 //! Usage:
-//!   cargo run -- <n_transfers> <out.bin>
+//!   cargo run -- <n_transfers> <output_path>
 //! e.g.
 //!   cargo run -- 1  ../../executor/tests/ethrex_simple_tx.bin
 //!   cargo run -- 10 ../../executor/tests/ethrex_10_transfers.bin
@@ -32,7 +32,7 @@ const RICH_PK: &str = "bcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214e
 const GENESIS_JSON: &str = include_str!("../genesis.json");
 
 fn usage_and_exit(program: &str) -> ! {
-    eprintln!("usage: {program} <n_transfers> <out.bin>");
+    eprintln!("usage: {program} <n_transfers> <output_path>");
     std::process::exit(2);
 }
 
@@ -49,7 +49,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if args.next().is_some() {
         usage_and_exit(&program);
     }
-    let n_transfers: u64 = n_transfers.parse()?;
+    let Ok(n_transfers) = n_transfers.parse::<u64>() else {
+        usage_and_exit(&program);
+    };
 
     // --- 1. genesis -> in-memory store -------------------------------------
     let genesis: Genesis = serde_json::from_str(GENESIS_JSON)?;

--- a/tooling/ethrex-fixtures/update_readme_checksums.py
+++ b/tooling/ethrex-fixtures/update_readme_checksums.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Refresh ethrex fixture SHA-256 values in executor/tests/README.md."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+FIXTURES = (
+    "ethrex_empty_block.bin",
+    "ethrex_simple_tx.bin",
+    "ethrex_10_transfers.bin",
+)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def refresh_readme(readme: Path, checksums: dict[str, str]) -> str:
+    lines = readme.read_text().splitlines()
+    replaced: set[str] = set()
+
+    for index, line in enumerate(lines[:-1]):
+        fixture = line.strip()
+        if fixture not in checksums:
+            continue
+
+        checksum_index = index + 1
+        if not lines[checksum_index].startswith("  sha256: "):
+            raise SystemExit(f"{readme}: expected sha256 line after {fixture}")
+
+        lines[checksum_index] = f"  sha256: {checksums[fixture]}"
+        replaced.add(fixture)
+
+    missing = set(checksums) - replaced
+    if missing:
+        raise SystemExit(
+            f"{readme}: missing fixture sections: {', '.join(sorted(missing))}"
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="fail if executor/tests/README.md has stale checksums",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    tests_dir = repo_root / "executor" / "tests"
+    readme = tests_dir / "README.md"
+    checksums = {fixture: sha256_file(tests_dir / fixture) for fixture in FIXTURES}
+
+    updated = refresh_readme(readme, checksums)
+    current = readme.read_text()
+
+    if args.check:
+        if updated != current:
+            raise SystemExit(f"{readme}: fixture checksums are stale")
+    else:
+        readme.write_text(updated)
+
+    for fixture in FIXTURES:
+        print(f"{fixture}: {checksums[fixture]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update make regen-ethrex-fixtures to refresh documented fixture SHA-256 values after regenerating blobs
- add a stdlib-only Python helper plus update/check checksum Make targets
- align fixture generator usage text with docs and route invalid n_transfers through usage plus exit 2

## Requirements
- no new third-party dependencies
- checksum helper uses Python 3 standard library only, matching existing repo/CI usage

## Verification
- make regen-ethrex-fixtures
- make update-ethrex-fixture-checksums
- make check-ethrex-fixture-checksums
- cargo fmt --manifest-path tooling/ethrex-fixtures/Cargo.toml --check
- cargo check --manifest-path tooling/ethrex-fixtures/Cargo.toml
- cargo run --manifest-path tooling/ethrex-fixtures/Cargo.toml --quiet -- abc /tmp/ethrex_bad.bin, expected exit 2 with usage
- python3 -m py_compile tooling/ethrex-fixtures/update_readme_checksums.py
- git diff --check