### PR TITLE
refactor(stark): make Table.data private, route writes through set_main

### DIFF
--- a/crypto/stark/src/table.rs
+++ b/crypto/stark/src/table.rs
@@ -48,7 +48,10 @@ impl std::fmt::Debug for TableMmapBacking {
 )]
 #[serde(bound = "")]
 pub struct Table<F: IsField> {
-    pub data: Vec<FieldElement<F>>,
+    /// Row-major backing store. Crate-private: external callers must go through
+    /// the spill-safe accessors (`get`/`get_row`/`set`) rather than indexing the
+    /// raw buffer, which bypasses the disk-spill mmap backing.
+    pub(crate) data: Vec<FieldElement<F>>,
     pub width: usize,
     pub height: usize,
     #[cfg(feature = "disk-spill")]

--- a/prover/src/tables/keccak_rc.rs
+++ b/prover/src/tables/keccak_rc.rs
@@ -223,8 +223,7 @@ pub fn update_multiplicities(
 ) {
     let mu = FieldElement::from(num_keccak_ops as u64);
     for round in 0..NUM_REAL_ROWS {
-        let base = round * cols::NUM_COLUMNS;
-        trace.main_table.data[base + cols::MU] = mu;
+        trace.set_main(round, cols::MU, mu);
     }
 }
 

--- a/prover/src/tests/branch_bus_tests.rs
+++ b/prover/src/tests/branch_bus_tests.rs
@@ -487,10 +487,8 @@ fn test_padding_rows_have_zero_multiplicity() {
     let trace = generate_branch_trace(&ops);
 
     // Check that padding rows have mu = 0
-    let data = &trace.main_table.data;
     for row_idx in 1..4 {
-        let base = row_idx * cols::NUM_COLUMNS;
-        assert_eq!(data[base + cols::MU], FE::zero());
+        assert_eq!(*trace.get_main(row_idx, cols::MU), FE::zero());
     }
 }
 

--- a/prover/src/tests/keccak_rnd_tests.rs
+++ b/prover/src/tests/keccak_rnd_tests.rs
@@ -21,7 +21,6 @@ fn test_pi_virtual_matches_rotate() {
         output,
     };
     let trace = generate_keccak_rnd_trace(&[op]);
-    let base = 0;
 
     // Recompute theta for round 0 in u64 to compare against virtual pi.
     let mut c = [0u64; 5];
@@ -46,8 +45,7 @@ fn test_pi_virtual_matches_rotate() {
             let rotated = theta_lanes[sx + 5 * sy].rotate_left(KECCAK_RHO[sx][sy]);
             for z in 0..8 {
                 let (l_col, r_col) = cols::pi_src_cols(x, y, z);
-                let virtual_pi =
-                    trace.main_table.data[base + l_col] + trace.main_table.data[base + r_col];
+                let virtual_pi = *trace.get_main(0, l_col) + *trace.get_main(0, r_col);
                 let expected = FE::from((rotated >> (z * 8)) & 0xFF);
                 assert_eq!(
                     virtual_pi, expected,

--- a/prover/src/tests/trace_builder_tests.rs
+++ b/prover/src/tests/trace_builder_tests.rs
@@ -670,7 +670,6 @@ mod keccak_tests {
             }
             ref_state[0] ^= rc;
 
-            let base = round * rnd_cols::NUM_COLUMNS;
             for (lane, &lane_val) in ref_state.iter().enumerate() {
                 let x = lane % 5;
                 let y = lane / 5;
@@ -681,7 +680,7 @@ mod keccak_tests {
                     } else {
                         rnd_cols::chi(x, y, byte_idx)
                     };
-                    let trace_val = &rnd_trace.main_table.data[base + col];
+                    let trace_val = rnd_trace.get_main(round, col);
                     assert_eq!(
                         &expected, trace_val,
                         "Round {round} lane ({x},{y}) byte {byte_idx}"
@@ -701,23 +700,22 @@ mod keccak_tests {
         for x in 0..5 {
             for y in 0..5 {
                 for b in 0..8 {
-                    let core_val = &core_trace.main_table.data[core_cols::input_state(x, y, b)];
-                    let rnd_val = &rnd_trace.main_table.data[rnd_cols::start(x, y, b)];
+                    let core_val = core_trace.get_main(0, core_cols::input_state(x, y, b));
+                    let rnd_val = rnd_trace.get_main(0, rnd_cols::start(x, y, b));
                     assert_eq!(core_val, rnd_val, "Round 0 start mismatch at ({x},{y},{b})");
                 }
             }
         }
 
         // Round 23 out == core output_state
-        let rnd_base_23 = 23 * rnd_cols::NUM_COLUMNS;
         for x in 0..5 {
             for y in 0..5 {
                 for b in 0..8 {
-                    let core_val = &core_trace.main_table.data[core_cols::output_state(x, y, b)];
+                    let core_val = core_trace.get_main(0, core_cols::output_state(x, y, b));
                     let rnd_val = if x == 0 && y == 0 {
-                        &rnd_trace.main_table.data[rnd_base_23 + rnd_cols::iota(b)]
+                        rnd_trace.get_main(23, rnd_cols::iota(b))
                     } else {
-                        &rnd_trace.main_table.data[rnd_base_23 + rnd_cols::chi(x, y, b)]
+                        rnd_trace.get_main(23, rnd_cols::chi(x, y, b))
                     };
                     assert_eq!(core_val, rnd_val, "Round 23 out mismatch at ({x},{y},{b})");
                 }


### PR DESCRIPTION
## What

`Table.data` was a `pub` field. That let callers bypass the `get`/`set`/`get_row` accessors and index the row-major buffer directly — which is why several different trace-write styles had crept in.

This narrows `Table.data` to `pub(crate)` and routes the stragglers through the API:
- `keccak_rc::update_multiplicities` — `trace.main_table.data[base + cols::MU] = mu` → `trace.set_main(round, cols::MU, mu)`
- test reads (`branch_bus_tests`, `keccak_rnd_tests`, `trace_builder_tests`) → `get_main(row, col)`

`bitwise` and `decode` already used `set_main`/`get`/`get_row` — unchanged.

## Why it's more than cleanup

The direct `.data` write was a **latent bug**: under the `disk-spill` feature, `Table` can be backed by an mmap, and `get`/`set` handle that case while raw `.data` indexing does not. `keccak_rc`'s poke would touch the wrong memory on a spilled table. Privatizing the field makes the bypass impossible to reintroduce.

## Correctness

Behavior-preserving. `cargo test -p lambda-vm-prover --lib`: **416 passed** (the 5 `*ecsm*` failures are pre-existing/environmental, identical on `main`). `cargo test -p stark --lib`: **128 passed**. `cargo fmt` + `cargo clippy` clean. The byte-pinned keccak_rc/bitwise static-commitment tests pass, confirming the `set_main` path produces identical traces.

## Relationship to #693

Supersedes #693 — **part 2 of 2** (part 1 is the `dword_wl`/`dword_hl` limb-decomposition PR). Independent of part 1; can land in either order.
