### PR TITLE
fix(ci): AI review — accept /review-ai, raise turn cap, scope agent commands

### DIFF
--- a/.github/ai-review/prompts/general.md
+++ b/.github/ai-review/prompts/general.md
@@ -21,3 +21,17 @@ Guidelines:
 - Always prefer simplicity over complexity when performance gains are marginal
 - Focus on real issues, not hypothetical improvements
 - Be concise and actionable
+
+Environment — review statically with the tools you have:
+- This is a static code review in a sandbox. The PR branch is ALREADY checked out in the
+  working directory and the diff is provided to you — read the changed files and their
+  dependencies directly. You do not need to (and cannot) fetch anything.
+- You MAY use only: reading files, grep, glob, `gh pr view`, `gh pr diff`, `gh pr comment`,
+  `cargo tree`, `cargo metadata`, `npm list`/`npm ls`, and `forge inspect`. Inline comments
+  go through the provided inline-comment tool.
+- You may NOT build, test, or reach the network: no `cargo build`/`cargo check`/`cargo test`/
+  `cargo clippy`, no `git fetch`/`git clone`/`git checkout` of other refs. These are blocked
+  and CI already builds and tests the PR — do not attempt them.
+- If a command is denied or fails, do NOT retry it, do NOT try variations to work around the
+  sandbox, and do NOT report the failure as a review finding. Skip it and continue with the
+  tools above. Never block or end the review because a command could not run.

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -748,14 +748,15 @@ def cmd_report(args: argparse.Namespace) -> int:
 
 
 def is_review_command(body: str) -> bool:
-    # Any /ai-review (or its easy-to-misremember alias /review-ai) comment, with or
-    # without a legacy standard|critical argument. Keep this in sync with the
-    # `contains(...)` gates in pr_ai_review.yaml (prepare `if:` and concurrency).
+    # Any /ai-review (or its easy-to-misremember alias /review-ai) comment. A trailing
+    # word (e.g. an old `standard`/`critical` argument) is tolerated and ignored. Keep
+    # this in sync with the `contains(...)` gates in pr_ai_review.yaml (prepare `if:`
+    # and concurrency).
     return bool(re.search(r"(?im)^\s*/(ai-review|review-ai)\b", body))
 
 
 def is_review_label(name: str) -> bool:
-    # Any ai-review* label (including the legacy ai-review-standard/-critical labels).
+    # The `ai-review` label. `startswith` also matches any leftover `ai-review-*` label.
     return name.strip().lower().startswith("ai-review")
 
 

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -748,8 +748,10 @@ def cmd_report(args: argparse.Namespace) -> int:
 
 
 def is_review_command(body: str) -> bool:
-    # Any /ai-review comment (with or without a legacy standard|critical argument).
-    return bool(re.search(r"(?im)^\s*/ai-review\b", body))
+    # Any /ai-review (or its easy-to-misremember alias /review-ai) comment, with or
+    # without a legacy standard|critical argument. Keep this in sync with the
+    # `contains(...)` gates in pr_ai_review.yaml (prepare `if:` and concurrency).
+    return bool(re.search(r"(?im)^\s*/(ai-review|review-ai)\b", body))
 
 
 def is_review_label(name: str) -> bool:

--- a/.github/workflows/pr_ai_review.yaml
+++ b/.github/workflows/pr_ai_review.yaml
@@ -8,6 +8,7 @@ on:
 
 # One review at a time per PR; a genuine re-request cancels the in-flight run so
 # rapid re-labels/`/ai-review` comments can't race and post duplicate reports.
+# Both `/ai-review` and `/review-ai` are accepted (the name is easy to misremember).
 #
 # cancel-in-progress is gated on the trigger being a REAL request. The native
 # claude-review job posts its report as a GitHub App comment (claude[bot]), and
@@ -19,7 +20,7 @@ on:
 # Gating the cancel means such non-command comments queue-and-skip instead.
 concurrency:
   group: ai-review-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/ai-review')) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && (contains(github.event.comment.body, '/ai-review') || contains(github.event.comment.body, '/review-ai'))) }}
 
 # Default least-privilege: read-only. Only the jobs that need to write (final-report
 # posts the comment; the native reviews) request write/id-token at the job level.
@@ -33,7 +34,7 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/ai-review') &&
+        (contains(github.event.comment.body, '/ai-review') || contains(github.event.comment.body, '/review-ai')) &&
         contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       ) ||
       (
@@ -515,7 +516,7 @@ jobs:
     uses: yetanotherco/actions/.github/workflows/pr_review_claude.yml@v1.0.0
     with:
       model: opus
-      max_turns: 30
+      max_turns: 50
       custom_prompt: ${{ needs.prepare.outputs.custom_prompt }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Fixes three issues with the agentic AI review workflow.

## 1. `/review-ai` silently skips every job
The trigger command is `/ai-review`, but `/review-ai` is easy to misremember and was being used. Since `contains("/review-ai", "/ai-review")` is false, `prepare`'s `if:` failed and **every job skipped** (confirmed on PR #701). Both spellings are now accepted in the `prepare` gate, the concurrency `cancel-in-progress` gate, and `is_review_command`.

## 2. Claude review hits the turn limit
On PR #703 the `claude-review` job failed with `Reached maximum number of turns (30)`. Raised `max_turns` 30 → 50.

`max_turns` is a ceiling, not a budget — unused turns cost nothing, so a higher cap is free on normal runs. Observed turn usage on real reviews:

| PR | size | num_turns | error calls | outcome |
|----|------|-----------|-------------|---------|
| #701 | small | 18 | 2 | success |
| #666 | ~35 files | 24 | 6 | success |
| #703 | 35 files | 31 (cap) | 11 | failed at 30 |

Clean reviews finish in ~18–24 turns even on large PRs; 50 is a safety ceiling with comfortable headroom.

## 3. Agents waste turns / spam on blocked commands
The real reason #703 hit the cap: **~46% of Claude's tool calls were denied** — `git fetch`, `cargo check`, output redirection, and piped commands that need approval. Same root cause as Codex spamming "I could not complete `cargo check -p prover`".

`general.md` (the `custom_prompt` fed to both native Codex and Claude) now states which commands they may run, that they must not build/test/fetch (the branch is already checked out and CI builds/tests), and that they must not retry or report a sandbox denial as a finding.

## Note
The authoritative tool allowlist and turn cap for the native reviews live in the external reusable workflow `yetanotherco/actions/.../pr_review_claude.yml@v1.0.0`. The prompt guidance here is the in-repo lever that reaches the models; a hard guarantee would also require changes in that repo.