### PR TITLE
ci: actually run the ethrex host-reference tests

### DIFF
--- a/.github/workflows/pr_main.yaml
+++ b/.github/workflows/pr_main.yaml
@@ -99,8 +99,17 @@ jobs:
 
       - name: Run ignored executor tests
         run: |
-          cargo test --release -p executor test_ethrex -- --ignored
           cargo test --release -p executor test_ckzg -- --ignored
+
+      # ethrex host-reference tests live in the detached `tooling/ethrex-tests`
+      # workspace (ethrex pins rkyv's `unaligned` feature, which must not
+      # feature-unify with the main workspace's aligned proof format), so run
+      # them from that directory to use its isolated Cargo.lock. The guest ELF
+      # and committed fixtures are already present from the steps above.
+      # --include-ignored also runs the heavier synthetic-block test.
+      - name: Run ethrex host-reference tests (detached workspace)
+        run: |
+          cd tooling/ethrex-tests && cargo test --release -- --include-ignored
 
   test-cli:
     name: CLI tests

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: deps deps-linux deps-macos compile-programs-asm compile-programs-rust compile-bench \
 compile-programs compile-recursion-elfs clean-asm clean-rust clean-bench clean-shared \
 clean-recursion-elfs clean test test-asm \
-test-rust test-executor test-flamegraph flamegraph-prover test-profile-recursion test-profile-recursion-single test-profile-recursion-multi \
+test-rust test-ethrex test-executor test-flamegraph flamegraph-prover test-profile-recursion test-profile-recursion-single test-profile-recursion-multi \
 test-fast test-prover test-prover-all test-prover-debug test-disk-spill test-math-cuda test-cuda-integration test-cuda-fallback \
 test-prover-cuda test-prover-comprehensive-cuda \
 bench-math-cuda bench-prover bench-prover-cuda build check clippy fmt lint regen-ethrex-fixtures \
@@ -261,6 +261,11 @@ test-asm: compile-programs-asm
 
 test-rust: compile-programs-rust
 	cargo test -p executor --test rust
+
+# ethrex host-reference tests live in the detached `tooling/ethrex-tests`
+# workspace (ethrex pins rkyv's `unaligned` feature; isolated Cargo.lock).
+test-ethrex: compile-programs-rust
+	cd tooling/ethrex-tests && cargo test --release -- --include-ignored
 
 test-flamegraph:
 	cargo test -p executor --test flamegraph


### PR DESCRIPTION
From the PR #769 review. The ethrex host-reference tests (`test_ethrex`, `test_ethrex_simple_tx`, `test_ethrex_empty_block`) were relocated from the `executor` crate into the detached `tooling/ethrex-tests` workspace, but **nothing runs it** — no CI job, no Makefile target — and CI still had `cargo test --release -p executor test_ethrex -- --ignored`, which now matches **zero** tests and exits green. Net: the ethrex guest/host rkyv `ProgramInput` cross-check ran nowhere, and the detached crate wasn't even compile-checked, so any ethrex-rev bump or rkyv-layout drift would ship undetected.

## Change
- **`pr_main.yaml`**: drop the vacuous `test_ethrex` line (kept `test_ckzg`), add a step that runs the detached workspace: `cd tooling/ethrex-tests && cargo test --release -- --include-ignored`. Running from that directory uses its isolated `Cargo.lock`, keeping the rkyv `unaligned`/`aligned` feature conflict contained (the reason the workspace was detached in the first place). `--include-ignored` also runs the heavier synthetic-block test. This step also compile-checks the crate, so it can no longer silently rot.
- **`Makefile`**: add a matching `test-ethrex` target (prereq `compile-programs-rust` for the guest ELF) and register it in `.PHONY`.

## What I could NOT verify locally
I can't run GitHub CI here, so I haven't confirmed the step goes green end-to-end (it pulls an ethrex git dep and does a fresh host build of the detached crate). Validated: `make -n test-ethrex` resolves correctly, the YAML parses, and the ELF/fixtures the crate reads are produced by the preceding rust-ELF steps. **Please confirm the first CI run is green.** One known caveat: `Swatinem/rust-cache` caches the root workspace target, not `tooling/ethrex-tests/target`, so this crate recompiles each run (a few minutes) — acceptable, and roughly the pre-PR baseline since `executor` already depended on the ethrex guest crate. If the recompile time is a problem, adding `tooling/ethrex-tests -> target` to the rust-cache `workspaces` input is the fix.