### PR TITLE
fix(stark): reject truncated deep_poly_openings instead of panicking

### DIFF
--- a/crypto/stark/src/tests/small_trace_tests.rs
+++ b/crypto/stark/src/tests/small_trace_tests.rs
@@ -116,6 +116,34 @@ fn test_verify_rejects_truncated_composition_poly_parts_ood() {
     );
 }
 
+/// A malformed proof whose `deep_poly_openings` Vec is shorter than the FRI
+/// query count. `reconstruct_deep_composition_poly_evaluations_for_all_queries`
+/// indexes `deep_poly_openings[i]` for every query index, and this Vec's length
+/// is not otherwise bound (the `query_list.len()` guard checks a different
+/// field), so a truncated `deep_poly_openings` must make the verifier return
+/// `false` instead of panicking with an out-of-bounds index in release builds.
+#[test_log::test]
+fn test_verify_rejects_truncated_deep_poly_openings() {
+    let (air, mut proof) = make_valid_simple_proof();
+
+    assert!(
+        proof.deep_poly_openings.len() >= 2,
+        "test precondition: a valid proof has one deep-poly opening per FRI query",
+    );
+    // Drop the last opening so the Vec is shorter than `fri_number_of_queries`;
+    // the query loop would then index past the end.
+    proof.deep_poly_openings.pop();
+
+    assert!(
+        !Verifier::verify(
+            &proof,
+            &air,
+            &mut DefaultTranscript::<GoldilocksField>::new(&[])
+        ),
+        "Verifier must reject when deep_poly_openings is shorter than the query count"
+    );
+}
+
 /// A malformed proof whose deep-poly opening `evaluations` slice has the
 /// wrong number of columns. The runtime width-mismatch guard added in this
 /// PR must cause the verifier to return `false` instead of indexing past

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -539,6 +539,18 @@ pub trait IsStarkVerifier<
         proof: &StarkProof<Field, FieldExtension, PI>,
     ) -> Option<DeepPolynomialEvaluations<FieldExtension>> {
         let num_queries = challenges.iotas.len();
+
+        // `deep_poly_openings` comes straight from the untrusted proof and its
+        // length is not otherwise pinned (the `query_list.len()` guard checks a
+        // different field). The loop below indexes `deep_poly_openings[i]` for
+        // every `i` in `0..num_queries`, so a truncated Vec would panic the
+        // verifier with an out-of-bounds index on a malicious proof. Reject
+        // instead. (Extra entries are harmless — they are never indexed —
+        // matching the `<` convention of the `query_list` guard.)
+        if proof.deep_poly_openings.len() < num_queries {
+            return None;
+        }
+
         let mut deep_poly_evaluations = Vec::with_capacity(num_queries);
         let mut deep_poly_evaluations_sym = Vec::with_capacity(num_queries);
 


### PR DESCRIPTION
## Summary

The STARK verifier panics with an out-of-bounds index (rather than returning `false`) when handed a malformed proof whose `deep_poly_openings` Vec is shorter than the FRI query count. This is a verifier-DoS on malicious input.

`reconstruct_deep_composition_poly_evaluations_for_all_queries` indexes `proof.deep_poly_openings[i]` for every `i in 0..fri_number_of_queries`, but that Vec's length is never checked. The only length guard in the verify path (`proof.query_list.len() < fri_number_of_queries`) validates a **different** field. A prover that keeps `query_list` at full length but truncates `deep_poly_openings` sails through Fiat-Shamir replay, grinding, and step 2, then triggers `index out of bounds` at `verifier.rs:552`.

## Fix

Add a length guard at the top of the reconstruct helper (it already returns `Option`, so `None` cleanly rejects), mirroring the existing `query_list` guard. Extra entries stay harmless (never indexed), matching the `<` convention of that guard.

## Test

`test_verify_rejects_truncated_deep_poly_openings` builds a valid proof, drops one opening, and asserts the verifier returns `false` without panicking. Verified to have teeth: it panics at `verifier.rs:552` (`index out of bounds: the len is 2 but the index is 2`) against the unpatched verifier, and passes with the guard. Full `small_trace_tests` module green; `cargo fmt --check` and `clippy -p stark` clean.

## Context

Found while reviewing #729 (FRI early termination). The bug is **pre-existing on `main`**, independent of that PR, so it is fixed here as a standalone hotfix rather than bundled into the feature branch. #729 adds structural length checks for exactly this class of untrusted-Vec-length bug on sibling fields; this closes the remaining one on `deep_poly_openings`.