### PR TITLE
refactor(math): move test-only FFT helpers into the test tree

### DIFF
--- a/crypto/math/src/fft/roots_of_unity.rs
+++ b/crypto/math/src/fft/roots_of_unity.rs
@@ -3,55 +3,6 @@ use alloc::vec::Vec;
 
 use crate::fft::errors::FFTError;
 
-// `RootsConfig` and the bit-reverse permutation are only used by the test-only
-// `get_powers_of_primitive_root` below.
-#[cfg(test)]
-use super::bit_reversing::in_place_bit_reverse_permute;
-#[cfg(test)]
-use crate::field::traits::RootsConfig;
-
-/// Returns a `Vec` of the powers of a `2^n`th primitive root of unity in some configuration
-/// `config`. For example, in a `Natural` config this would yield: w^0, w^1, w^2...
-///
-/// Test-only: production twiddle generation goes through `bowers_fft::LayerTwiddles`.
-#[cfg(test)]
-pub fn get_powers_of_primitive_root<F: IsFFTField>(
-    n: u64,
-    count: usize,
-    config: RootsConfig,
-) -> Result<Vec<FieldElement<F>>, FFTError> {
-    if count == 0 {
-        return Ok(Vec::new());
-    }
-
-    let root = match config {
-        RootsConfig::Natural | RootsConfig::BitReverse => F::get_primitive_root_of_unity(n)?,
-        _ => F::get_primitive_root_of_unity(n)?.inv().unwrap(),
-    };
-    let up_to = match config {
-        RootsConfig::Natural | RootsConfig::NaturalInversed => count,
-        // In bit reverse form we could need as many as `(1 << count.bits()) - 1` roots
-        _ => count.next_power_of_two(),
-    };
-
-    let mut results = Vec::with_capacity(up_to);
-    // NOTE: a nice version would be using `core::iter::successors`. However, this is 10% faster.
-    results.extend((0..up_to).scan(FieldElement::one(), |state, _| {
-        let res = state.clone();
-        *state = &(*state) * &root;
-        Some(res)
-    }));
-
-    if matches!(
-        config,
-        RootsConfig::BitReverse | RootsConfig::BitReverseInversed
-    ) {
-        in_place_bit_reverse_permute(&mut results);
-    }
-
-    Ok(results)
-}
-
 /// Returns a `Vec` of the powers of a `2^n`th primitive root of unity, scaled `offset` times,
 /// in a Natural configuration.
 pub fn get_powers_of_primitive_root_coset<F: IsFFTField>(

--- a/crypto/math/src/fft/test_helpers.rs
+++ b/crypto/math/src/fft/test_helpers.rs
@@ -1,11 +1,52 @@
 use crate::{
-    fft::roots_of_unity::get_powers_of_primitive_root,
+    fft::{bit_reversing::in_place_bit_reverse_permute, errors::FFTError},
     field::{
         element::FieldElement,
         traits::{IsFFTField, RootsConfig},
     },
 };
 use alloc::vec::Vec;
+
+/// Returns a `Vec` of the powers of a `2^n`th primitive root of unity in some configuration
+/// `config`. For example, in a `Natural` config this would yield: w^0, w^1, w^2...
+///
+/// Test-only: production twiddle generation goes through `bowers_fft::LayerTwiddles`.
+pub fn get_powers_of_primitive_root<F: IsFFTField>(
+    n: u64,
+    count: usize,
+    config: RootsConfig,
+) -> Result<Vec<FieldElement<F>>, FFTError> {
+    if count == 0 {
+        return Ok(Vec::new());
+    }
+
+    let root = match config {
+        RootsConfig::Natural | RootsConfig::BitReverse => F::get_primitive_root_of_unity(n)?,
+        _ => F::get_primitive_root_of_unity(n)?.inv().unwrap(),
+    };
+    let up_to = match config {
+        RootsConfig::Natural | RootsConfig::NaturalInversed => count,
+        // In bit reverse form we could need as many as `(1 << count.bits()) - 1` roots
+        _ => count.next_power_of_two(),
+    };
+
+    let mut results = Vec::with_capacity(up_to);
+    // NOTE: a nice version would be using `core::iter::successors`. However, this is 10% faster.
+    results.extend((0..up_to).scan(FieldElement::one(), |state, _| {
+        let res = state.clone();
+        *state = &(*state) * &root;
+        Some(res)
+    }));
+
+    if matches!(
+        config,
+        RootsConfig::BitReverse | RootsConfig::BitReverseInversed
+    ) {
+        in_place_bit_reverse_permute(&mut results);
+    }
+
+    Ok(results)
+}
 
 /// Calculates the (non-unitary) Discrete Fourier Transform of `input` via the DFT matrix.
 pub fn naive_matrix_dft_test<F: IsFFTField>(input: &[FieldElement<F>]) -> Vec<FieldElement<F>> {

--- a/crypto/math/src/polynomial.rs
+++ b/crypto/math/src/polynomial.rs
@@ -504,25 +504,6 @@ impl<E: IsField> Polynomial<FieldElement<E>> {
     }
 }
 
-#[cfg(test)]
-pub fn compose_fft<F, E>(
-    poly_1: &Polynomial<FieldElement<E>>,
-    poly_2: &Polynomial<FieldElement<E>>,
-) -> Polynomial<FieldElement<E>>
-where
-    F: IsFFTField + IsSubFieldOf<E>,
-    E: IsField + Send + Sync,
-{
-    let poly_2_evaluations = Polynomial::evaluate_fft::<F>(poly_2, 1, None).unwrap();
-
-    let values: Vec<_> = poly_2_evaluations
-        .iter()
-        .map(|value| poly_1.evaluate(value))
-        .collect();
-
-    Polynomial::interpolate_fft::<F>(values.as_slice()).unwrap()
-}
-
 fn evaluate_fft_cpu_raw<F, E>(
     coeffs: &[FieldElement<E>],
     permute_to_natural: bool,

--- a/crypto/math/src/tests/fft_friendly_u64_goldilocks_tests.rs
+++ b/crypto/math/src/tests/fft_friendly_u64_goldilocks_tests.rs
@@ -272,9 +272,8 @@ fn test_from_i64_max_value() {
 #[cfg(all(feature = "std", not(feature = "instruments")))]
 mod fft_tests {
     use super::*;
-    use crate::fft::roots_of_unity::{
-        get_powers_of_primitive_root, get_powers_of_primitive_root_coset,
-    };
+    use crate::fft::roots_of_unity::get_powers_of_primitive_root_coset;
+    use crate::fft::test_helpers::get_powers_of_primitive_root;
     use crate::field::traits::{IsFFTField, RootsConfig};
     use crate::polynomial::Polynomial;
     use alloc::vec::Vec;

--- a/crypto/math/src/tests/fft_tests.rs
+++ b/crypto/math/src/tests/fft_tests.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod fft_helpers_test {
-    use crate::fft::roots_of_unity::get_powers_of_primitive_root;
-    use crate::fft::test_helpers::naive_matrix_dft_test;
+    use crate::fft::test_helpers::{get_powers_of_primitive_root, naive_matrix_dft_test};
     use crate::field::element::FieldElement;
     use crate::field::test_fields::u64_test_field::U64TestField;
     use crate::field::traits::RootsConfig;
@@ -48,15 +47,31 @@ mod fft_helpers_test {
 mod fft_polynomial_tests {
     use crate::field::traits::IsField;
 
-    use crate::fft::roots_of_unity::{
-        get_powers_of_primitive_root, get_powers_of_primitive_root_coset,
-    };
+    use crate::fft::roots_of_unity::get_powers_of_primitive_root_coset;
+    use crate::fft::test_helpers::get_powers_of_primitive_root;
     use crate::field::element::FieldElement;
     use crate::field::extensions_goldilocks::Degree2GoldilocksExtensionField;
     use crate::field::traits::{IsFFTField, RootsConfig};
     use crate::polynomial::Polynomial;
-    use crate::polynomial::compose_fft;
     use proptest::{collection, prelude::*};
+
+    fn compose_fft<F, E>(
+        poly_1: &Polynomial<FieldElement<E>>,
+        poly_2: &Polynomial<FieldElement<E>>,
+    ) -> Polynomial<FieldElement<E>>
+    where
+        F: IsFFTField + crate::field::traits::IsSubFieldOf<E>,
+        E: IsField + Send + Sync,
+    {
+        let poly_2_evaluations = Polynomial::evaluate_fft::<F>(poly_2, 1, None).unwrap();
+
+        let values: Vec<_> = poly_2_evaluations
+            .iter()
+            .map(|value| poly_1.evaluate(value))
+            .collect();
+
+        Polynomial::interpolate_fft::<F>(values.as_slice()).unwrap()
+    }
 
     /// Evaluates a polynomial at a slice of points
     fn evaluate_slice<F: IsFFTField + Send + Sync>(
@@ -266,7 +281,7 @@ mod fft_polynomial_tests {
 #[cfg(test)]
 mod roots_of_unity_tests {
     use crate::fft::bit_reversing::in_place_bit_reverse_permute;
-    use crate::fft::roots_of_unity::get_powers_of_primitive_root;
+    use crate::fft::test_helpers::get_powers_of_primitive_root;
     use crate::field::test_fields::u64_test_field::U64TestField;
     use crate::field::traits::RootsConfig;
     use proptest::prelude::*;

--- a/crypto/math/src/tests/fft_tests.rs
+++ b/crypto/math/src/tests/fft_tests.rs
@@ -51,7 +51,7 @@ mod fft_polynomial_tests {
     use crate::fft::test_helpers::get_powers_of_primitive_root;
     use crate::field::element::FieldElement;
     use crate::field::extensions_goldilocks::Degree2GoldilocksExtensionField;
-    use crate::field::traits::{IsFFTField, RootsConfig};
+    use crate::field::traits::{IsFFTField, IsSubFieldOf, RootsConfig};
     use crate::polynomial::Polynomial;
     use proptest::{collection, prelude::*};
 
@@ -60,7 +60,7 @@ mod fft_polynomial_tests {
         poly_2: &Polynomial<FieldElement<E>>,
     ) -> Polynomial<FieldElement<E>>
     where
-        F: IsFFTField + crate::field::traits::IsSubFieldOf<E>,
+        F: IsFFTField + IsSubFieldOf<E>,
         E: IsField + Send + Sync,
     {
         let poly_2_evaluations = Polynomial::evaluate_fft::<F>(poly_2, 1, None).unwrap();


### PR DESCRIPTION
Moves two `#[cfg(test)]` test-only functions out of production `math` files:

- `get_powers_of_primitive_root` (roots_of_unity.rs) → `fft/test_helpers.rs`. The production `get_powers_of_primitive_root_coset` is untouched.
- `compose_fft` (polynomial.rs) → its only test (`tests/fft_tests.rs`).

`roots_of_unity.rs` and `polynomial.rs` now have zero `#[cfg(test)]` items. Behavior-preserving: math lib **178/178**, clippy clean, build clean, no visibility widened.