### PR TITLE
ci(bench-gpu): cap CPU cores at 32 when picking offer

### DIFF
--- a/.github/workflows/benchmark-gpu.yml
+++ b/.github/workflows/benchmark-gpu.yml
@@ -181,7 +181,7 @@ jobs:
           # whole, but up to 7 noisy neighbors share the host CPU/PCIe and add per-pair
           # variance that ABBA pairing can't cancel (it's not static drift). Dedicated boxes
           # exist in the same pool, just priced lower per slot.
-          QUERY="gpu_name=${GPU_NAME} num_gpus=1 gpu_frac=1 cpu_cores_effective>=16 cpu_ram>=48 disk_space>=64 verified=true rentable=true cuda_max_good>=12.8 dph_total<=${PRICE_CAP}"
+          QUERY="gpu_name=${GPU_NAME} num_gpus=1 gpu_frac=1 cpu_cores_effective>=16 cpu_cores_effective<=32 cpu_ram>=48 disk_space>=64 verified=true rentable=true cuda_max_good>=12.8 dph_total<=${PRICE_CAP}"
           echo "Query: $QUERY (+ client-side driver_version major >= $MIN_DRIVER)"
           # Keep only offers whose driver major >= MIN_DRIVER, then most expensive first
           # (within the price cap). Within the now whole-machine pool, price just tracks


### PR DESCRIPTION
## What

Add a `cpu_cores_effective<=32` ceiling to the `/bench-gpu` Vast offer query, keeping the existing `>=16` floor:

```
... gpu_frac=1 cpu_cores_effective>=16 cpu_cores_effective<=32 cpu_ram>=48 ...
```

## Why

Limit rentals to machines with at most 32 cores. Because `gpu_frac=1` (whole-machine rental) is retained, this selects boxes whose **total** core count is 16–32, and we still get all of those cores.

## Availability impact

Live count at time of change (RTX 5090, after the client-side driver≥580 filter): ~15 qualifying offers, so the pool stays healthy.