### PR TITLE
fix(test): row-pair leaf layout in merkle_root_parity GPU parity tests

### DIFF
--- a/crypto/math-cuda/tests/merkle_root_parity.rs
+++ b/crypto/math-cuda/tests/merkle_root_parity.rs
@@ -55,9 +55,11 @@ fn gpu_merkle_root(columns: &[Vec<u64>], blowup: usize, weights: &[u64]) -> [u8;
         }
     }
 
-    // Per-row leaves (rows_per_leaf = 1): this parity test compares the generic
-    // keccak-leaves + Merkle primitives against a per-row CPU reference.
-    let gpu_leaves = math_cuda::merkle::keccak_leaves_base(&flat, n_lde, num_cols, n_lde, 1)
+    // Row-pair leaves (rows_per_leaf = 2, matching `ROWS_PER_LEAF`): the CPU
+    // reference is `commit_rows_bit_reversed`, which hashes bit-reversed row
+    // pairs into each leaf, so the generic GPU keccak-leaves + Merkle path must
+    // use the same row-pair layout to produce a matching root.
+    let gpu_leaves = math_cuda::merkle::keccak_leaves_base(&flat, n_lde, num_cols, n_lde, 2)
         .expect("GPU keccak leaves");
     let nodes =
         math_cuda::merkle::build_merkle_tree_on_device(&gpu_leaves).expect("GPU Merkle tree");
@@ -191,8 +193,10 @@ fn gpu_ext3_merkle_root(columns: &[Vec<Fp3>], blowup: usize, weights: &[u64]) ->
         }
     }
 
+    // Row-pair leaves (rows_per_leaf = 2, matching `ROWS_PER_LEAF`) to match the
+    // row-pair `commit_rows_bit_reversed` CPU reference below.
     let gpu_leaves =
-        math_cuda::merkle::keccak_leaves_ext3(&flat_for_keccak, lde_size, num_cols, lde_size, 1)
+        math_cuda::merkle::keccak_leaves_ext3(&flat_for_keccak, lde_size, num_cols, lde_size, 2)
             .expect("GPU ext3 keccak leaves");
     let nodes =
         math_cuda::merkle::build_merkle_tree_on_device(&gpu_leaves).expect("GPU Merkle tree");


### PR DESCRIPTION
## What

Two GPU↔CPU root-parity cases in `crypto/math-cuda/tests/merkle_root_parity.rs` compare against the wrong Merkle leaf layout on `main`:

- `gpu_and_cpu_row_major_merkle_roots_match`
- `gpu_and_cpu_ext3_merkle_roots_match`

Their GPU helpers (`gpu_merkle_root` / `gpu_ext3_merkle_root`) call `keccak_leaves_base` / `keccak_leaves_ext3` with `rows_per_leaf = 1` (per-row → `num_rows` leaves), but the CPU reference `commit_rows_bit_reversed` uses the **row-pair** layout (`ROWS_PER_LEAF = 2` → `num_rows / 2` leaves, each hashing a bit-reversed row pair). Different leaf count *and* different leaf bytes ⇒ different root, so these two cases can never match `main`'s row-pair commitment scheme.

## Fix

Pass `rows_per_leaf = 2` at both call sites so the generic GPU keccak-leaves + Merkle path uses the same bit-reversed row-pair layout as the CPU commit. (Plus updated the now-inaccurate "per-row" comments.)

## Why this is a test fix, not a production bug

- **Test-only surface.** `keccak_leaves_base` / `keccak_leaves_ext3` have no production callers — the proving path uses the fused `coset_lde_*_row_major_with_merkle_tree_keep`, which is already row-pair. GPU/CPU proof parity was never affected, which is exactly why proofs verify with **and** without the GPU.
- **The row-pair primitive is already proven.** `tests/keccak_leaves.rs::keccak_leaves_base_row_pair_matches_cpu` (and the ext3 equivalent) already verify that `keccak_leaves_base(.., 2)` matches the CPU row-pair prover helper.
- **The production-path cases in this same file already pass.** `new_row_major_pipeline_base_root_matches_cpu` / `…_ext3_…` exercise the real fused pipeline (row-pair on both sides) and are green.

## Background

These two cases were introduced in #715 (per-row GPU leaves). #735 ("unify & clean up the commitment layer") moved the scheme to row-pair — adding `ROWS_PER_LEAF = 2`, the row-pair leaf kernels, and a row-pair `commit_rows_bit_reversed` — but left these two test calls at the old `rows_per_leaf = 1`. This realigns them. The mismatch went unnoticed because GPU tests don't run in CI (no `nvcc`).

## Testing

Not run locally — no GPU/CUDA on the dev box, and `math-cuda` only builds under the `cuda` feature. **To be confirmed on a GPU machine:** all four cases in `merkle_root_parity.rs` should pass. `rustfmt` clean.
