### PR TITLE
ci(bench): two-tier benchmarking — cheap-tier knobs + on-demand /bench-abba tiebreaker

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -38,7 +38,10 @@ env:
   ELF: executor/program_artifacts/rust/ethrex.elf
   INPUT: executor/tests/ethrex_bench_20.bin
   BENCH_RUNS_PR: 3
-  BENCH_RUNS_BASELINE: 3
+  # Baseline is the amortized side of the comparison (computed once per main push,
+  # off the PR critical path). With unequal n the smaller-n side dominates the
+  # comparison noise, so the baseline runs more than the PR side. 10 is the clamp max.
+  BENCH_RUNS_BASELINE: 10
   # Memory-scaling sweep: same ELF, different N-transfer inputs. GROWTH_PROGRAMS
   # are the generated (gitignored) fixture basenames in executor/tests/; GROWTH_STEPS
   # the matching transfer counts (x-axis; slope is MB per transfer).


### PR DESCRIPTION
Builds a **two-tier** PR benchmarking flow so we can trust small (~1%) prover deltas without slowing every PR.

## Tier 1 — the cheap screen (unchanged cost, auto on `/bench`)
- `BENCH_RUNS_BASELINE: 3 → 5`; clamp `/bench N` to **1–5** (per-PR default stays **3** for fast feedback).
- **Why cap at 5:** the single-session cached comparison can't beat the ~1% cross-session drift wall, so more runs buy little — measured run-to-run CV is ~0.5–0.9%, giving a reliable floor of ~1.5% at 5 runs vs ~1.1% at 10. Not worth the latency.
- When a PR shows a **small time speedup (<1.5%)** the cheap CI can't confirm, the benchmark comment now suggests escalating to `/bench-abba`.

## Tier 2 — the on-demand tiebreaker (`/bench-abba`, manual only)
New workflow `bench-abba.yml` + `scripts/bench_abba.sh`:
- Triggered **only** by a `/bench-abba` comment on a PR from a repo member. **Never auto-triggers** — it occupies the single bench server for **~30–40 min**, and posts a "server occupied" notice when it starts.
- Runs a **drift-free interleaved A/B/B/A paired** benchmark (builds the PR and `main` `cli` in an isolated worktree), then posts a **paired-t CI + exact Wilcoxon** test (pure-stdlib, no scipy) as a PR comment.
- Optional pair count: `/bench-abba 32` (default **20** → resolves ~1%; **32** → ~0.6%).
- `/bench-abba` is excluded from the regular `/bench` trigger so it doesn't double-fire.

## Why two tiers
Empirically (ethrex 20-transfer, ~50s/run): the cheap path resolves ≥~1.5% but is drift-limited near 1%; the ABBA path cancels drift via pairing and resolves ~1% with ~20 pairs, ~0.6% with ~32 — at the cost of ~30–40 min of server time, so it's opt-in. PR #696 was confirmed a real ~0.9% speedup this way (inconclusive at 8 pairs, clean at 24).