### PR TITLE
chore(lint): run clippy with the cuda feature in make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,6 +355,10 @@ lint:
 	cargo clippy --workspace --all-targets -- -D warnings -A clippy::op_ref
 	cargo clippy --workspace --all-targets --no-default-features --features lambda-vm-prover/debug-checks -- -D warnings -A clippy::op_ref
 	cargo clippy --workspace --all-targets --features lambda-vm-prover/disk-spill -- -D warnings -A clippy::op_ref
+	# The cuda feature gates whole modules + cuda-only integration tests. build.rs emits empty
+	# cubin stubs when nvcc is absent, so this checks on a GPU-less host (CI lint runner, dev laptop)
+	# too — no GPU required. Catches cuda-gated breakage that the non-cuda passes above miss.
+	cargo clippy --workspace --all-targets --features lambda-vm-prover/cuda -- -D warnings -A clippy::op_ref
 
 flamegraph-prover:
 	cd crypto/stark && samply record cargo bench --bench profile_prover --features parallel


### PR DESCRIPTION
## What

Adds a `cargo clippy --features lambda-vm-prover/cuda` pass to the `make lint` target.

## Why

`make lint` runs clippy for the default / `debug-checks` / `disk-spill` feature sets, but never the **cuda** feature. The cuda feature gates whole modules and cuda-only integration tests that those passes never compile, so cuda-gated breakage slips through both `make lint` and the CI `lint` job (both GPU-less) and only surfaces on a GPU box.

Concretely: a merge that removes a helper (e.g. an AIR constructor inlined into another table) can leave a dangling call inside a `#[cfg(feature = "cuda")]` test; nothing in CI catches it until someone builds cuda on a GPU box.

`math-cuda`'s `build.rs` emits empty cubin stubs when `nvcc` is absent, so `cargo clippy --features cuda` checks cleanly on any host **without a GPU** — the existing `test-stark-cuda-lib` CI job already compiles cuda on `ubuntu-latest` the same way. Since the CI `lint` job just runs `make lint`, this pass is picked up automatically with no workflow change.

## Cost

One extra clippy invocation (pulls in `math-cuda` + `cudarc`); check-only, no GPU, no link. A couple of minutes on the lint job.