### PR TITLE
Harden sysroot tarball provisioning

### DIFF
--- a/.github/workflows/bench-vs-nightly.yml
+++ b/.github/workflows/bench-vs-nightly.yml
@@ -56,8 +56,8 @@ jobs:
         run: |
           # Provision the RISC-V sysroot in a user-writable dir instead of the default
           # /opt/lambda-vm-sysroot, which on the self-hosted bench runner is root-owned
-          # and was never fully provisioned (missing libc headers → c-kzg failed to find
-          # stdlib.h). `make` (via SYSROOT_DIR ?=) picks this up and passes it as clang's
+          # and was never fully provisioned (missing libc headers for guest C dependencies).
+          # `make` (via SYSROOT_DIR ?=) picks this up and passes it as clang's
           # --sysroot, so the guest ELF rebuild self-provisions with no sudo, and the
           # extracted sysroot persists in $HOME across runs on the persistent
           # self-hosted runner (no actions/cache step is involved).

--- a/Makefile
+++ b/Makefile
@@ -48,13 +48,9 @@ BENCH_ARTIFACTS := $(addprefix $(BENCH_ARTIFACTS_DIR)/, $(addsuffix .elf, $(BENC
 # Override with: make ... SYSROOT_DIR=$HOME/.lambda-vm-sysroot
 # to install the sysroot in a user-writable location and avoid sudo.
 SYSROOT_DIR ?= /opt/lambda-vm-sysroot
-# Fixed, global path: prepare-sysroot assumes a single writer at a time. The recipe
-# `rm -f`s this before downloading, so a stale tarball can't be extracted — but two
-# concurrent `make prepare-sysroot` on one host would race on it. The current CI runs
-# no concurrent jobs sharing a SYSROOT_DIR; revisit (e.g. mktemp/flock) if that changes.
-SYSROOT_TARBALL := /tmp/lambda-vm-sysroot-rv64im.tar.gz
 SYSROOT_URL := https://lambda.alignedlayer.com/lambda-vm-sysroot-rv64im.tar.gz
-# CFLAGS for ckzg / ethrex guest programs: overrides the hardcoded `/opt/lambda-vm-sysroot`
+SYSROOT_SHA256 := 420e394a096f3859235e3a8121a8d5a10f995ac48e636e8d700f17d50803a0e7
+# CFLAGS for guest programs with C dependencies: overrides the hardcoded `/opt/lambda-vm-sysroot`
 # in their .cargo/config.toml so cargo picks up our $(SYSROOT_DIR) instead.
 # $(abspath ...) because the build rule cd's into the program dir before invoking cargo.
 SYSROOT_CFLAGS := --target=riscv64 -march=rv64im -mabi=lp64 --sysroot=$(abspath $(SYSROOT_DIR))
@@ -86,23 +82,42 @@ prepare-sysroot:
 			lambda-vm-sysroot|.lambda-vm-sysroot) : ;; \
 			*) echo "prepare-sysroot: refusing to (sudo) rm -rf SYSROOT_DIR=$(SYSROOT_DIR) - expected a path ending in lambda-vm-sysroot or .lambda-vm-sysroot"; exit 1 ;; \
 		esac; \
+		tmp_dir=""; \
+		cleanup() { if [ -n "$$tmp_dir" ]; then rm -rf "$$tmp_dir"; fi; }; \
+		trap 'cleanup' EXIT; \
+		trap 'cleanup; exit 130' INT; \
+		trap 'cleanup; exit 143' TERM; \
+		tmp_dir="$$(mktemp -d /tmp/lambda-vm-sysroot.XXXXXX)"; \
+		tarball="$$tmp_dir/lambda-vm-sysroot-rv64im.tar.gz"; \
 		echo "Provisioning sysroot at $(SYSROOT_DIR) (downloading lambda-vm-sysroot-rv64im.tar.gz)..."; \
-		rm -f "$(SYSROOT_TARBALL)"; \
-		curl -fL --proto '=https' "$(SYSROOT_URL)" -o "$(SYSROOT_TARBALL)" \
-			|| { rm -f "$(SYSROOT_TARBALL)"; exit 1; }; \
+		curl -fL --proto '=https' "$(SYSROOT_URL)" -o "$$tarball"; \
+		echo "Verifying sysroot checksum..."; \
+		checksum_ok=false; \
+		if command -v sha256sum >/dev/null 2>&1; then \
+			printf '%s  %s\n' "$(SYSROOT_SHA256)" "$$tarball" | sha256sum -c - >/dev/null && checksum_ok=true; \
+		elif command -v shasum >/dev/null 2>&1; then \
+			actual="$$(shasum -a 256 "$$tarball" | awk '{print $$1}')"; \
+			[ "$$actual" = "$(SYSROOT_SHA256)" ] && checksum_ok=true; \
+		else \
+			echo "prepare-sysroot: missing sha256sum or shasum for checksum verification" >&2; \
+			exit 1; \
+		fi; \
+		if [ "$$checksum_ok" != true ]; then \
+			echo "prepare-sysroot: checksum mismatch for $(SYSROOT_URL)" >&2; \
+			exit 1; \
+		fi; \
 		echo "Extracting sysroot to $(SYSROOT_DIR)..."; \
 		if mkdir -p "$(SYSROOT_DIR)" 2>/dev/null && [ -w "$(SYSROOT_DIR)" ]; then \
 			rm -rf "$(SYSROOT_DIR)" && mkdir -p "$(SYSROOT_DIR)" \
-				&& tar -xzf "$(SYSROOT_TARBALL)" -C "$(SYSROOT_DIR)" --strip-components=1 --no-same-owner \
-				|| { rm -rf "$(SYSROOT_DIR)" "$(SYSROOT_TARBALL)"; exit 1; }; \
+				&& tar -xzf "$$tarball" -C "$(SYSROOT_DIR)" --strip-components=1 --no-same-owner \
+				|| { rm -rf "$(SYSROOT_DIR)"; exit 1; }; \
 		else \
 			echo "$(SYSROOT_DIR) is not writable; using sudo."; \
 			echo "Tip: re-run with SYSROOT_DIR=\$$HOME/.lambda-vm-sysroot to avoid sudo."; \
 			sudo rm -rf "$(SYSROOT_DIR)" && sudo mkdir -p "$(SYSROOT_DIR)" \
-				&& sudo tar -xzf "$(SYSROOT_TARBALL)" -C "$(SYSROOT_DIR)" --strip-components=1 --no-same-owner \
-				|| { sudo rm -rf "$(SYSROOT_DIR)"; rm -f "$(SYSROOT_TARBALL)"; exit 1; }; \
+				&& sudo tar -xzf "$$tarball" -C "$(SYSROOT_DIR)" --strip-components=1 --no-same-owner \
+				|| { sudo rm -rf "$(SYSROOT_DIR)"; exit 1; }; \
 		fi; \
-		rm -f "$(SYSROOT_TARBALL)"; \
 	fi
 
 compile-programs-asm:
@@ -123,7 +138,7 @@ compile-programs: compile-programs-asm compile-programs-rust compile-bench
 # Order-only `| prepare-sysroot` so a direct `make .../foo.elf` provisions the sysroot
 # first (the aggregate compile-programs-rust/compile-bench targets already do, but a
 # bare pattern-rule invocation like `make -B .../ethrex.elf` would otherwise skip it
-# and fail to compile C deps such as c-kzg). Order-only because prepare-sysroot is
+# and fail to compile guest C dependencies). Order-only because prepare-sysroot is
 # .PHONY — a normal prereq would force a rebuild every time; its recipe is idempotent.
 $(RUST_ARTIFACTS_DIR)/%.elf: $(RUST_PROGRAMS_DIR)/%/Cargo.toml | prepare-sysroot
 	@mkdir -p $(RUST_ARTIFACTS_DIR)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Or do it manually:
 
 ```sh
 wget https://lambda.alignedlayer.com/lambda-vm-sysroot-rv64im.tar.gz
+echo "420e394a096f3859235e3a8121a8d5a10f995ac48e636e8d700f17d50803a0e7  lambda-vm-sysroot-rv64im.tar.gz" | sha256sum -c -
 sudo mkdir -p /opt && sudo tar -xzf lambda-vm-sysroot-rv64im.tar.gz -C /opt
 ```
 

--- a/infra/provision.sh
+++ b/infra/provision.sh
@@ -150,20 +150,29 @@ APP_CLAUDE
 
 # --- 8. lambda-vm sysroot (rv64im) ------------------------------------------
 # Guard on include/stdlib.h and re-extract from scratch so a partial/interrupted extract
-# self-heals on re-run; a bare `[ ! -d ]` guard left a headerless sysroot that broke c-kzg.
+# self-heals on re-run; a bare `[ ! -d ]` guard left a headerless sysroot that broke
+# guest C dependencies.
 SYSROOT_DIR=/opt/lambda-vm-sysroot
 SYSROOT_URL=https://lambda.alignedlayer.com/lambda-vm-sysroot-rv64im.tar.gz
+SYSROOT_SHA256=420e394a096f3859235e3a8121a8d5a10f995ac48e636e8d700f17d50803a0e7
 if [ -f "$SYSROOT_DIR/include/stdlib.h" ] && [ -d "$SYSROOT_DIR/lib" ]; then
     log "sysroot already present at $SYSROOT_DIR"
 else
     log "provisioning sysroot at $SYSROOT_DIR"
-    curl -fL --proto '=https' "$SYSROOT_URL" -o /tmp/sysroot.tar.gz \
-        || { rm -f /tmp/sysroot.tar.gz; exit 1; }
+    sysroot_tmp_dir=$(mktemp -d /tmp/lambda-vm-sysroot.XXXXXX)
+    sysroot_tarball="$sysroot_tmp_dir/lambda-vm-sysroot-rv64im.tar.gz"
+    cleanup_sysroot_tmp() { rm -rf "$sysroot_tmp_dir"; }
+    trap cleanup_sysroot_tmp EXIT
+
+    curl -fL --proto '=https' "$SYSROOT_URL" -o "$sysroot_tarball"
+    printf '%s  %s\n' "$SYSROOT_SHA256" "$sysroot_tarball" | sha256sum -c -
+
     rm -rf "$SYSROOT_DIR"
     mkdir -p /opt
-    tar -xzf /tmp/sysroot.tar.gz -C /opt --no-same-owner \
-        || { rm -rf "$SYSROOT_DIR"; rm -f /tmp/sysroot.tar.gz; exit 1; }
-    rm -f /tmp/sysroot.tar.gz
+    tar -xzf "$sysroot_tarball" -C /opt --no-same-owner \
+        || { rm -rf "$SYSROOT_DIR"; exit 1; }
+    rm -rf "$sysroot_tmp_dir"
+    trap - EXIT
 fi
 
 # --- 9. Clone lambda_vm (as app, public repo over HTTPS) ---------------------


### PR DESCRIPTION
## Summary
- pin the sysroot tarball SHA-256 and verify it before extraction in both make-based provisioning and infra/provision.sh
- use a per-process temp dir for make prepare-sysroot downloads so stale shared tarballs cannot be reused
- update README manual install instructions and remove stale c-kzg wording from sysroot comments

## Verification
- make -n prepare-sysroot SYSROOT_DIR=/tmp/.lambda-vm-sysroot
- make prepare-sysroot SYSROOT_DIR=/private/tmp/codex-sysroot-test/.lambda-vm-sysroot
- bash -n infra/provision.sh
- git diff --check