### PR TITLE
fix(ci): rent dedicated (gpu_frac=1) host for GPU bench

### DIFF
--- a/.github/workflows/benchmark-gpu.yml
+++ b/.github/workflows/benchmark-gpu.yml
@@ -33,7 +33,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Vast offer search: RTX 5090, >=16 cores, >=96GB RAM, >=64GB disk, verified +
+  # Vast offer search: RTX 5090, >=16 cores, >=48GB RAM, >=64GB disk, verified +
   # rentable, Blackwell-capable driver, <= cap. gpu_frac=1 (whole-machine, dedicated
   # host) — see the query step for why.
   GPU_NAME: RTX_5090
@@ -170,7 +170,10 @@ jobs:
           # because vast can't numerically compare the driver_version string server-side.
           MIN_DRIVER: "580"
         run: |
-          # cpu_ram filter is in GB.
+          # cpu_ram filter is in GB. Floor 48 GB: the bench workload moved to the
+          # 5-transfer ethrex fixture (executor/tests/ethrex_5_transfers.bin), far smaller
+          # than the old 20-transfer prove (~78 GB heap) that set the previous 96 GB floor.
+          # 48 GB widens the dedicated pool (~15 vs ~11 offers).
           # gpu_frac=1 requires a WHOLE-MACHINE offer (you rent every GPU on the host), so
           # Vast places no other tenant on the box: CPU cores, RAM/memory bandwidth, PCIe,
           # and NVMe are fully dedicated. Without it the "most expensive" sort below lands on
@@ -178,7 +181,7 @@ jobs:
           # whole, but up to 7 noisy neighbors share the host CPU/PCIe and add per-pair
           # variance that ABBA pairing can't cancel (it's not static drift). Dedicated boxes
           # exist in the same pool, just priced lower per slot.
-          QUERY="gpu_name=${GPU_NAME} num_gpus=1 gpu_frac=1 cpu_cores_effective>=16 cpu_ram>=96 disk_space>=64 verified=true rentable=true cuda_max_good>=12.8 dph_total<=${PRICE_CAP}"
+          QUERY="gpu_name=${GPU_NAME} num_gpus=1 gpu_frac=1 cpu_cores_effective>=16 cpu_ram>=48 disk_space>=64 verified=true rentable=true cuda_max_good>=12.8 dph_total<=${PRICE_CAP}"
           echo "Query: $QUERY (+ client-side driver_version major >= $MIN_DRIVER)"
           # Keep only offers whose driver major >= MIN_DRIVER, then most expensive first
           # (within the price cap). Within the now whole-machine pool, price just tracks

--- a/.github/workflows/benchmark-gpu.yml
+++ b/.github/workflows/benchmark-gpu.yml
@@ -34,7 +34,8 @@ concurrency:
 
 env:
   # Vast offer search: RTX 5090, >=16 cores, >=96GB RAM, >=64GB disk, verified +
-  # rentable, Blackwell-capable driver, <= cap.
+  # rentable, Blackwell-capable driver, <= cap. gpu_frac=1 (whole-machine, dedicated
+  # host) — see the query step for why.
   GPU_NAME: RTX_5090
   PRICE_CAP: "1"
   VAST_IMAGE_DISK: "64"
@@ -158,9 +159,10 @@ jobs:
       - name: Pick a Vast offer
         id: offer
         env:
-          # Retry the same query to ride out transient scarcity (datacenter RTX 5090s
-          # are a small, fast-churning pool). Total wait ~= ATTEMPTS * INTERVAL.
-          OFFER_ATTEMPTS: "10"
+          # Retry the same query to ride out transient scarcity. Requiring gpu_frac=1
+          # (dedicated host) shrinks the rentable pool (~7 vs ~28 fractional), so give it
+          # more attempts to find a free whole-machine box. Total wait ~= ATTEMPTS * INTERVAL.
+          OFFER_ATTEMPTS: "20"
           OFFER_INTERVAL: "30"
           # Require driver >= this major so cudarc (default cuda-version-from-build-system)
           # matches the runtime driver. Older drivers (e.g. 575) lack newer symbols like
@@ -169,11 +171,19 @@ jobs:
           MIN_DRIVER: "580"
         run: |
           # cpu_ram filter is in GB.
-          QUERY="gpu_name=${GPU_NAME} num_gpus=1 cpu_cores_effective>=16 cpu_ram>=96 disk_space>=64 verified=true rentable=true cuda_max_good>=12.8 dph_total<=${PRICE_CAP}"
+          # gpu_frac=1 requires a WHOLE-MACHINE offer (you rent every GPU on the host), so
+          # Vast places no other tenant on the box: CPU cores, RAM/memory bandwidth, PCIe,
+          # and NVMe are fully dedicated. Without it the "most expensive" sort below lands on
+          # 1-of-8 slices (gpu_frac=0.125) on big multi-GPU servers — the GPU die is still
+          # whole, but up to 7 noisy neighbors share the host CPU/PCIe and add per-pair
+          # variance that ABBA pairing can't cancel (it's not static drift). Dedicated boxes
+          # exist in the same pool, just priced lower per slot.
+          QUERY="gpu_name=${GPU_NAME} num_gpus=1 gpu_frac=1 cpu_cores_effective>=16 cpu_ram>=96 disk_space>=64 verified=true rentable=true cuda_max_good>=12.8 dph_total<=${PRICE_CAP}"
           echo "Query: $QUERY (+ client-side driver_version major >= $MIN_DRIVER)"
           # Keep only offers whose driver major >= MIN_DRIVER, then most expensive first
-          # (within the price cap) — premium hosts have faster disks/network (quicker image
-          # pulls) and better reliability; the cheapest boxes were flaky.
+          # (within the price cap). Within the now whole-machine pool, price just tracks
+          # core/RAM size; the priciest box gives the most headroom. The cheapest boxes were
+          # flaky (slow image pulls, OOM), so bias high.
           # `try ... catch 0` so a malformed/null driver_version on one offer is treated as 0
           # (filtered out) rather than erroring the whole jq and wasting the attempt.
           SELECT="map(select((try (.driver_version|split(\".\")[0]|tonumber) catch 0) >= ${MIN_DRIVER})) | sort_by(.dph_total) | reverse"


### PR DESCRIPTION
## Problem

Benchmark noise in `/bench-gpu`. The offer query in `benchmark-gpu.yml` selects the **most-expensive** RTX 5090 ≤ \$1/hr. On the 5090 pool that systematically lands on **1-of-8 GPU slices** (`gpu_frac=0.125`) of big multi-GPU servers:

```
$0.79/hr  gpu_frac=0.125  (1 of 8)  ← picked
$0.73/hr  gpu_frac=1.0    (dedicated)  ← skipped, cheaper
...
```

The GPU die is whole (Vast doesn't time-slice a GPU), but the **physical host is shared with up to 7 other tenants**. You get only 48 of 384 cores (12%), and — critically — cgroups pin core *count* but don't isolate **memory bandwidth, last-level cache, PCIe, or NVMe**. A neighbor ramping up mid-run perturbs a memory-/transfer-bound prover and adds **per-pair variance that ABBA pairing can't cancel** (it's not static machine drift).

## Fix

Add `gpu_frac=1` to the offer query → only **whole-machine** offers qualify, so Vast places no other tenant on the box. CPU cores, RAM/memory bandwidth, PCIe, and NVMe are fully dedicated (`cpu_cores_effective == cpu_cores` → 100% of host cores).

Dedicated boxes live in the same pool (verified ~11 at driver≥580, ≤\$1/hr right now) — they were just priced lower per slot, so the most-expensive sort never reached them. Within the now whole-machine pool, price just tracks core/RAM size, so the existing sort still picks the most headroom.

Also bump `OFFER_ATTEMPTS` 10→20 since the dedicated pool is smaller (~11 vs ~28).

## Validation

- Confirmed `gpu_frac=1` filters server-side: returns only `gpu_frac=1.0` offers, healthy pool size.
- Run `/bench-gpu` on this PR to compare noise vs the prior fractional-host runs.

> Note: per the bench harness design, the box runs **main's** `bench_abba.sh`, so the dedicated-host selection only takes effect once this merges. For a pre-merge noise comparison we can temporarily point the checkout at the branch harness, or just observe the offer chosen in the run log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)