### PR TITLE
review(stark): tidy test layout + remove AGENTS.md (follow-up to #740)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,0 @@
-# Agent Rules
-
-- Before pushing code or conflict-resolution commits to a PR branch, run `make lint` from the repository root. `cargo fmt --check` is not a substitute because CI's `Lint` job runs the full `make lint` target.
-- If `make lint` cannot complete, do not push unless the user explicitly accepts that risk, and report the incomplete lint result.

--- a/crypto/stark/src/tests/row_pair_opening_tests.rs
+++ b/crypto/stark/src/tests/row_pair_opening_tests.rs
@@ -6,7 +6,7 @@
 //! tests restore it — an implementation that ignored `evaluations_sym` or the
 //! authentication path would otherwise pass every other test.
 
-use super::small_trace_tests::make_valid_simple_proof;
+use crate::tests::trace_test_helpers::make_valid_simple_proof;
 use crate::verifier::{IsStarkVerifier, Verifier};
 use crypto::fiat_shamir::default_transcript::DefaultTranscript;
 use math::field::{element::FieldElement, goldilocks::GoldilocksField};

--- a/crypto/stark/src/tests/small_trace_tests.rs
+++ b/crypto/stark/src/tests/small_trace_tests.rs
@@ -11,36 +11,12 @@ use crate::{
     },
     proof::options::ProofOptions,
     prover::{IsStarkProver, Prover},
+    tests::trace_test_helpers::make_valid_simple_proof,
     traits::AIR,
     verifier::{IsStarkVerifier, Verifier},
 };
 
 type Felt = FieldElement<GoldilocksField>;
-
-pub(crate) fn make_valid_simple_proof() -> (
-    SimpleAdditionAIR<GoldilocksField>,
-    crate::proof::stark::StarkProof<
-        GoldilocksField,
-        GoldilocksField,
-        SimpleAdditionPublicInputs<GoldilocksField>,
-    >,
-) {
-    let mut trace = simple_addition_trace::<GoldilocksField>(2);
-    let proof_options = ProofOptions::default_test_options();
-    let pub_inputs = SimpleAdditionPublicInputs {
-        a: Felt::from(1u64),
-        b: Felt::from(2u64),
-    };
-    let air = SimpleAdditionAIR::<GoldilocksField>::new(&proof_options);
-    let proof = Prover::prove(
-        &air,
-        &mut trace,
-        &pub_inputs,
-        &mut DefaultTranscript::<GoldilocksField>::new(&[]),
-    )
-    .unwrap();
-    (air, proof)
-}
 
 /// Test STARK prove/verify with a single-row trace.
 /// This exercises the FRI protocol with 0 FRI layers (trace_length=1, number_layers=0).

--- a/crypto/stark/src/tests/trace_test_helpers.rs
+++ b/crypto/stark/src/tests/trace_test_helpers.rs
@@ -1,14 +1,50 @@
+use crate::examples::simple_addition::{
+    SimpleAdditionAIR, SimpleAdditionPublicInputs, simple_addition_trace,
+};
+use crate::proof::options::ProofOptions;
+use crate::prover::{IsStarkProver, Prover};
 use crate::table::Table;
 use crate::trace::{TraceTable, compute_frame_evaluation_points};
+use crate::traits::AIR;
+use crypto::fiat_shamir::default_transcript::DefaultTranscript;
 use itertools::Itertools;
 use math::field::{
     element::FieldElement,
+    goldilocks::GoldilocksField,
     traits::{IsField, IsSubFieldOf},
 };
 use math::polynomial::Polynomial;
 
 #[cfg(feature = "parallel")]
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+
+/// Builds a valid 2-row `SimpleAddition` proof. Shared base for the
+/// proof-tamper / rejection tests in `small_trace_tests` and
+/// `row_pair_opening_tests`.
+pub fn make_valid_simple_proof() -> (
+    SimpleAdditionAIR<GoldilocksField>,
+    crate::proof::stark::StarkProof<
+        GoldilocksField,
+        GoldilocksField,
+        SimpleAdditionPublicInputs<GoldilocksField>,
+    >,
+) {
+    let mut trace = simple_addition_trace::<GoldilocksField>(2);
+    let proof_options = ProofOptions::default_test_options();
+    let pub_inputs = SimpleAdditionPublicInputs {
+        a: FieldElement::from(1u64),
+        b: FieldElement::from(2u64),
+    };
+    let air = SimpleAdditionAIR::<GoldilocksField>::new(&proof_options);
+    let proof = Prover::prove(
+        &air,
+        &mut trace,
+        &pub_inputs,
+        &mut DefaultTranscript::<GoldilocksField>::new(&[]),
+    )
+    .unwrap();
+    (air, proof)
+}
 
 /// Reference Horner-based trace-evaluation used as an oracle by the prover
 /// tests (`tests::prover_tests`). The production prover uses the LDE-based


### PR DESCRIPTION
Two cleanups that landed after #740 had already merged.

## Shared test helper → `trace_test_helpers.rs`
`#740` left `row_pair_opening_tests.rs` importing `make_valid_simple_proof` from a **sibling** test file (`use super::small_trace_tests::...`) — the only file in the suite that reached sideways into another test module. The crate's convention is shared test helpers live in `tests/trace_test_helpers.rs` (e.g. `prover_tests` sources `get_trace_evaluations` from there). This moves `make_valid_simple_proof` into `trace_test_helpers.rs`; both `small_trace_tests.rs` and `row_pair_opening_tests.rs` now import it from the shared module. Keeps test code in the `#[cfg(test)]` `tests/` tree and out of the production source files.

## Remove `AGENTS.md`
Added by #735; removed per request.

## Verification
- `cargo test -p stark` — 136 passed.
- `make lint` — clean across all three combos.