### PR TITLE
zeroed_fe_vec: reinterpret via from_raw_parts, not Vec transmute

### DIFF
--- a/prover/src/tables/types.rs
+++ b/prover/src/tables/types.rs
@@ -57,10 +57,22 @@ pub fn zeroed_fe_vec(len: usize) -> Vec<FE> {
     const _: () = assert!(core::mem::size_of::<FE>() == core::mem::size_of::<u64>());
     const _: () = assert!(core::mem::align_of::<FE>() == core::mem::align_of::<u64>());
     let zeros: Vec<u64> = vec![0u64; len];
+    // Reinterpret the buffer as `Vec<FE>` via its raw parts rather than
+    // `mem::transmute::<Vec<u64>, Vec<FE>>`. `Vec`'s field layout is unspecified
+    // and may depend on its element type, so transmuting one `Vec` to another
+    // relies on that unspecified layout (the std `mem::transmute` docs call this
+    // out and recommend `from_raw_parts`). Rebuilding from `(ptr, len, cap)`
+    // reuses the same allocation and carries no `Vec`-layout assumption.
+    let mut zeros = core::mem::ManuallyDrop::new(zeros);
     // SAFETY: `FE` is `#[repr(transparent)]` over `u64` with identical size and
     // alignment (asserted above), and `0u64` is exactly `FE::zero()`'s bit
-    // pattern (no Montgomery form), so reinterpreting the buffer is valid.
-    unsafe { core::mem::transmute::<Vec<u64>, Vec<FE>>(zeros) }
+    // pattern (Goldilocks has no Montgomery form), so the zeroed `u64` buffer is
+    // a valid `[FE]` of all `FE::zero()`. `len`/`capacity` are element counts and
+    // the element sizes are equal, so they carry over unchanged; the eventual
+    // dealloc uses the same `size * capacity` and alignment as the original
+    // allocation. `ManuallyDrop` stops the source `Vec` from freeing the buffer
+    // that the returned `Vec` now owns.
+    unsafe { Vec::from_raw_parts(zeros.as_mut_ptr() as *mut FE, zeros.len(), zeros.capacity()) }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Small hardening of the `zeroed_fe_vec` helper added in the `opt` commit (calloc-backed zeroed trace buffers). **No behavior change** — pure implementation swap.

### Why
The helper reinterpreted its calloc'd buffer with:
```rust
unsafe { core::mem::transmute::<Vec<u64>, Vec<FE>>(zeros) }
```
Transmuting one `Vec` to another relies on `Vec`'s field layout being identical across element types. `Vec` is `#[repr(Rust)]` (unspecified layout, permitted to depend on the element type), so this isn't guaranteed by the language — the std [`mem::transmute` docs](https://doc.rust-lang.org/std/mem/fn.transmute.html) call out this exact `Vec`→`Vec` pattern as a Bad Idea and recommend `from_raw_parts`. It's sound on the pinned `rustc 1.94.0` (no layout randomization), but e.g. `-Zrandomize-layout` could permute `{ptr, cap}` differently for the two types and make it UB.

### What
Rebuild the `Vec<FE>` from `(ptr, len, cap)` on the same allocation:
```rust
let mut zeros = core::mem::ManuallyDrop::new(zeros);
unsafe { Vec::from_raw_parts(zeros.as_mut_ptr() as *mut FE, zeros.len(), zeros.capacity()) }
```
Same calloc'd buffer, same element size/align (already `const`-asserted), so the eventual dealloc `Layout` matches exactly and there's **no dependence on `Vec`'s internal layout**. The `FE`-is-`u64` / zero-is-all-zero justification is unchanged and stays self-contained in the helper (no coupling to the disk-spill `SpillSafe` trait — deliberately, since that's a separate, feature-scoped concern).

### Testing
Full `cargo test -p lambda-vm-prover --lib`: **503 passed** (only the 5 known missing rust-guest ELF fixtures fail, at file-read). The `zeroed_fe_vec_matches_fe_zero` guard test and end-to-end prove+verify pass, confirming byte-identical behavior. `make lint`, `clippy --all-targets`, `fmt --check` clean.