### PR TITLE
ci: post recursion guest cycle+accelerator diff (main vs PR) on /bench-verify

### DIFF
--- a/.github/workflows/bench-verify.yml
+++ b/.github/workflows/bench-verify.yml
@@ -26,9 +26,13 @@ jobs:
       startsWith(github.event.comment.body, '/bench-verify') &&
       contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: [self-hosted, bench]
-    # Verifier bench is ~4 min and the recursion measurement itself ~1 min, but the
-    # recursion guest builds (one per ref) dominate: ~10-20 min each the first time on
-    # a fresh runner, cached in /tmp for later runs. Headroom for the cold first run.
+    # Job cap. The verifier bench is ~4 min and the recursion measurement itself ~1 min,
+    # but on a cold runner the recursion BUILDS dominate: MEASURE_CLI (release cli) once,
+    # plus PER REF a guest build (~10-20 min) and a prover-test build for the blob dump.
+    # All cached in /tmp for later runs, and build-std / the host cargo target are shared
+    # across ref worktrees (see the recursion step's env) to keep the cold run under this
+    # cap. The recursion step also has its own tighter timeout so a runaway build there
+    # can't burn the whole job and lose the already-captured verifier result.
     timeout-minutes: 90
     steps:
       - name: Acknowledge (react + occupancy notice)
@@ -90,16 +94,29 @@ jobs:
 
       # Additive: deterministic recursion-guest cycle+accelerator diff (PR vs main).
       # The measurement is one exact `execute --cycles` reading per ref (~1 min total, no
-      # ABBA); the recursion guest builds dominate wall time (~10-20 min/ref cold, cached
-      # in /tmp afterwards). continue-on-error + `!cancelled()` keep this fully isolated
-      # from the verifier bench above: a failure here never fails the job nor clobbers the
+      # ABBA). Cold wall time is dominated by BUILDS: MEASURE_CLI (release cli) once, plus
+      # per ref a guest build (~10-20 min) and a prover-test build for the blob dump; the
+      # GUEST_TARGET_DIR / HOST_TARGET_DIR below share build-std and the host cargo target
+      # across the two ref worktrees so the second ref is much cheaper (and per-worktree
+      # disk shrinks). continue-on-error + `!cancelled()` keep this fully isolated from the
+      # verifier bench above: a failure OR timeout here never fails the job nor clobbers the
       # verifier verdict, and it still runs if the verifier step failed.
       - name: Run recursion guest cycle benchmark
         id: recursion
         if: ${{ !cancelled() }}
         continue-on-error: true
+        # Fail-fast well under the 90-min job cap so a runaway recursion build can't burn
+        # the whole job and lose the already-captured verifier result (continue-on-error
+        # absorbs the timeout; the job still posts the verifier verdict). Sized with
+        # headroom over a cold shared-build run (MEASURE_CLI + 2 guest builds + 2 blob-dump
+        # builds).
+        timeout-minutes: 70
         env:
           HEAD_SHA: ${{ steps.cfg.outputs.head_sha }}
+          # Share build-std and the host cargo target across ref worktrees, rooted under
+          # the script's /tmp cache dir: cuts cold build time and per-worktree disk.
+          GUEST_TARGET_DIR: /tmp/recursion_cycles_run/shared_guest_target
+          HOST_TARGET_DIR: /tmp/recursion_cycles_run/shared_host_target
         run: |
           export SYSROOT_DIR="$HOME/.lambda-vm-sysroot"
           set -o pipefail
@@ -118,32 +135,35 @@ jobs:
           script: |
             const fs = require('fs');
             const read = (p) => { try { return fs.readFileSync(p, 'utf8').trim(); } catch { return ''; } };
+            // Bound any raw-log fallback so a future header rename (empty *_result.txt)
+            // can't dump the entire build log into the PR comment.
+            const tail = (s, n) => s.split('\n').slice(-n).join('\n');
             const head = (process.env.HEAD_SHA || '').slice(0, 10), pairs = process.env.PAIRS;
             let body = `## Verifier benchmark — \`${head}\` vs \`main\` (${pairs} pairs)\n\n`;
             if (process.env.OUTCOME === 'success') {
-              const res = read('/tmp/verify_result.txt') || read('/tmp/verify_out.txt');
+              const res = read('/tmp/verify_result.txt') || tail(read('/tmp/verify_out.txt'), 30);
               body += res + '\n';
               body += '\n<sub>Drift-free interleaved A/B/B/A measurement. - = PR faster. ';
               body += 'Trust the verdict when paired-t and Wilcoxon agree.</sub>\n';
             } else {
-              const tail = read('/tmp/verify_out.txt').split('\n').slice(-30).join('\n');
-              body += `❌ Run failed. Last log lines:\n\n` + '```\n' + tail + '\n```\n';
+              body += `❌ Run failed. Last log lines:\n\n` + '```\n' + tail(read('/tmp/verify_out.txt'), 30) + '\n```\n';
             }
             // Additive recursion-guest cycle section, kept clearly separated from the
             // verifier verdict above so a failure here can't change how the bench reads.
             body += '\n---\n\n## Recursion guest cycles (main vs PR)\n\n';
             if (process.env.RECURSION_OUTCOME === 'success') {
-              const rec = read('/tmp/recursion_result.txt') || read('/tmp/recursion_out.txt');
+              const rec = read('/tmp/recursion_result.txt') || tail(read('/tmp/recursion_out.txt'), 20);
               if (rec) {
                 body += rec + '\n';
                 body += '\n<sub>Deterministic in-VM verifier: one exact `execute --cycles` reading per ref ';
                 body += '(no ABBA needed). - = PR does fewer cycles/calls = better. keccak/ecsm are 0 when ';
-                body += 'the verifier uses Poseidon2.</sub>\n';
+                body += 'the verifier uses Poseidon2. Each ref dumps its own input blob, so for a PR that ';
+                body += 'changes the proof format the delta reflects both guest-code and proof-structure changes.</sub>\n';
               } else {
                 body += '_No recursion comparison output was captured._\n';
               }
             } else {
-              const rtail = read('/tmp/recursion_out.txt').split('\n').slice(-20).join('\n');
+              const rtail = tail(read('/tmp/recursion_out.txt'), 20);
               body += '⚠️ Recursion cycle bench did not complete (does not affect the verifier verdict above).';
               body += rtail ? ' Last log lines:\n\n' + '```\n' + rtail + '\n```\n' : '\n';
             }

--- a/.github/workflows/bench-verify.yml
+++ b/.github/workflows/bench-verify.yml
@@ -22,7 +22,10 @@ jobs:
       startsWith(github.event.comment.body, '/bench-verify') &&
       contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: [self-hosted, bench]
-    timeout-minutes: 60
+    # Verifier bench is ~4 min and the recursion measurement itself ~1 min, but the
+    # recursion guest builds (one per ref) dominate: ~10-20 min each the first time on
+    # a fresh runner, cached in /tmp for later runs. Headroom for the cold first run.
+    timeout-minutes: 90
     steps:
       - name: Acknowledge (react + occupancy notice)
         uses: actions/github-script@v7
@@ -81,6 +84,24 @@ jobs:
           scripts/bench_verify.sh "$HEAD_SHA" origin/main "$PAIRS" 2>&1 | tee /tmp/verify_out.txt
           sed -n '/=== Verify ABBA result/,$p' /tmp/verify_out.txt > /tmp/verify_result.txt
 
+      # Additive: deterministic recursion-guest cycle+accelerator diff (PR vs main).
+      # The measurement is one exact `execute --cycles` reading per ref (~1 min total, no
+      # ABBA); the recursion guest builds dominate wall time (~10-20 min/ref cold, cached
+      # in /tmp afterwards). continue-on-error + `!cancelled()` keep this fully isolated
+      # from the verifier bench above: a failure here never fails the job nor clobbers the
+      # verifier verdict, and it still runs if the verifier step failed.
+      - name: Run recursion guest cycle benchmark
+        id: recursion
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        env:
+          HEAD_SHA: ${{ steps.cfg.outputs.head_sha }}
+        run: |
+          export SYSROOT_DIR="$HOME/.lambda-vm-sysroot"
+          set -o pipefail
+          scripts/bench_recursion_cycles.sh "$HEAD_SHA" origin/main min 2>&1 | tee /tmp/recursion_out.txt
+          sed -n '/=== Recursion-guest cycle/,$p' /tmp/recursion_out.txt > /tmp/recursion_result.txt
+
       - name: Post result
         if: always()
         uses: actions/github-script@v7
@@ -88,6 +109,7 @@ jobs:
           HEAD_SHA: ${{ steps.cfg.outputs.head_sha }}
           PAIRS: ${{ steps.cfg.outputs.pairs }}
           OUTCOME: ${{ steps.run.outcome }}
+          RECURSION_OUTCOME: ${{ steps.recursion.outcome }}
         with:
           script: |
             const fs = require('fs');
@@ -102,6 +124,24 @@ jobs:
             } else {
               const tail = read('/tmp/verify_out.txt').split('\n').slice(-30).join('\n');
               body += `❌ Run failed. Last log lines:\n\n` + '```\n' + tail + '\n```\n';
+            }
+            // Additive recursion-guest cycle section, kept clearly separated from the
+            // verifier verdict above so a failure here can't change how the bench reads.
+            body += '\n---\n\n## Recursion guest cycles (main vs PR)\n\n';
+            if (process.env.RECURSION_OUTCOME === 'success') {
+              const rec = read('/tmp/recursion_result.txt') || read('/tmp/recursion_out.txt');
+              if (rec) {
+                body += rec + '\n';
+                body += '\n<sub>Deterministic in-VM verifier: one exact `execute --cycles` reading per ref ';
+                body += '(no ABBA needed). - = PR does fewer cycles/calls = better. keccak/ecsm are 0 when ';
+                body += 'the verifier uses Poseidon2.</sub>\n';
+              } else {
+                body += '_No recursion comparison output was captured._\n';
+              }
+            } else {
+              const rtail = read('/tmp/recursion_out.txt').split('\n').slice(-20).join('\n');
+              body += '⚠️ Recursion cycle bench did not complete (does not affect the verifier verdict above).';
+              body += rtail ? ' Last log lines:\n\n' + '```\n' + rtail + '\n```\n' : '\n';
             }
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo,

--- a/bin/cli/src/main.rs
+++ b/bin/cli/src/main.rs
@@ -10,6 +10,8 @@ use clap::{Parser, Subcommand, ValueHint};
 
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+use executor::vm::instruction::decoding::Instruction;
+use executor::vm::instruction::execution::{ECSM_SYSCALL_NUMBER, KECCAK_SYSCALL_NUMBER};
 use executor::{elf::Elf, flamegraph::FlamegraphGenerator, vm::execution::Executor};
 use prover::VmProof;
 use stark::proof::options::GoldilocksCubicProofOptions;
@@ -339,6 +341,37 @@ struct FlamegraphCliOptions {
     checkpoint_cycles: Option<u64>,
 }
 
+/// The VM's two syscall accelerators. Each accelerator call is a single ECALL
+/// instruction (one cycle) with the whole permutation / scalar-mul running
+/// inside it, so invocations must be tallied separately from the cycle count.
+#[derive(Clone, Copy)]
+enum Accelerator {
+    /// keccak-f[1600] permutation.
+    Keccak,
+    /// secp256k1 scalar multiplication.
+    Ecsm,
+}
+
+/// Classifies one executed instruction as an accelerator syscall invocation.
+///
+/// Mirrors `CpuOperation::from_log` (prover/src/tables/cpu.rs): the prover sets
+/// `ecall_keccak`/`ecall_ecsm` from `f.ecall && log.src1_val == <SYSCALL_NUMBER>`.
+/// Here `f.ecall` is the instruction at the log's `current_pc` being
+/// `EcallEbreak`, and `src1_val` carries a7 (the syscall number) on ECALL logs.
+/// Keep this in sync with that classifier so the CLI's counts equal the prover's
+/// chip-trigger counts by construction. (`get_private_input` is a memory-mapped
+/// read, not a syscall, so it never reaches this path.)
+fn accelerator_of(instruction: Option<&Instruction>, src1_val: u64) -> Option<Accelerator> {
+    if !matches!(instruction, Some(Instruction::EcallEbreak)) {
+        return None;
+    }
+    match src1_val {
+        KECCAK_SYSCALL_NUMBER => Some(Accelerator::Keccak),
+        ECSM_SYSCALL_NUMBER => Some(Accelerator::Ecsm),
+        _ => None,
+    }
+}
+
 fn cmd_execute(
     elf_path: PathBuf,
     private_input_path: Option<PathBuf>,
@@ -369,6 +402,12 @@ fn cmd_execute(
             return ExitCode::FAILURE;
         }
     };
+
+    // Accelerator invocation counts, tallied only in the plain streaming path
+    // below (the flamegraph path drives execution inside the executor and does
+    // not expose per-log data). `None` means "not counted", so the accel lines
+    // are omitted rather than printed as misleading zeros.
+    let mut accel_counts: Option<(u64, u64)> = None;
 
     let cycle_count = if let Some(ref output_path) = flamegraph.path {
         // Shared execute+flamegraph path (executor::flamegraph) instead of
@@ -434,6 +473,14 @@ fn cmd_execute(
         };
 
         let mut cycle_count: u64 = 0;
+        let mut keccak_calls: u64 = 0;
+        let mut ecsm_calls: u64 = 0;
+        // Reused per chunk: `(current_pc, a7)` for logs whose a7 matches an
+        // accelerator syscall number. This is a cheap superset — a non-ECALL
+        // instruction can hold the same value in src1 — that `accelerator_of`
+        // confirms below, once the chunk's `&Log` borrow (tied to the executor's
+        // `&mut`) is released so the instruction cache can be read again.
+        let mut accel_candidates: Vec<(u64, u64)> = Vec::new();
         loop {
             let logs = match executor.resume_budgeted(cycle_count, cycle_budget) {
                 Ok(logs) => logs,
@@ -442,9 +489,24 @@ fn cmd_execute(
                     return ExitCode::FAILURE;
                 }
             };
-            match logs {
-                Some(logs) => cycle_count += logs.len() as u64,
-                None => break,
+            let Some(logs) = logs else { break };
+            cycle_count += logs.len() as u64;
+            if cycles {
+                for log in logs {
+                    if log.src1_val == KECCAK_SYSCALL_NUMBER || log.src1_val == ECSM_SYSCALL_NUMBER
+                    {
+                        accel_candidates.push((log.current_pc, log.src1_val));
+                    }
+                }
+            }
+            // `logs` is no longer used, so the executor's `&mut` borrow is free
+            // and the instruction cache can be read to confirm each candidate.
+            for (pc, a7) in accel_candidates.drain(..) {
+                match accelerator_of(executor.instructions.get(pc), a7) {
+                    Some(Accelerator::Keccak) => keccak_calls += 1,
+                    Some(Accelerator::Ecsm) => ecsm_calls += 1,
+                    None => {}
+                }
             }
             if cycle_budget.is_some_and(|budget| cycle_count >= budget) {
                 break;
@@ -456,11 +518,18 @@ fn cmd_execute(
             return ExitCode::FAILURE;
         }
 
+        if cycles {
+            accel_counts = Some((keccak_calls, ecsm_calls));
+        }
         cycle_count
     };
 
     if cycles {
         println!("Cycles: {}", cycle_count);
+        if let Some((keccak_calls, ecsm_calls)) = accel_counts {
+            println!("Keccak calls: {}", keccak_calls);
+            println!("Ecsm calls: {}", ecsm_calls);
+        }
     }
 
     ExitCode::SUCCESS
@@ -1010,5 +1079,36 @@ mod tests {
     #[test]
     fn continuation_epoch_size_uses_exact_power_of_two() {
         assert_eq!(continuation_epoch_size(20).unwrap(), 1 << 20);
+    }
+
+    // `accelerator_of` must match the prover's `CpuOperation::from_log`: count an
+    // invocation only when the instruction is an ECALL AND a7 is the accelerator
+    // syscall number. Covers both accelerators, the non-accelerator syscalls, a
+    // non-ECALL whose src1 collides with an accelerator number, and a cache miss.
+    #[test]
+    fn accelerator_of_mirrors_prover_classification() {
+        use executor::vm::instruction::execution::SyscallNumbers;
+
+        let ecall = Instruction::EcallEbreak;
+
+        assert!(matches!(
+            accelerator_of(Some(&ecall), KECCAK_SYSCALL_NUMBER),
+            Some(Accelerator::Keccak)
+        ));
+        assert!(matches!(
+            accelerator_of(Some(&ecall), ECSM_SYSCALL_NUMBER),
+            Some(Accelerator::Ecsm)
+        ));
+
+        // Non-accelerator syscalls (Commit=64, Halt=93) count as neither.
+        assert!(accelerator_of(Some(&ecall), SyscallNumbers::Commit as u64).is_none());
+        assert!(accelerator_of(Some(&ecall), SyscallNumbers::Halt as u64).is_none());
+
+        // A non-ECALL instruction whose src1 happens to equal an accelerator a7
+        // must not count — this is the `f.ecall &&` guard the prover applies.
+        assert!(accelerator_of(Some(&Instruction::Fence), KECCAK_SYSCALL_NUMBER).is_none());
+
+        // No decoded instruction at the pc (cache miss) counts as neither.
+        assert!(accelerator_of(None, KECCAK_SYSCALL_NUMBER).is_none());
     }
 }

--- a/scripts/bench_recursion_cycles.sh
+++ b/scripts/bench_recursion_cycles.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# bench_recursion_cycles.sh — deterministic recursion-guest cycle + accelerator
+# comparison (PR vs baseline).
+#
+# The recursion guest is the in-VM STARK verifier: it runs the verifier INSIDE the
+# VM. For a fixed (guest ELF, input blob) its cost is fully DETERMINISTIC, so
+# comparing two git refs is two EXACT integer readings — no A/B/B/A interleaving.
+# For each ref we report three numbers, all read from one `execute --cycles` run of
+# a single measuring CLI (MEASURE_CLI) built once from this branch:
+#   * Guest cycles  — retired instructions.
+#   * Keccak calls  — keccak-permutation accelerator ecalls (one cycle each, but each
+#                     runs a whole permutation invisibly, so it's the companion signal).
+#   * Ecsm calls    — elliptic-curve scalar-mul accelerator ecalls (same idea).
+# The executor semantics are main's, so MEASURE_CLI faithfully counts ANY ref's guest
+# ELF — it just feeds the blob as private input and reads the counters.
+#
+# Improvement convention matches scripts/bench_verify.sh:
+#   NEGATIVE Δ  =  REF_A (PR) does fewer cycles/calls  =  better.
+#
+# Usage: scripts/bench_recursion_cycles.sh REF_A [REF_B=origin/main] [PRESET=min]
+#   REF_A    ref/SHA to evaluate (the PR side).
+#   REF_B    baseline ref/SHA (default origin/main).
+#   PRESET   recursion-verifier preset (default min). The tool prefers
+#            recursion-<PRESET>.elf and falls back to recursion.elf on refs
+#            (older/main) that build a single unnamed recursion guest.
+#   Env:
+#     REBUILD=1            force rebuild of MEASURE_CLI and re-run of every ref
+#                          (guest build + blob dump + measurement); ignore caches.
+#     SYSROOT_DIR=<path>   guest-build sysroot (default $HOME/.lambda-vm-sysroot).
+#     GUEST_TARGET_DIR=<p> share the RV64 guest build dir across ref worktrees
+#                          (reuses build-std → big speedup for the 2nd ref's guest
+#                          build). Unset = per-worktree (default, fully isolated).
+#     HOST_TARGET_DIR=<p>  share the host cargo target dir for the blob-dump test
+#                          build across refs. Unset = per-worktree (default).
+#
+# Caching: each ref's result is cached in $WORK keyed on its resolved SHA + preset,
+# so re-runs are fast. Ref worktrees are kept (named by SHA) so a re-measure is a
+# cargo no-op. REBUILD=1 forces everything.
+#
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "usage: bench_recursion_cycles.sh REF_A [REF_B=origin/main] [PRESET=min]" >&2
+  echo "  REF_A: ref or SHA to evaluate (the PR side)" >&2
+  echo "  REF_B: baseline ref (default origin/main)" >&2
+  echo "  PRESET: recursion verifier preset (default min)" >&2
+  exit 2
+fi
+REF_A="$1"
+REF_B="${2:-origin/main}"
+PRESET="${3:-min}"
+SYSROOT_DIR="${SYSROOT_DIR:-$HOME/.lambda-vm-sysroot}"
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+WORK="/tmp/recursion_cycles_run"
+mkdir -p "$WORK"
+
+echo "==> Refs"
+git fetch origin --quiet || echo "WARNING: 'git fetch origin' failed — resolving against possibly-stale local refs." >&2
+SHA_A="$(git rev-parse "$REF_A")"
+SHA_B="$(git rev-parse "$REF_B")"
+echo "   A (PR)       $REF_A  -> ${SHA_A:0:10}"
+echo "   B (baseline) $REF_B  -> ${SHA_B:0:10}"
+echo "   preset=$PRESET  work=$WORK  sysroot=$SYSROOT_DIR"
+
+if [ ! -d "$SYSROOT_DIR/lib" ]; then
+  echo "ERROR: SYSROOT_DIR=$SYSROOT_DIR does not look provisioned (no lib/). Guest builds will fail." >&2
+  echo "       Provision it or point SYSROOT_DIR at an existing sysroot." >&2
+  exit 1
+fi
+
+# --- 1. Build MEASURE_CLI once (release) from the current branch ---------------
+# This branch is based on feat/cycles-accelerator-counts, so `cli` here has
+# `execute --cycles` with the keccak/ecsm counters. Its executor is main's, so it
+# counts any ref's guest ELF correctly.
+HEAD_SHA="$(git rev-parse HEAD)"
+MEASURE_CLI="$WORK/measure_cli"
+if [ "${REBUILD:-0}" = "1" ] || [ ! -x "$MEASURE_CLI" ] || \
+   [ "$(cat "$MEASURE_CLI.sha" 2>/dev/null)" != "$HEAD_SHA" ]; then
+  echo "==> Building MEASURE_CLI (cli, release) from ${HEAD_SHA:0:10} ..."
+  if ! cargo build --release -p cli >"$WORK/build_measure_cli.log" 2>&1; then
+    echo "ERROR: MEASURE_CLI build failed. Tail of $WORK/build_measure_cli.log:" >&2
+    tail -40 "$WORK/build_measure_cli.log" >&2
+    exit 1
+  fi
+  cp "$ROOT/target/release/cli" "$MEASURE_CLI"
+  echo "$HEAD_SHA" > "$MEASURE_CLI.sha"
+else
+  echo "==> Reusing cached MEASURE_CLI (${HEAD_SHA:0:10})"
+fi
+
+# --- 2. Per-ref: worktree + guest build + blob dump + measurement ---------------
+# Prints progress to stderr; emits the parseable result block (key=value lines) to
+# stdout so the caller can capture it.
+measure_ref() {
+  local ref="$1" sha="$2" role="$3"
+  local sha8="${sha:0:8}"
+  local result="$WORK/result_${sha8}_${PRESET}.txt"
+
+  if [ "${REBUILD:-0}" != "1" ] && [ -f "$result" ]; then
+    echo "==> [$role] Reusing cached measurement: $ref ($sha8) preset=$PRESET" >&2
+    cat "$result"
+    return 0
+  fi
+
+  local wt="$WORK/wt_${sha8}"
+  if [ ! -d "$wt" ]; then
+    echo "==> [$role] Adding worktree $wt @ $sha8" >&2
+    git worktree prune
+    git worktree add --detach "$wt" "$sha" >/dev/null
+  else
+    echo "==> [$role] Reusing worktree $wt (checkout -f $sha8)" >&2
+    git -C "$wt" checkout --quiet -f "$sha"
+  fi
+
+  # 2a. Build the recursion guest ELF(s) (+ empty.elf inner program).
+  echo "==> [$role] make compile-recursion-elfs @ $sha8 (this can take 10-20 min the first time) ..." >&2
+  local glog="$WORK/build_guest_${sha8}.log"
+  if [ -n "${GUEST_TARGET_DIR:-}" ]; then
+    if ! ( cd "$wt" && SYSROOT_DIR="$SYSROOT_DIR" make compile-recursion-elfs "SHARED_TARGET_DIR=$GUEST_TARGET_DIR" ) >"$glog" 2>&1; then
+      echo "ERROR: [$role] 'make compile-recursion-elfs' failed for $ref ($sha8). Tail of $glog:" >&2
+      tail -40 "$glog" >&2
+      exit 1
+    fi
+  else
+    if ! ( cd "$wt" && SYSROOT_DIR="$SYSROOT_DIR" make compile-recursion-elfs ) >"$glog" 2>&1; then
+      echo "ERROR: [$role] 'make compile-recursion-elfs' failed for $ref ($sha8). Tail of $glog:" >&2
+      tail -40 "$glog" >&2
+      exit 1
+    fi
+  fi
+
+  # 2b. Detect the guest ELF: prefer recursion-<PRESET>.elf, else recursion.elf.
+  local artdir="$wt/executor/program_artifacts/recursion"
+  local guest_elf=""
+  if [ -f "$artdir/recursion-${PRESET}.elf" ]; then
+    guest_elf="$artdir/recursion-${PRESET}.elf"
+  elif [ -f "$artdir/recursion.elf" ]; then
+    guest_elf="$artdir/recursion.elf"
+  else
+    echo "ERROR: [$role] no recursion guest artifact for $ref ($sha8):" >&2
+    echo "       neither recursion-${PRESET}.elf nor recursion.elf found in $artdir" >&2
+    ls -la "$artdir" >&2 2>/dev/null || true
+    exit 1
+  fi
+  echo "==> [$role] guest ELF: $(basename "$guest_elf")" >&2
+
+  # 2c. Generate this ref's own input blob via its ignored dump test.
+  if ! grep -rq "fn test_dump_recursion_input" "$wt/prover/src/tests/" 2>/dev/null; then
+    echo "ERROR: [$role] ref $ref ($sha8) has no 'test_dump_recursion_input' — cannot generate its input blob." >&2
+    exit 1
+  fi
+  echo "==> [$role] dumping recursion input blob (cargo test test_dump_recursion_input) ..." >&2
+  rm -f /tmp/recursion_input.bin
+  local dlog="$WORK/dump_${sha8}.log"
+  if [ -n "${HOST_TARGET_DIR:-}" ]; then
+    if ! ( cd "$wt" && CARGO_TARGET_DIR="$HOST_TARGET_DIR" cargo test -p lambda-vm-prover --lib test_dump_recursion_input -- --ignored --nocapture ) >"$dlog" 2>&1; then
+      echo "ERROR: [$role] blob-dump test failed for $ref ($sha8). Tail of $dlog:" >&2
+      tail -40 "$dlog" >&2
+      exit 1
+    fi
+  else
+    if ! ( cd "$wt" && cargo test -p lambda-vm-prover --lib test_dump_recursion_input -- --ignored --nocapture ) >"$dlog" 2>&1; then
+      echo "ERROR: [$role] blob-dump test failed for $ref ($sha8). Tail of $dlog:" >&2
+      tail -40 "$dlog" >&2
+      exit 1
+    fi
+  fi
+  if [ ! -f /tmp/recursion_input.bin ]; then
+    echo "ERROR: [$role] test_dump_recursion_input did not write /tmp/recursion_input.bin for $ref ($sha8)." >&2
+    exit 1
+  fi
+  local blob="$WORK/blob_${sha8}_${PRESET}.bin"
+  cp /tmp/recursion_input.bin "$blob"
+  echo "==> [$role] blob: $(wc -c <"$blob" | tr -d '[:space:]') bytes -> $blob" >&2
+
+  # 2d. Measure: one deterministic execute --cycles run. Time it (CI feasibility).
+  echo "==> [$role] measuring: $MEASURE_CLI execute $(basename "$guest_elf") --private-input <blob> --cycles" >&2
+  local t0 t1 dt out
+  t0=$(date +%s)
+  if ! out="$("$MEASURE_CLI" execute "$guest_elf" --private-input "$blob" --cycles 2>"$WORK/measure_${sha8}.err")"; then
+    echo "ERROR: [$role] MEASURE_CLI execute failed for $ref ($sha8). Tail of stderr:" >&2
+    tail -20 "$WORK/measure_${sha8}.err" >&2
+    exit 1
+  fi
+  t1=$(date +%s); dt=$((t1 - t0))
+
+  local cyc kec ecs
+  cyc="$(printf '%s\n' "$out" | awk -F': ' '/^Cycles:/{print $2; exit}')"
+  kec="$(printf '%s\n' "$out" | awk -F': ' '/^Keccak calls:/{print $2; exit}')"
+  ecs="$(printf '%s\n' "$out" | awk -F': ' '/^Ecsm calls:/{print $2; exit}')"
+  if [ -z "$cyc" ] || [ -z "$kec" ] || [ -z "$ecs" ]; then
+    echo "ERROR: [$role] could not parse Cycles/Keccak/Ecsm from MEASURE_CLI output for $ref ($sha8):" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  fi
+  echo "==> [$role] cycles=$cyc keccak=$kec ecsm=$ecs  (execute wall-time ${dt}s)" >&2
+
+  {
+    printf 'cycles=%s\n' "$cyc"
+    printf 'keccak=%s\n' "$kec"
+    printf 'ecsm=%s\n' "$ecs"
+    printf 'wall=%s\n' "$dt"
+    printf 'elf=%s\n' "$(basename "$guest_elf")"
+  } > "$result"
+  cat "$result"
+}
+
+# Baseline first, then PR (so a fresh GUEST_TARGET_DIR is warmed by the baseline).
+RES_B="$(measure_ref "$REF_B" "$SHA_B" baseline)"
+RES_A="$(measure_ref "$REF_A" "$SHA_A" PR)"
+
+getv() { printf '%s\n' "$1" | awk -F= -v k="$2" '$1==k{print $2; exit}'; }
+CYC_B="$(getv "$RES_B" cycles)"; KEC_B="$(getv "$RES_B" keccak)"; ECS_B="$(getv "$RES_B" ecsm)"
+WALL_B="$(getv "$RES_B" wall)"; ELF_B="$(getv "$RES_B" elf)"
+CYC_A="$(getv "$RES_A" cycles)"; KEC_A="$(getv "$RES_A" keccak)"; ECS_A="$(getv "$RES_A" ecsm)"
+WALL_A="$(getv "$RES_A" wall)"; ELF_A="$(getv "$RES_A" elf)"
+
+# signed integer delta (A - B); 0 prints bare, >0 gets a leading '+'
+sd() { local d=$(( $1 - $2 )); if [ "$d" -gt 0 ]; then printf '+%d' "$d"; else printf '%d' "$d"; fi; }
+# signed integer delta + percentage of baseline
+sdp() {
+  local a="$1" b="$2"
+  awk -v a="$a" -v b="$b" 'BEGIN{
+    d=a-b;
+    pct=(b!=0)? d/b*100 : 0;
+    printf("%s%d (%s%.2f%%)", (d>=0?"+":""), d, (pct>=0?"+":""), pct);
+  }'
+}
+
+echo
+echo "=== Recursion-guest cycle/accelerator comparison (deterministic, exact) ==="
+echo "   REF_B (baseline) $REF_B  ${SHA_B:0:10}  guest=$ELF_B"
+echo "   REF_A (PR)       $REF_A  ${SHA_A:0:10}  guest=$ELF_A"
+echo "   preset=$PRESET   convention: - = PR fewer = better"
+echo
+echo "| Metric        | REF_B (baseline) | REF_A (PR) | Δ (A-B) |"
+echo "|---------------|------------------|------------|---------|"
+printf '| Guest cycles  | %s | %s | %s |\n' "$CYC_B" "$CYC_A" "$(sdp "$CYC_A" "$CYC_B")"
+printf '| Keccak calls  | %s | %s | %s |\n' "$KEC_B" "$KEC_A" "$(sd "$KEC_A" "$KEC_B")"
+printf '| Ecsm calls    | %s | %s | %s |\n' "$ECS_B" "$ECS_A" "$(sd "$ECS_A" "$ECS_B")"
+echo
+echo "=== RAW (machine-parseable) ==="
+printf 'ref_b_sha=%s ref_b_elf=%s ref_b_cycles=%s ref_b_keccak=%s ref_b_ecsm=%s ref_b_execute_wall_s=%s\n' \
+  "$SHA_B" "$ELF_B" "$CYC_B" "$KEC_B" "$ECS_B" "$WALL_B"
+printf 'ref_a_sha=%s ref_a_elf=%s ref_a_cycles=%s ref_a_keccak=%s ref_a_ecsm=%s ref_a_execute_wall_s=%s\n' \
+  "$SHA_A" "$ELF_A" "$CYC_A" "$KEC_A" "$ECS_A" "$WALL_A"
+printf 'delta_cycles=%s delta_keccak=%s delta_ecsm=%s\n' \
+  "$(( CYC_A - CYC_B ))" "$(( KEC_A - KEC_B ))" "$(( ECS_A - ECS_B ))"

--- a/scripts/bench_recursion_cycles.sh
+++ b/scripts/bench_recursion_cycles.sh
@@ -4,16 +4,26 @@
 # comparison (PR vs baseline).
 #
 # The recursion guest is the in-VM STARK verifier: it runs the verifier INSIDE the
-# VM. For a fixed (guest ELF, input blob) its cost is fully DETERMINISTIC, so
-# comparing two git refs is two EXACT integer readings — no A/B/B/A interleaving.
-# For each ref we report three numbers, all read from one `execute --cycles` run of
-# a single measuring CLI (MEASURE_CLI) built once from this branch:
+# VM. For a fixed (guest ELF, input blob) its cost is fully DETERMINISTIC, so a single
+# ref is one EXACT integer reading — no A/B/B/A interleaving needed. Note the two refs
+# do NOT share one blob: each ref dumps its OWN input blob from its own prover (via its
+# ignored dump test). So when a PR only changes guest code the delta is a clean
+# guest-cycle diff, but when a PR changes the prover / proof format the delta conflates
+# the guest-code change with the proof-structure change (a different blob) — read it as
+# "total verifier work for each side's own proof", not an isolated guest-code delta.
+#
+# For each ref we report three numbers, all read from one `execute --cycles` run of a
+# single measuring CLI (MEASURE_CLI) built once from the checkout this script runs in:
 #   * Guest cycles  — retired instructions.
 #   * Keccak calls  — keccak-permutation accelerator ecalls (one cycle each, but each
 #                     runs a whole permutation invisibly, so it's the companion signal).
 #   * Ecsm calls    — elliptic-curve scalar-mul accelerator ecalls (same idea).
-# The executor semantics are main's, so MEASURE_CLI faithfully counts ANY ref's guest
-# ELF — it just feeds the blob as private input and reads the counters.
+# MEASURE_CLI's executor counts ANY ref's guest ELF correctly (it just feeds the blob
+# as private input and reads the counters), so building it once is fine — indeed
+# preferable: the SAME counter reads both refs. In CI's issue_comment flow the checkout
+# has no explicit ref, so MEASURE_CLI is built from the repo default branch (main),
+# whose `cli` has `execute --cycles` with the keccak/ecsm counters (#807); that is
+# intentional — one stable counter applied identically to both refs.
 #
 # Improvement convention matches scripts/bench_verify.sh:
 #   NEGATIVE Δ  =  REF_A (PR) does fewer cycles/calls  =  better.
@@ -21,9 +31,14 @@
 # Usage: scripts/bench_recursion_cycles.sh REF_A [REF_B=origin/main] [PRESET=min]
 #   REF_A    ref/SHA to evaluate (the PR side).
 #   REF_B    baseline ref/SHA (default origin/main).
-#   PRESET   recursion-verifier preset (default min). The tool prefers
-#            recursion-<PRESET>.elf and falls back to recursion.elf on refs
-#            (older/main) that build a single unnamed recursion guest.
+#   PRESET   recursion-verifier preset (default min). Per ref the tool prefers
+#            recursion-<PRESET>.elf and falls back to recursion.elf (older refs / main
+#            build a single unnamed recursion guest). It is EXPECTED and correct for the
+#            two sides to use DIFFERENT artifacts — e.g. main→recursion.elf while a
+#            preset PR→recursion-min.elf — because both are verified under the SAME min
+#            proof options (the dump test pins MIN_PROOF_OPTIONS). The printed per-ref
+#            `guest=<artifact>` labels show which each side used; a differing name is the
+#            expected comparison, not a mismatch.
 #   Env:
 #     REBUILD=1            force rebuild of MEASURE_CLI and re-run of every ref
 #                          (guest build + blob dump + measurement); ignore caches.
@@ -33,10 +48,17 @@
 #                          build). Unset = per-worktree (default, fully isolated).
 #     HOST_TARGET_DIR=<p>  share the host cargo target dir for the blob-dump test
 #                          build across refs. Unset = per-worktree (default).
+#     PRUNE_KEEP=<n>       cap on cached ref worktrees kept under $WORK (default 10);
+#                          older ones (+ their results/blobs/logs) are pruned at startup
+#                          to bound disk on the long-lived bench runner.
 #
-# Caching: each ref's result is cached in $WORK keyed on its resolved SHA + preset,
-# so re-runs are fast. Ref worktrees are kept (named by SHA) so a re-measure is a
-# cargo no-op. REBUILD=1 forces everything.
+# Caching: each ref's result is cached in $WORK keyed on its resolved SHA + preset + the
+# MEASURE_CLI source SHA (so a baseline and PR side are never compared across two
+# different counters). Result files are written ATOMICALLY (tmp + mv) and VALIDATED on
+# read: a truncated/partial cache is discarded and re-measured, never emitted as zeros.
+# Ref worktrees are kept (named by SHA) so a re-measure is a cargo no-op; the newest
+# PRUNE_KEEP are retained and older ones pruned. A worktree whose guest build fails
+# mid-run is removed immediately. REBUILD=1 forces everything.
 #
 set -euo pipefail
 
@@ -51,12 +73,39 @@ REF_A="$1"
 REF_B="${2:-origin/main}"
 PRESET="${3:-min}"
 SYSROOT_DIR="${SYSROOT_DIR:-$HOME/.lambda-vm-sysroot}"
+PRUNE_KEEP="${PRUNE_KEEP:-10}"
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
 WORK="/tmp/recursion_cycles_run"
 mkdir -p "$WORK"
+
+# Bound the on-disk cache so the long-lived bench runner doesn't grow without limit.
+# Keep the PRUNE_KEEP most-recently-used ref worktrees (each is `touch`ed on use, so
+# "recent" tracks actual use, not creation) and drop older ones plus their cached
+# results/blobs/logs. This preserves the reuse speedup for recent refs while capping
+# disk; the big consumers are the worktrees (full checkout + build artifacts).
+prune_worktree_cache() {
+  local stale
+  # ls -t mtime-sort is the portable way to order by recency (BSD/GNU find can't do it
+  # without GNU-only -printf); names are wt_<sha8>, so word-splitting is safe here.
+  # shellcheck disable=SC2012
+  stale="$(ls -1dt "$WORK"/wt_* 2>/dev/null | tail -n +"$((PRUNE_KEEP + 1))" || true)"
+  [ -n "$stale" ] || return 0
+  local wt s8
+  while IFS= read -r wt; do
+    [ -n "$wt" ] || continue
+    s8="$(basename "$wt")"; s8="${s8#wt_}"
+    echo "==> Pruning old ref worktree $wt (keeping newest $PRUNE_KEEP)" >&2
+    git worktree remove --force "$wt" >/dev/null 2>&1 || rm -rf "$wt"
+    rm -f "$WORK"/result_"${s8}"_*.txt "$WORK"/blob_"${s8}"_*.bin \
+          "$WORK"/build_guest_"${s8}".log "$WORK"/dump_"${s8}".log \
+          "$WORK"/measure_"${s8}".err
+  done <<< "$stale"
+  git worktree prune >/dev/null 2>&1 || true
+}
+prune_worktree_cache
 
 echo "==> Refs"
 git fetch origin --quiet || echo "WARNING: 'git fetch origin' failed — resolving against possibly-stale local refs." >&2
@@ -72,10 +121,11 @@ if [ ! -d "$SYSROOT_DIR/lib" ]; then
   exit 1
 fi
 
-# --- 1. Build MEASURE_CLI once (release) from the current branch ---------------
-# This branch is based on feat/cycles-accelerator-counts, so `cli` here has
-# `execute --cycles` with the keccak/ecsm counters. Its executor is main's, so it
-# counts any ref's guest ELF correctly.
+# --- 1. Build MEASURE_CLI once (release) from the checkout we run in ------------
+# `cli` on main has `execute --cycles` with the keccak/ecsm counters (#807), so the
+# checkout this script runs in builds a counter that reads any ref's guest ELF
+# correctly. In CI's issue_comment flow the checkout is the default branch (main) — a
+# single stable counter for both refs, which is exactly what we want.
 HEAD_SHA="$(git rev-parse HEAD)"
 MEASURE_CLI="$WORK/measure_cli"
 if [ "${REBUILD:-0}" = "1" ] || [ ! -x "$MEASURE_CLI" ] || \
@@ -92,21 +142,45 @@ else
   echo "==> Reusing cached MEASURE_CLI (${HEAD_SHA:0:10})"
 fi
 
+# Validate a result record (key=value lines on stdin): the four numeric keys must be
+# present and integer, and elf must be non-empty. Exit 0 iff trustworthy. Used both to
+# vet a cached result before reuse and to guard the final table/RAW emit, so a
+# truncated/partial cache (e.g. a run killed mid-write) can never surface as bogus zeros.
+valid_result() {
+  awk -F= '
+    $1=="cycles" {c=$2} $1=="keccak" {k=$2} $1=="ecsm" {e=$2}
+    $1=="wall"   {w=$2} $1=="elf"    {f=$2}
+    END {
+      if (c ~ /^[0-9]+$/ && k ~ /^[0-9]+$/ && e ~ /^[0-9]+$/ &&
+          w ~ /^[0-9]+$/ && length(f) > 0) exit 0
+      exit 1
+    }'
+}
+
 # --- 2. Per-ref: worktree + guest build + blob dump + measurement ---------------
 # Prints progress to stderr; emits the parseable result block (key=value lines) to
 # stdout so the caller can capture it.
 measure_ref() {
   local ref="$1" sha="$2" role="$3"
   local sha8="${sha:0:8}"
-  local result="$WORK/result_${sha8}_${PRESET}.txt"
+  # Key the cache on ref SHA + preset AND the MEASURE_CLI source SHA, so a baseline and
+  # PR side measured by different counters (after a cli change) never share a result.
+  local result="$WORK/result_${sha8}_${PRESET}_m${HEAD_SHA:0:8}.txt"
+  local wt="$WORK/wt_${sha8}"
 
   if [ "${REBUILD:-0}" != "1" ] && [ -f "$result" ]; then
-    echo "==> [$role] Reusing cached measurement: $ref ($sha8) preset=$PRESET" >&2
-    cat "$result"
-    return 0
+    if valid_result < "$result"; then
+      echo "==> [$role] Reusing cached measurement: $ref ($sha8) preset=$PRESET" >&2
+      # Mark this ref as recently used so the startup prune keeps its worktree/result.
+      touch "$result" 2>/dev/null || true
+      if [ -d "$wt" ]; then touch "$wt" 2>/dev/null || true; fi
+      cat "$result"
+      return 0
+    fi
+    echo "==> [$role] Cached result corrupt/incomplete ($result) — discarding and re-measuring." >&2
+    rm -f "$result"
   fi
 
-  local wt="$WORK/wt_${sha8}"
   if [ ! -d "$wt" ]; then
     echo "==> [$role] Adding worktree $wt @ $sha8" >&2
     git worktree prune
@@ -115,22 +189,24 @@ measure_ref() {
     echo "==> [$role] Reusing worktree $wt (checkout -f $sha8)" >&2
     git -C "$wt" checkout --quiet -f "$sha"
   fi
+  touch "$wt" 2>/dev/null || true
 
-  # 2a. Build the recursion guest ELF(s) (+ empty.elf inner program).
+  # 2a. Build the recursion guest ELF(s) (+ empty.elf inner program). GUEST_TARGET_DIR,
+  # when set, shares the RV64 build dir across ref worktrees (reuses build-std).
   echo "==> [$role] make compile-recursion-elfs @ $sha8 (this can take 10-20 min the first time) ..." >&2
   local glog="$WORK/build_guest_${sha8}.log"
+  local -a make_args=(compile-recursion-elfs)
   if [ -n "${GUEST_TARGET_DIR:-}" ]; then
-    if ! ( cd "$wt" && SYSROOT_DIR="$SYSROOT_DIR" make compile-recursion-elfs "SHARED_TARGET_DIR=$GUEST_TARGET_DIR" ) >"$glog" 2>&1; then
-      echo "ERROR: [$role] 'make compile-recursion-elfs' failed for $ref ($sha8). Tail of $glog:" >&2
-      tail -40 "$glog" >&2
-      exit 1
-    fi
-  else
-    if ! ( cd "$wt" && SYSROOT_DIR="$SYSROOT_DIR" make compile-recursion-elfs ) >"$glog" 2>&1; then
-      echo "ERROR: [$role] 'make compile-recursion-elfs' failed for $ref ($sha8). Tail of $glog:" >&2
-      tail -40 "$glog" >&2
-      exit 1
-    fi
+    make_args+=("SHARED_TARGET_DIR=$GUEST_TARGET_DIR")
+  fi
+  if ! ( cd "$wt" && SYSROOT_DIR="$SYSROOT_DIR" make "${make_args[@]}" ) >"$glog" 2>&1; then
+    echo "ERROR: [$role] 'make compile-recursion-elfs' failed for $ref ($sha8). Tail of $glog:" >&2
+    tail -40 "$glog" >&2
+    # A failed build can leave a partial worktree; drop it so it never lingers or
+    # poisons a later reuse. (The startup prune also caps total worktrees.)
+    git worktree remove --force "$wt" >/dev/null 2>&1 || rm -rf "$wt"
+    git worktree prune >/dev/null 2>&1 || true
+    exit 1
   fi
 
   # 2b. Detect the guest ELF: prefer recursion-<PRESET>.elf, else recursion.elf.
@@ -199,19 +275,35 @@ measure_ref() {
   fi
   echo "==> [$role] cycles=$cyc keccak=$kec ecsm=$ecs  (execute wall-time ${dt}s)" >&2
 
+  # Write atomically (tmp + mv) so a run killed mid-write never leaves a half file that
+  # a later run would trust and parse as zeros.
   {
     printf 'cycles=%s\n' "$cyc"
     printf 'keccak=%s\n' "$kec"
     printf 'ecsm=%s\n' "$ecs"
     printf 'wall=%s\n' "$dt"
     printf 'elf=%s\n' "$(basename "$guest_elf")"
-  } > "$result"
+  } > "$result.tmp"
+  mv -f "$result.tmp" "$result"
   cat "$result"
 }
 
 # Baseline first, then PR (so a fresh GUEST_TARGET_DIR is warmed by the baseline).
 RES_B="$(measure_ref "$REF_B" "$SHA_B" baseline)"
 RES_A="$(measure_ref "$REF_A" "$SHA_A" PR)"
+
+# Guard the emit: refuse to print a table/RAW block from any incomplete/non-numeric
+# record. A truncated result must fail loudly here, never render as a bogus zero/-100%.
+if ! printf '%s\n' "$RES_B" | valid_result; then
+  echo "ERROR: baseline measurement is incomplete/non-numeric — refusing to emit a bogus table." >&2
+  printf '%s\n' "$RES_B" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$RES_A" | valid_result; then
+  echo "ERROR: PR measurement is incomplete/non-numeric — refusing to emit a bogus table." >&2
+  printf '%s\n' "$RES_A" >&2
+  exit 1
+fi
 
 getv() { printf '%s\n' "$1" | awk -F= -v k="$2" '$1==k{print $2; exit}'; }
 CYC_B="$(getv "$RES_B" cycles)"; KEC_B="$(getv "$RES_B" keccak)"; ECS_B="$(getv "$RES_B" ecsm)"
@@ -235,6 +327,11 @@ echo
 echo "=== Recursion-guest cycle/accelerator comparison (deterministic, exact) ==="
 echo "   REF_B (baseline) $REF_B  ${SHA_B:0:10}  guest=$ELF_B"
 echo "   REF_A (PR)       $REF_A  ${SHA_A:0:10}  guest=$ELF_A"
+if [ "$ELF_A" != "$ELF_B" ]; then
+  echo "   note: the sides used different guest artifacts ($ELF_B vs $ELF_A). This is EXPECTED"
+  echo "         for a preset PR (e.g. main→recursion.elf vs PR→recursion-min.elf); both verify"
+  echo "         under the same min proof options, so it is a valid comparison, not a mismatch."
+fi
 echo "   preset=$PRESET   convention: - = PR fewer = better"
 echo
 echo "| Metric        | REF_B (baseline) | REF_A (PR) | Δ (A-B) |"


### PR DESCRIPTION
## What this adds

`/bench-verify` already posts the interleaved A/B/B/A verifier wall-time comparison
(PR vs `main`) as a single marker comment. This wires the **recursion-guest cycle +
accelerator diff** into the same flow so reviewers get both numbers in one place.

After the existing "Run verifier benchmark" step, a new step runs:

```
scripts/bench_recursion_cycles.sh "$HEAD_SHA" origin/main min
```

and the existing "Post result" github-script step appends a
**"Recursion guest cycles (main vs PR)"** section — the comparison table plus the
machine-parseable `=== RAW ===` block — to the *same* marker comment (no second
comment is posted).

## Why it's a clean signal

The recursion guest is the in-VM STARK verifier. For a fixed (guest ELF, input blob)
its cost is fully **deterministic**, so comparing two refs is two **exact** integer
readings — no A/B/B/A interleaving is needed (unlike the wall-time verifier bench).
Each ref reports guest cycles, keccak-permutation accel calls, and ecsm accel calls.
Convention matches `bench_verify.sh`: **`-` = PR does fewer = better.**

Local validation (main vs #782):

| Metric       | main          | PR (#782)   | Δ (PR − main)          |
|--------------|---------------|-------------|------------------------|
| Guest cycles | 5,239,681,960 | 116,724,803 | −5,122,957,157 (−97.77%) |
| Keccak calls | 0             | 0           | 0                      |
| Ecsm calls   | 0             | 0           | 0                      |

keccak/ecsm are `0` because this recursion verifier uses Poseidon2 (no keccak/ecsm
accelerator ecalls) — the counters are wired and will be non-zero for guests that use
those accelerators.

## Failure isolation

The recursion step is purely **additive** and cannot affect the verifier verdict:

- `continue-on-error: true` — a recursion-bench failure never fails the job.
- `if: ${{ !cancelled() }}` — it still runs if the verifier step failed, but respects
  concurrency cancellation.
- The "Post result" step reads `steps.recursion.outcome`; on failure it appends a
  clearly-separated `⚠️` note with the log tail instead of the table, and the verifier
  section above is untouched.

`scripts/bench_verify.sh` and the wall-time logic are **unchanged**.

## Cost

The measurement itself is ~1 min (one `execute --cycles` per ref). The recursion guest
builds dominate: ~10–20 min per ref the first time on a fresh runner, cached in `/tmp`
for later runs. The job `timeout-minutes` is bumped 60 → 90 for the cold first run; the
bench runner already serializes benches.

## Dependency

Stacked on #807 (`feat/cycles-accelerator-counts`) for the accel-counting
`cli execute --cycles`. **Rebase to `main` after #807 merges.**
