### PR TITLE
Simplify continuation L2G trace construction

### DIFF
--- a/prover/src/continuation.rs
+++ b/prover/src/continuation.rs
@@ -340,10 +340,6 @@ fn prove_epoch(
     boundary: &[CellBoundary],
     opts: &ProofOptions,
 ) -> Result<EpochProof, Error> {
-    // Use the cross-epoch boundary so this epoch's L2G table is identical to the
-    // one the global proof commits (the commitment binding compares their roots).
-    traces.local_to_global = local_to_global::generate_local_to_global_trace(boundary);
-
     // Count this L2G table's range-check lookups into the BITWISE table so its
     // AreBytes/IsHalfword multiplicities balance the range-check senders.
     crate::tables::bitwise::update_multiplicities(
@@ -396,10 +392,10 @@ fn prove_epoch(
     };
 
     let l2g_air = l2g_memory_air(opts, label);
-    let mut l2g_trace = std::mem::replace(
-        &mut traces.local_to_global,
-        local_to_global::generate_local_to_global_trace(&[]),
-    );
+    // Build this epoch's L2G table from the cross-epoch boundary so it is identical
+    // to the one the global proof commits (the commitment binding compares their
+    // roots). It is appended to the proof below, not through `air_trace_pairs`.
+    let mut l2g_trace = local_to_global::generate_local_to_global_trace(boundary);
 
     let mut pairs = airs.air_trace_pairs(&mut traces);
     pairs.push((&l2g_air, &mut l2g_trace, &()));


### PR DESCRIPTION
This PR keeps only the prove_epoch L2G staging cleanup.

## Changes

- Build the epoch-local L2G trace directly from the cross-epoch boundary.
- Remove the temporary traces.local_to_global assignment and immediate mem::replace with an empty trace.
- Leave CLI epoch-size policy unchanged; no --epoch-size-log2 upper bound is introduced here.

## Why

The L2G table is appended to the epoch proof explicitly, not via VmAirs::air_trace_pairs. Building it directly avoids constructing and swapping an unused temporary trace without changing the committed table.

## Testing

- make compile-programs-asm
- cargo test -p lambda-vm-prover continuation::tests -- --nocapture
- make lint