### PR TITLE
Check ethrex fixture checksums in CI

### DIFF
--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -37,6 +37,9 @@ jobs:
       - name: Run lint checks
         run: make lint
 
+      - name: Check ethrex fixture checksums
+        run: make check-ethrex-fixture-checksums
+
   test-executor:
     name: Executor tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add the ethrex fixture checksum check to the existing required Lint job
- keep it as a separate lightweight CI step instead of a new required check name

## Rationale
The check is cheap and only compares the committed fixture binaries against the documented SHA-256 values. Running it in the Lint job makes stale checksum documentation block PRs without regenerating fixtures in CI.

## Verification
- make check-ethrex-fixture-checksums