### PR TITLE
Reject continuations exceeding the IsB20 cross-epoch ordering range

### DIFF
--- a/prover/src/continuation.rs
+++ b/prover/src/continuation.rs
@@ -662,6 +662,18 @@ pub fn prove_continuation(
         if executor.pc() == 0 {
             break;
         }
+        // The cross-epoch ordering check (IsB20 on `fini_epoch - 1 - init_epoch`)
+        // only spans `local_to_global::MAX_EPOCHS` epochs. Beyond that the IsB20 bus
+        // cannot balance, so an honest proof is impossible — fail fast with a clear
+        // error instead of building an unprovable trace. The verifier already
+        // rejects any such proof; this is a prover-side guard for a clean message.
+        if index >= local_to_global::MAX_EPOCHS {
+            return Err(Error::InvalidContinuationEpochSize(format!(
+                "execution needs more than {} continuation epochs (the IsB20 cross-epoch \
+                 ordering range); use a larger epoch size",
+                local_to_global::MAX_EPOCHS
+            )));
+        }
         let register_init: Vec<u32> = if index == 0 {
             register::register_init_from_entry_point(elf.entry_point)
         } else {

--- a/prover/src/tables/local_to_global.rs
+++ b/prover/src/tables/local_to_global.rs
@@ -72,6 +72,16 @@ type Provenance = PagedMem<(u64, u64, u64)>;
 /// (1-based) epoch label, so `init_epoch < fini_epoch` holds for genesis cells.
 pub const GENESIS_EPOCH: u64 = 0;
 
+/// Maximum number of epochs a continuation run may have.
+///
+/// The cross-epoch ordering check proves `init_epoch < fini_epoch` via an `IsB20`
+/// (20-bit) lookup on `fini_epoch - 1 - init_epoch`. A genesis-sourced cell
+/// finalized in epoch `index` (0-based) has gap `index`, so every epoch must
+/// satisfy `index < 2^20`. A run needing more epochs cannot be proved — the
+/// IsB20 bus would not balance — so the driver rejects it up front (see
+/// `prove_continuation`).
+pub const MAX_EPOCHS: u64 = 1 << 20;
+
 /// A cell's state when an epoch first touches it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct InitClaim {
@@ -462,7 +472,7 @@ pub fn collect_bitwise_from_l2g(boundaries: &[CellBoundary]) -> Vec<BitwiseOpera
         // Ordering: IsB20[fini_epoch - 1 - init_epoch]. Honest rows have
         // init_epoch < fini_epoch, so the difference is a small non-negative value.
         let diff = b.fini.epoch - 1 - b.init.originating_epoch;
-        debug_assert!(diff < (1 << 20), "epoch gap exceeds IsB20 range");
+        debug_assert!(diff < MAX_EPOCHS, "epoch gap exceeds IsB20 range");
         ops.push(BitwiseOperation::b20(
             (diff & 0xFF) as u8,
             ((diff >> 8) & 0xFF) as u8,


### PR DESCRIPTION
The cross-epoch ordering check proves `init_epoch < fini_epoch` via an `IsB20` (20-bit) lookup on `fini_epoch - 1 - init_epoch`, so a continuation run can have at most `2^20` epochs (a genesis-sourced cell finalized in epoch `index` has gap `index`). Beyond that the IsB20 bus cannot balance and no honest proof exists.

Previously this limit was guarded only by a `debug_assert!` in the prover's bitwise multiplicity emission (`local_to_global::collect_bitwise_from_l2g`). In a release build, a run that needed more epochs would build an unprovable trace and fail cryptically (unbalanced bus) instead of erroring clearly. It is unreachable through the CLI (min `--epoch-size-log2 18`) but reachable through the library `prove_continuation` with a small epoch size.

## Change

Add a hard check in `prove_continuation`'s epoch loop that returns `Error::InvalidContinuationEpochSize` with a clear message once the epoch count would exceed the range, and introduce `local_to_global::MAX_EPOCHS` (`1 << 20`) as the single source of truth, used by both the new check and the existing debug_assert.

## Not a soundness change

This is a **prover-side** guard only. The verifier already rejects any out-of-range proof, independently:
- it rebuilds the IsB20 ordering sender itself, from committed columns and its own **positional** `epoch_label` (`verify_epoch` → `l2g_memory_air(opts, label)` → `range_check_interactions`);
- the IsB20 table is **preprocessed** (`bitwise::is_preprocessed()`), so its entries are the canonical `0..2^20` and the prover cannot forge an out-of-range entry;
- a value `≥ 2^20` (a real large gap, or a forged `init_epoch ≥ fini_epoch` that wraps) matches no table entry → the LogUp bus does not balance → reject;
- `MU` is forced to 1 on every touched cell by the Memory bus, so the ordering lookup cannot be skipped.

So the cap does not need to be a trusted verifier check — it only converts an unprovable/confusing prover failure into a clean, early error.

## Testing

- `cargo check -p lambda-vm-prover` — clean.
- `cargo test -p lambda-vm-prover --release continuation::tests` — 15/15 pass (no regression; the guard does not trigger for valid runs).

No direct test of the error path: exercising it would require generating `2^20` epochs, which is infeasible in a unit test. The bound is a straightforward `index >= MAX_EPOCHS` comparison.