### PR TITLE
ci(gpu-tests): review fixes — rc capture, ssh keepalive, log artifact, sed guard, doc nits

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -232,8 +232,9 @@ jobs:
               } >> "$GITHUB_STEP_SUMMARY"
               echo "instance $IID ready — proceeding to tests"
               exit 0
+            else
+              rc=$?
             fi
-            rc=$?
             echo "::warning::instance $IID not ready (rc=$rc: 1=timeout, 2=image/scheduling failure); destroying and trying another host"
             destroy "$IID"; rm -f "$RUNNER_TEMP/vast_instance_id"
           done
@@ -267,7 +268,10 @@ jobs:
           # so we test exactly what will land. workflow_dispatch: the chosen branch ref.
           REF: ${{ github.ref }}
         run: |
-          SSH="ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o BatchMode=yes -i $KEY -p $PORT root@$HOST"
+          # ServerAlive*: ConnectTimeout only covers connection setup; without keepalives a box
+          # that wedges or drops off the network mid-suite would hang this step silently until
+          # the 240-minute job timeout. 60s x 10 fails the run ~10 minutes after the box goes dark.
+          SSH="ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -o BatchMode=yes -i $KEY -p $PORT root@$HOST"
           # Defense-in-depth: never interpolate an unvalidated ref into the remote `bash -lc`.
           case "$REF" in
             ''|*[!A-Za-z0-9._/-]*) echo "::error::invalid ref: '$REF'"; exit 1 ;;
@@ -327,9 +331,20 @@ jobs:
                 echo; echo "No individual test failures parsed (build/infra error?). Last lines:"
                 echo '```'; tail -n 40 "$OUT" 2>/dev/null || echo "(no output captured)"; echo '```'
               fi
-              echo; echo "<sub>Full output is in the \"Run GPU tests\" step log.</sub>"
+              echo; echo "<sub>Full output: \"Run GPU tests\" step log, or the \`gpu-test-log\` artifact (survives UI log truncation).</sub>"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # The step log gets truncated/rotated in the UI for multi-hour runs (see the machine-info
+      # comment above); the artifact keeps the complete output retrievable.
+      - name: Upload full test log
+        if: always() && (steps.tests.outcome == 'success' || steps.tests.outcome == 'failure')
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpu-test-log
+          path: ${{ runner.temp }}/gpu_test_out.txt
+          if-no-files-found: ignore
+          retention-days: 14
 
       # --- Teardown: ALWAYS destroy the instance (cost guardrail) ---
       - name: Destroy instance

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 compile-programs compile-recursion-elfs clean-asm clean-rust clean-bench clean-shared \
 clean-recursion-elfs clean test test-asm \
 test-rust test-executor test-flamegraph flamegraph-prover test-profile-recursion test-profile-recursion-single test-profile-recursion-multi \
-test-fast test-prover test-prover-all test-disk-spill test-math-cuda test-cuda-integration test-cuda-fallback \
+test-fast test-prover test-prover-all test-prover-debug test-disk-spill test-math-cuda test-cuda-integration test-cuda-fallback \
 test-prover-cuda test-prover-comprehensive-cuda \
 bench-math-cuda bench-prover bench-prover-cuda build check clippy fmt lint regen-ethrex-fixtures \
 update-ethrex-fixture-checksums check-ethrex-fixture-checksums
@@ -288,7 +288,7 @@ test-math-cuda:
 	cargo test -p math-cuda --release
 
 # End-to-end cuda dispatch coverage (requires NVIDIA GPU + nvcc).
-# Asserts every R1/R2/R3 GPU counter fired on a real prove.
+# Asserts the R1-R4 GPU dispatch counters fired on a real prove.
 test-cuda-integration:
 	cargo test -p lambda-vm-prover --release --features cuda \
 	    --test cuda_path_integration -- --ignored --nocapture
@@ -308,7 +308,8 @@ test-prover-cuda:
 	    --features lambda-vm-prover/cuda -- --test-threads=1
 
 # The comprehensive all-instructions prove (ignored by default) on the GPU path (requires
-# NVIDIA GPU + nvcc). GPU counterpart of CPU CI's merge-queue-only comprehensive job.
+# NVIDIA GPU + nvcc). GPU counterpart of the all-instructions half of CPU CI's merge-queue-only
+# comprehensive job (the CPU job also runs test_recursion_execute; recursion has no GPU leg yet).
 test-prover-comprehensive-cuda:
 	cargo test --release -p lambda-vm-prover --features cuda \
 	    test_prove_elfs_all_instructions_64_full -- --ignored --test-threads=1 --nocapture

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,8 +55,8 @@ The first version is going to use the primitives contained in [lambdaworks](http
 | Feature                     | Description                       | Status       |
 |---------------------------- |-----------------------------------|--------------|
 | Fields                      | Improve field performance using assembly | Planned |
-| GPU-Fast-Fourier transform      | Implement GPU version of FFT | Planned |
-| GPU-Merkle tree                 | Implement GPU version for Merkle trees | Planned |
+| GPU-Fast-Fourier transform      | Implement GPU version of FFT | Done |
+| GPU-Merkle tree                 | Implement GPU version for Merkle trees | Done |
 | Parallel trace generation   | Use GPU for fast trace generation | Planned |
-| GPU-FRI | Perform FRI on GPU | Planned |
+| GPU-FRI | Perform FRI on GPU | Done |
   

--- a/prover/src/tests/prove_elfs_tests.rs
+++ b/prover/src/tests/prove_elfs_tests.rs
@@ -1440,7 +1440,7 @@ fn test_verify_rejects_tampered_public_output() {
 /// - Division: DIV, DIVU, REM, REMU
 /// - Control: LUI, AUIPC, JALR
 #[test]
-#[ignore] // Slow: run with `cargo test --ignored` or `make test-prover-all`
+#[ignore] // Slow: run with `cargo test -- --ignored` or `make test-prover-all`
 fn test_prove_elfs_all_instructions_64_full() {
     let _ = env_logger::builder().is_test(true).try_init();
 

--- a/scripts/gpu_test.sh
+++ b/scripts/gpu_test.sh
@@ -44,6 +44,17 @@ nvidia-smi --query-gpu=name,driver_version,compute_cap --format=csv,noheader
 # conservative CUDA version binds a known driver-symbol set instead. (This is cudarc's
 # host-side driver-API floor — independent of the PTX/driver version the offer filter targets.)
 log "pinning cudarc to $CUDARC_PIN"
+# Guard the sed anchors: if math-cuda's cudarc features are ever renamed/reformatted, a silent
+# no-op here would bring the fallback-latest driver-symbol panic back with a confusing signature.
+for anchor in '"cuda-version-from-build-system"' '"fallback-latest"'; do
+    grep -qF "$anchor" crypto/math-cuda/Cargo.toml \
+        || { echo "ERROR: sed anchor $anchor not found in crypto/math-cuda/Cargo.toml — update this script's cudarc pin" >&2; exit 1; }
+done
+# Restore the tracked file on exit so a manual run on a dev box doesn't leave the tree dirty
+# (CI doesn't need this — the workflow re-checks-out before every run — but it's harmless there).
+CUDARC_TOML_BACKUP="$(mktemp)"
+cp crypto/math-cuda/Cargo.toml "$CUDARC_TOML_BACKUP"
+trap 'cp "$CUDARC_TOML_BACKUP" crypto/math-cuda/Cargo.toml; rm -f "$CUDARC_TOML_BACKUP"' EXIT
 sed -i "s/\"cuda-version-from-build-system\"/\"${CUDARC_PIN}\"/; /\"fallback-latest\"/d" \
     crypto/math-cuda/Cargo.toml
 


### PR DESCRIPTION
Review follow-ups for #747, targeting its branch. All small, behavior-preserving fixes; `shellcheck` and `actionlint` pass.

## Fixes

**`.github/workflows/gpu-tests.yml`**
- **`rc=$?` after `if wait_ready ...; fi` was always 0** — bash gives a false `if` with no `else` exit status 0, so the `rc=1 timeout / rc=2 image failure` diagnostic in the provisioning warning never worked. Now captured in an `else` branch (verified empirically).
- **ssh keepalive on the test session** — `ConnectTimeout` only covers connection setup; a box that wedged or dropped off the network mid-suite would hang the step until the 240-minute job timeout, stalling the merge queue. `ServerAliveInterval=60` + `ServerAliveCountMax=10` fails ~10 minutes after the box goes dark.
- **upload the full test log as an artifact** (`gpu-test-log`, 14-day retention) — the workflow's own comment notes the UI truncates/rotates huge step logs; the artifact keeps the complete multi-hour output retrievable. Summary footer now points to it.

**`scripts/gpu_test.sh`**
- **Guard the cudarc-pin sed anchors** — if `crypto/math-cuda/Cargo.toml`'s cudarc features are ever renamed or reformatted, the sed would silently no-op, `fallback-latest` would stay active, and the driver-symbol panic the pin exists to prevent (`cuDevSmResourceSplit` etc.) would come back with a confusing signature. Now fails loudly.
- **Restore the mutated `Cargo.toml` on exit** — CI re-checks-out before every run so it never noticed, but a manual run on a dev GPU box was left with a silently dirty tracked file that could be committed by accident.

**`Makefile`**
- Add `test-prover-debug` to `.PHONY` (pre-existing omission; every other test target is listed).
- `test-cuda-integration` comment said the test asserts R1/R2/R3 counters — it also asserts the R4 DEEP-composition and FRI-commit counters.
- Scope the `test-prover-comprehensive-cuda` parity comment: CPU CI's merge-queue comprehensive job also runs `test_recursion_execute`, which has no GPU leg (see 'Not fixed here' below).

**Docs**
- `docs/roadmap.md`: GPU FFT, GPU Merkle tree, and GPU FRI were still listed as *Planned* — all three are implemented (`crypto/math-cuda/kernels/`), dispatch-counted (`crypto/stark/src/gpu_lde.rs`), and CI-tested by this very PR. Now *Done*.
- `prove_elfs_tests.rs`: `cargo test --ignored` → `cargo test -- --ignored` in the ignore comment.

## Deliberately NOT fixed here (bigger than one-liners)

1. **Vast box leak window**: teardown is `if: always()` in the same job and the cleanup label embeds `run_attempt` — if the GitHub runner itself dies (infra failure, 6h hard kill), the box leaks and nothing ever sweeps it. Needs a small scheduled sweeper workflow (also covers `benchmark-gpu.yml`, which has the same gap).
2. **Merge-queue status-check timeout**: repo setting, not code — if it's still the 60-min default when `gpu-tests` becomes a required check, worst-case provisioning (~75 min) fails every queue entry. Check when flipping the required check on.
3. **Recursion on the GPU path**: `test_recursion_execute` is never run with `cuda` enabled anywhere; adding it needs recursion ELF builds on the box and a test-time budget decision.