### PR TITLE
harden(syscalls): clamp private-input length to MAX_PRIVATE_INPUT_SIZE

### DIFF
--- a/syscalls/src/syscalls.rs
+++ b/syscalls/src/syscalls.rs
@@ -8,6 +8,15 @@ use core::arch::asm;
 #[cfg(target_arch = "riscv64")]
 pub const PRIVATE_INPUT_START: usize = 0xFF000000;
 
+/// Maximum private-input length the guest will read, in bytes (64 MiB).
+/// The host caps stored input at this size in `Memory::store_private_inputs`,
+/// so an honest length prefix is always `<=` this bound; a larger value can only
+/// come from a malformed or forged prefix. The reader clamps to this cap so a
+/// bogus length can never make the guest fabricate an arbitrarily long slice.
+/// Must match `executor::vm::memory::MAX_PRIVATE_INPUT_SIZE`.
+#[cfg(target_arch = "riscv64")]
+const MAX_PRIVATE_INPUT_SIZE: usize = 64 * 1024 * 1024;
+
 #[cfg(target_arch = "riscv64")]
 pub enum SyscallNumbers {
     Print = 1,
@@ -104,7 +113,12 @@ pub fn get_private_input_slice() -> &'static [u8] {
     // for the `'static` lifetime of the guest's single-threaded execution
     // region, which stays mapped and unmodified for the whole execution.
     let len_ptr = PRIVATE_INPUT_START as *const u32;
-    let len = unsafe { core::ptr::read_volatile(len_ptr) } as usize;
+    // Clamp the prover-written length prefix to `MAX_PRIVATE_INPUT_SIZE`. An
+    // honest prefix (written by the host, which caps stored input at this size)
+    // is always within bound, so clamping never changes behavior for real
+    // inputs — it only bounds the slice length when a malformed or forged prefix
+    // claims more, keeping the read deterministic.
+    let len = (unsafe { core::ptr::read_volatile(len_ptr) } as usize).min(MAX_PRIVATE_INPUT_SIZE);
     let data_ptr = (PRIVATE_INPUT_START + 4) as *const u8;
     unsafe { core::slice::from_raw_parts(data_ptr, len) }
 }


### PR DESCRIPTION
From the PR #769 review. `get_private_input_slice` reads a prover-controlled `u32` length prefix and builds a `&'static [u8]` of that length with no upper bound. This clamps it to 64 MiB — the same `MAX_PRIVATE_INPUT_SIZE` the host enforces in `Memory::store_private_inputs`. An honest length is always within bound (the host caps it at store time), so the clamp never changes behavior for real inputs; it only bounds the slice when a malformed or forged prefix claims more.

## Honest framing — this is the weakest of the review's findings
It is **defense-in-depth, not a fix for a reachable bug**:
- On 64-bit the `u32` length can't overflow the pointer range, so `from_raw_parts`'s preconditions already held; there's no UB today.
- No writable guest region overlaps the oversized span (heap/stack are elsewhere; unmapped cells read deterministic zeros), so an oversized read is benign.
- It is **not a security boundary**: in the recursion threat model the prover controls the guest binary and the whole input region, so a malicious prover could simply remove the clamp. Its value is robustness of honest guest builds against a corrupted length word, plus a self-documenting invariant at the read site.

By the same "a guard can't defend against code you'd reject at review" logic we applied to the dropped `CanonicalAgnosticField` change, this is a legitimate candidate to **skip**. Putting it up per request so it's your call; a one-line documented-precondition comment would be ~90% of the value if you'd rather not carry the constant.

## Verification
Host `make lint` clean. The change is guest-only (`riscv64`-gated) and is a trivial `.min()` on a `usize`, so it compiles by construction; I could not reproduce the full guest-target build in my environment (the `/opt/lambda-vm-sysroot` isn't installed here), but the identical change was guest-compiled during the review, and CI's guest-program build exercises it.