### PR TITLE
ci: report gpu-tests as skipped on PRs so the required check can pass

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -8,9 +8,13 @@ name: GPU Tests (merge queue)
 # runner; all GPU work happens on the rented box (provisioned by the template onstart). The box
 # is ALWAYS destroyed at the end.
 #
-# Triggered on `merge_group` (one rental per merge, not per push) + `workflow_dispatch` for
-# manual runs. To gate merges, add the job name `gpu-tests` to the branch-protection required
-# status checks for `main` (GitHub UI).
+# The GPU suite runs on `merge_group` (one rental per merge, not per push) + `workflow_dispatch`
+# for manual runs. The `pull_request` trigger exists ONLY so the job reports on PRs: it is
+# skipped there (no rental, no cost), and GitHub counts a skipped job as satisfying a required
+# status check. Without it, `gpu-tests` never reports on the PR head and the PR is stuck at
+# "Expected — Waiting for status to be reported", unable to enter the merge queue. To gate
+# merges, add the job name `gpu-tests` to the branch-protection required status checks for
+# `main` (GitHub UI).
 #
 # Requires repo secrets:
 #   VAST_API_KEY        — https://cloud.vast.ai/manage-keys/
@@ -18,6 +22,9 @@ name: GPU Tests (merge queue)
 
 on:
   merge_group:
+  # Reports the check as Skipped on PRs (see the job-level `if`) so the required check is
+  # satisfied and the PR can enter the merge queue.
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -45,6 +52,9 @@ env:
 jobs:
   gpu-tests:
     runs-on: ubuntu-latest
+    # Skip on PRs (reports as Skipped = required check satisfied, no GPU rental); run for
+    # real on merge_group and manual dispatch.
+    if: github.event_name != 'pull_request'
     # Provisioning + cuda builds + 5 test groups; the prover suite (single-threaded, real
     # ELF proves) dominates. Generous ceiling; teardown still always destroys the box.
     timeout-minutes: 240


### PR DESCRIPTION
## Problem

`gpu-tests` was added to the branch-protection required status checks, but `gpu-tests.yml` only triggers on `merge_group` + `workflow_dispatch`. On a PR the workflow never runs, so **no `gpu-tests` check is ever reported on the PR head commit** — the PR sits at *"Expected — Waiting for status to be reported"* forever and can never enter the merge queue.

## Fix

- Add a `pull_request` trigger so the workflow runs (and reports) on PRs.
- Skip the job at the **job level** with `if: github.event_name != 'pull_request'`.

A job skipped via a job-level `if:` reports the conclusion **Skipped**, which GitHub counts as satisfying a required status check. So:

- **PR pushes:** job is skipped before any step runs — no Vast rental, zero cost — and the required check turns green, letting the PR enter the queue.
- **Merge queue:** `merge_group` fires as before; the GPU suite runs for real and a failure kicks the PR out of the queue.
- **Manual runs:** `workflow_dispatch` still works (`!= 'pull_request'`, not `== 'merge_group'`).

This is the same pattern `pr_main.yaml` already uses for the queue-only `test-prover-comprehensive` job.

## Notes

- This PR unblocks itself: `pull_request` events use the workflow from the PR merged with main, so `gpu-tests` will report Skipped here, and the real suite runs on this PR's merge group.
- Already-open PRs stuck on the missing check need a fresh `pull_request` event after this lands (push/rebase or close-reopen) to pick up the new trigger.
