### PR TITLE
FRI early-termination review follow-ups (3/3): bind k into the continuation-global statement

### DIFF
--- a/prover/src/continuation.rs
+++ b/prover/src/continuation.rs
@@ -110,6 +110,7 @@ fn global_transcript(
     elf_bytes: &[u8],
     num_epochs: usize,
     num_private_input_pages: usize,
+    fri_final_poly_log_degree: u8,
     touched_page_bases: &[u64],
 ) -> DefaultTranscript<E> {
     let mut transcript = DefaultTranscript::<E>::new(&[]);
@@ -118,6 +119,7 @@ fn global_transcript(
         elf_bytes,
         num_epochs,
         num_private_input_pages,
+        fri_final_poly_log_degree,
         touched_page_bases,
     );
     transcript
@@ -686,6 +688,7 @@ fn prove_global(
             elf_bytes,
             boundaries.len(),
             num_private_input_pages,
+            opts.fri_final_poly_log_degree,
             page_bases,
         ),
         #[cfg(feature = "disk-spill")]
@@ -730,7 +733,13 @@ fn verify_global(
     Verifier::multi_verify(
         &refs,
         proof,
-        &mut global_transcript(elf_bytes, num_epochs, num_private_input_pages, page_bases),
+        &mut global_transcript(
+            elf_bytes,
+            num_epochs,
+            num_private_input_pages,
+            opts.fri_final_poly_log_degree,
+            page_bases,
+        ),
         &FieldElement::zero(),
     )
 }

--- a/prover/src/statement.rs
+++ b/prover/src/statement.rs
@@ -125,26 +125,32 @@ pub(crate) fn absorb_statement(
 /// Continuation domain tags. Distinct from the monolithic `DOMAIN_TAG` so a
 /// monolithic proof and a continuation proof can never share a transcript prefix.
 const CONTINUATION_EPOCH_TAG: &[u8] = b"LAMBDAVM_CONTINUATION_EPOCH_V2";
-const CONTINUATION_GLOBAL_TAG: &[u8] = b"LAMBDAVM_CONTINUATION_GLOBAL_V1";
+const CONTINUATION_GLOBAL_TAG: &[u8] = b"LAMBDAVM_CONTINUATION_GLOBAL_V2";
 
 /// Statement bound into the cross-epoch **global** proof's transcript before
 /// Phase A: the ELF (so the global proof is program-bound), the epoch count (so a
 /// global proof from a run with a different number of epochs cannot be spliced in),
 /// the private-input page count (so the global proof's AIR layout — which touched pages
 /// are built non-preprocessed — is canonically pinned, like the monolithic path's
-/// `absorb_statement`), and the touched page-base set (which GLOBAL_MEMORY tables exist).
+/// `absorb_statement`), `fri_final_poly_log_degree` (which sets the FRI transcript
+/// shape, exactly as the monolithic and epoch statements bind it), and the touched
+/// page-base set (which GLOBAL_MEMORY tables exist).
 /// Prove and verify must call this with identical arguments.
 pub(crate) fn absorb_continuation_global_statement(
     t: &mut impl IsTranscript<E>,
     elf_bytes: &[u8],
     num_epochs: usize,
     num_private_input_pages: usize,
+    fri_final_poly_log_degree: u8,
     touched_page_bases: &[u64],
 ) {
     t.append_bytes(CONTINUATION_GLOBAL_TAG);
     t.append_bytes(&elf_digest(elf_bytes));
     t.append_bytes(&(num_epochs as u64).to_le_bytes());
     t.append_bytes(&(num_private_input_pages as u64).to_le_bytes());
+
+    // fri_final_poly_log_degree: single byte, no endianness concern.
+    t.append_bytes(&[fri_final_poly_log_degree]);
 
     // Touched page-base set: count-prefixed, each fixed-width u64. Binds the exact set
     // (and order) of GLOBAL_MEMORY tables the verifier rebuilds, so a tampered list

--- a/prover/src/tests/statement_tests.rs
+++ b/prover/src/tests/statement_tests.rs
@@ -178,6 +178,7 @@ fn global_state(
     elf: &[u8],
     num_epochs: usize,
     num_private_input_pages: usize,
+    fri_final_poly_log_degree: u8,
     touched_page_bases: &[u64],
 ) -> [u8; 32] {
     let mut t = DefaultTranscript::<E>::new(&[]);
@@ -186,6 +187,7 @@ fn global_state(
         elf,
         num_epochs,
         num_private_input_pages,
+        fri_final_poly_log_degree,
         touched_page_bases,
     );
     t.state()
@@ -193,31 +195,36 @@ fn global_state(
 
 #[test]
 fn continuation_global_state_binds_program_epoch_count_pages_and_touched_set() {
-    let baseline = global_state(b"elf", 3, 1, &[0x1000, 0x2000]);
-    assert_eq!(baseline, global_state(b"elf", 3, 1, &[0x1000, 0x2000])); // deterministic
+    let baseline = global_state(b"elf", 3, 1, 7, &[0x1000, 0x2000]);
+    assert_eq!(baseline, global_state(b"elf", 3, 1, 7, &[0x1000, 0x2000])); // deterministic
     assert_ne!(
         baseline,
-        global_state(b"elf", 4, 1, &[0x1000, 0x2000]),
+        global_state(b"elf", 4, 1, 7, &[0x1000, 0x2000]),
         "must bind epoch count"
     );
     assert_ne!(
         baseline,
-        global_state(b"other-elf", 3, 1, &[0x1000, 0x2000]),
+        global_state(b"other-elf", 3, 1, 7, &[0x1000, 0x2000]),
         "must bind the ELF"
     );
     assert_ne!(
         baseline,
-        global_state(b"elf", 3, 2, &[0x1000, 0x2000]),
+        global_state(b"elf", 3, 2, 7, &[0x1000, 0x2000]),
         "must bind the private-input page count"
     );
     assert_ne!(
         baseline,
-        global_state(b"elf", 3, 1, &[0x1000, 0x3000]),
+        global_state(b"elf", 3, 1, 8, &[0x1000, 0x2000]),
+        "must bind fri_final_poly_log_degree"
+    );
+    assert_ne!(
+        baseline,
+        global_state(b"elf", 3, 1, 7, &[0x1000, 0x3000]),
         "must bind the touched page-base set"
     );
     assert_ne!(
         baseline,
-        global_state(b"elf", 3, 1, &[0x1000]),
+        global_state(b"elf", 3, 1, 7, &[0x1000]),
         "must bind the touched page-base count"
     );
 }


### PR DESCRIPTION
Stack **3 of 3** of review follow-ups from #729. **Base is PR 2/3** (#787) — review/merge that first. Single commit.

## The gap
#729 binds `fri_final_poly_log_degree` into the monolithic statement (`STATEMENT_V3`) and the continuation-epoch statement (`CONTINUATION_EPOCH_V2`), but **not** into `absorb_continuation_global_statement` (`CONTINUATION_GLOBAL_V1`). The cross-epoch global proof is itself a STARK produced and verified under the same `ProofOptions`, so its FRI transcript shape depends on `k` exactly like the other two. Leaving it unbound makes the canonical-binding guarantee half-applied and contradicts the global statement's own doc comment ("canonically pinned, like the monolithic path's `absorb_statement`").

## The fix
Absorb the `k` byte in `absorb_continuation_global_statement` and bump `CONTINUATION_GLOBAL_V1` → `V2`; thread `opts.fri_final_poly_log_degree` through `global_transcript` and both call sites (`prove_global` / `verify_global`).

Not a soundness fix: a prover/verifier `k` mismatch on the global proof could only ever **reject** (the verifier derives every FRI parameter from its own options and structurally checks layer/coeff counts). This is defense-in-depth / consistency so the three statement paths bind `k` uniformly.

## Testing
- `statement_tests` (6) pass, including a new `must bind fri_final_poly_log_degree` assertion on the global statement.
- Continuation prove→verify roundtrips pass (`test_prove_and_verify_continuation`, `test_continuation_private_input_verifies_without_bytes`, `test_continuation_bincode_roundtrip`) — the global proof still verifies with `k` bound in.
- `cargo fmt --check` + `clippy` clean.

_Note: the pre-existing flaky test `test_bundle_carries_no_touched_cell_values` (a probabilistic marker-byte check over non-deterministic bundle bytes) is unrelated to this change and unaffected by it._