### PR TITLE
perf+fix(stark): composition poly is the quotient — (d-1) parts + verifier derives count from AIR

### DIFF
--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -998,7 +998,13 @@ where
             .map(|c| c.degree())
             .max()
             .unwrap_or(1);
-        trace_length * max_degree
+        // The composition polynomial is the constraint QUOTIENT H = Σ βᵢ·Cᵢ/Zᵢ. Its degree is
+        // deg(Cᵢ) − deg(Zᵢ) = (max_degree−1)·N − max_degree + eᵢ, so with the end-exemptions
+        // eᵢ < max_degree (the max-degree LogUp constraints have eᵢ = 0) it fits in
+        // (max_degree−1) parts — the max_degree-th part is identically zero. The tight bound is
+        // therefore (max_degree−1)·N; the previous max_degree·N committed and opened a wasted
+        // all-zero part (e.g. 3 parts for a degree-3 AIR where 2 suffice).
+        trace_length * (max_degree - 1).max(1)
     }
 
     fn context(&self) -> &AirContext {

--- a/crypto/stark/src/prover.rs
+++ b/crypto/stark/src/prover.rs
@@ -918,7 +918,8 @@ pub trait IsStarkProver<
         // Compute entirely in base field — mixed F×E multiplication when used with extension values.
         let two_base = FieldElement::<Field>::from(2u64);
         let mut inv_2x: Vec<FieldElement<Field>> = (0..n)
-            .map(|i| &two_base * &domain.lde_roots_of_unity_coset[i])
+            // 2·(g·ωⁱ) = (g·ωⁱ).double() — one add, vs a base mul+reduce per element.
+            .map(|i| domain.lde_roots_of_unity_coset[i].double())
             .collect();
         FieldElement::inplace_batch_inverse(&mut inv_2x).expect("Coset points are non-zero");
 

--- a/crypto/stark/src/tests/bus_tests/soundness_tests.rs
+++ b/crypto/stark/src/tests/bus_tests/soundness_tests.rs
@@ -93,6 +93,61 @@ fn test_wrong_result_value() {
     ));
 }
 
+/// The composition-poly part count is fixed by the AIR's max constraint degree,
+/// not chosen by the prover. A proof advertising a different number of parts must
+/// be rejected — otherwise a malicious prover could inflate the parts to widen the
+/// composition polynomial's degree space and weaken the low-degree test.
+#[test_log::test]
+fn test_rejects_inflated_composition_part_count() {
+    // All-padding traces: a valid, bus-balanced (Σ = 0) proof — the simplest valid case.
+    let mut cpu_trace = TraceTable::from_columns_main(vec![vec![FE::zero(); 4]; 5], 1);
+    let mut add_trace = TraceTable::from_columns_main(vec![vec![FE::zero(); 4]; 4], 1);
+    let mut mul_trace = TraceTable::from_columns_main(vec![vec![FE::zero(); 4]; 4], 1);
+
+    let proof_options = ProofOptions::default_test_options();
+    let cpu_air = new_cpu_air_with_lookup(&proof_options);
+    let add_air = new_add_air_with_lookup(&proof_options);
+    let mul_air = new_mul_air_with_lookup(&proof_options);
+
+    let air_trace_pairs: Vec<(
+        &dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>,
+        _,
+        _,
+    )> = vec![
+        (&cpu_air, &mut cpu_trace, &()),
+        (&add_air, &mut add_trace, &()),
+        (&mul_air, &mut mul_trace, &()),
+    ];
+    let mut multi_proof =
+        multi_prove_ram(air_trace_pairs, &mut DefaultTranscript::<E>::new(&[])).unwrap();
+
+    let airs: Vec<&dyn AIR<Field = F, FieldExtension = E, PublicInputs = ()>> =
+        vec![&cpu_air, &add_air, &mul_air];
+
+    // The untampered proof verifies.
+    assert!(Verifier::multi_verify(
+        &airs,
+        &multi_proof,
+        &mut DefaultTranscript::<E>::new(&[]),
+        &FieldElement::zero(),
+    ));
+
+    // Tamper: inflate the first table's composition-poly part count.
+    multi_proof.proofs[0]
+        .composition_poly_parts_ood_evaluation
+        .push(FieldElement::<E>::zero());
+
+    assert!(
+        !Verifier::multi_verify(
+            &airs,
+            &multi_proof,
+            &mut DefaultTranscript::<E>::new(&[]),
+            &FieldElement::zero(),
+        ),
+        "verifier must reject a composition part count that disagrees with the AIR degree bound"
+    );
+}
+
 /// Off-by-one error: CPU sends (5, 3, 8) but ADD claims (5, 3, 9).
 #[test_log::test]
 fn test_off_by_one() {

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -742,6 +742,17 @@ pub trait IsStarkVerifier<
         // trust the prover). For normal tables, use the commitment from the proof.
 
         for (idx, (air, proof)) in airs.iter().zip(&multi_proof.proofs).enumerate() {
+            // Soundness: the number of composition-poly parts is fixed by the AIR's
+            // degree bound, NOT chosen by the prover. Deriving it from the proof would
+            // let a malicious prover inflate the part count, widening the composition
+            // polynomial's degree space and weakening the low-degree test. Reject any
+            // proof whose advertised part count disagrees with the AIR.
+            if proof.trace_length == 0
+                || proof.composition_poly_parts_ood_evaluation.len()
+                    != air.composition_poly_degree_bound(proof.trace_length) / proof.trace_length
+            {
+                return false;
+            }
             if air.is_preprocessed() {
                 // Preprocessed table: VERIFY precomputed commitment matches hardcoded.
                 // This is the critical soundness check - ensures prover used correct precomputed values.


### PR DESCRIPTION
## What

Two coupled changes to the composition-polynomial handling, driven by the observation that the composition poly is the constraint **quotient** H = Σ βᵢ·Cᵢ/Zᵢ — so its degree is `(max_degree − 1)·N`, not `max_degree·N`.

### 1. `perf(stark)`: emit `(d−1)` composition parts, not `d`
`AirWithBuses::composition_poly_degree_bound` returned `trace_length · max_degree`, which bounds the constraint **numerator**, not the quotient H. The end-exemptions of the max-degree (LogUp) constraints are 0, so `deg(H) = (max_degree−1)·N − max_degree < (max_degree−1)·N` and H fits in `max_degree − 1` parts — the top part was always zero. Changed to `trace_length · (max_degree − 1)`.

**Effect on the VM (degree-3 tables):** 3 → **2** composition parts ⇒ one fewer LDE + Merkle commit + OOD opening per proof, and the degree-3 tables now take the fast algebraic `decompose_and_extend_d2` path instead of the generic iFFT+break+FFT. (The `read_only_memory_logup` example already hardcoded `trace_length * 2` for its degree-3 AIR — this aligns the generic formula with that.) Also: `2·(g·ωⁱ)` via `.double()` instead of a base multiply.

### 2. `fix(stark)`: verifier derives the part count from the AIR (soundness)
The verifier read the number of composition parts from the proof itself. That count is a **soundness parameter** (fixed by the AIR's max constraint degree). Trusting the proof let a malicious prover inflate the part count, widening the composition's degree space and weakening the low-degree test. `multi_verify` now derives the expected count from the AIR (`composition_poly_degree_bound / trace_length`) and rejects any mismatch (+ a `trace_length == 0` guard). This also makes prover and verifier consistent on change #1.

## ⚠️ Proof-format change
This changes the number of committed composition parts (VM: 3 → 2), so proofs are **not** byte-identical to `main`. The verifier auto-handles the new count (and now validates it against the AIR).

## Validation
- `stark` lib **129/129** — includes AirWithBuses prove/verify with the new bound, plus a new soundness test (`test_rejects_inflated_composition_part_count`) that confirms an inflated part count is rejected.
- Real VM proof (`fib_iterative_1200k`) prove+verify OK end-to-end with both changes together.
- `clippy` + `cargo fmt` clean.
- Needs the full VM prove suite in CI (local ELF artifacts unavailable).

## Not included (follow-ups)
Byte-identical perf wins now that degree-3 tables use the 2-part path: fuse `extend_half_to_lde` onto `coset_lde_full` (drop the intermediate coefficient allocation), `halve()` for the `/2`, drop the R3 OOD stride-collect temp, parallelize the FRI fold. Plus quality debt (decompose `multi_prove`, the d>2-arm `.unwrap()`s).
