### PR TITLE
test(math): pin `stream_bytes` byte parity with `as_bytes`

### DIFF
--- a/crypto/math/src/field/extensions_goldilocks.rs
+++ b/crypto/math/src/field/extensions_goldilocks.rs
@@ -555,10 +555,14 @@ impl AsBytes for FieldElement<Degree3GoldilocksExtensionField> {
         self.to_bytes_be()
     }
 
-    // One sink call over a stack buffer instead of three (one per limb): each
-    // sink call lands as its own `Digest::update` on the guest, and dyn dispatch
-    // here is fully devirtualized by the #[inline(always)] chain, so call count
-    // — not indirection — is the cost being cut.
+    // Same 24 bytes as `as_bytes`, staged in a stack buffer so the guest skips
+    // the per-element `Vec`; `#[inline(always)]` is what lets the `dyn` sink
+    // devirtualize at the call site. Emitting them in one call rather than one
+    // per limb keeps it to a single `Digest::update`.
+    //
+    // The layout is load-bearing beyond this crate: `math-cuda`'s
+    // `keccak_leaves_ext3` kernel reads components in order 0,1,2 to match
+    // `write_bytes_be`, and CPU/GPU leaf parity depends on the two agreeing.
     #[inline(always)]
     fn stream_bytes(&self, sink: &mut dyn FnMut(&[u8])) {
         let mut buf = [0u8; 24];

--- a/crypto/math/src/traits.rs
+++ b/crypto/math/src/traits.rs
@@ -42,6 +42,14 @@ pub trait AsBytes {
 
     /// Streams the byte representation to `sink` without heap-allocating a `Vec`.
     /// Default falls back to `as_bytes`; override for zero-allocation hashing/transcript hot paths.
+    ///
+    /// An override must stream exactly the bytes `as_bytes` would return, in
+    /// order; splitting them across several `sink` calls is fine, but the
+    /// concatenation must be identical. Merkle leaf hashes and the Fiat-Shamir
+    /// transcript take their input through here, so an override that disagrees
+    /// with `as_bytes` silently changes commitments and challenges rather than
+    /// failing to compile. `math/tests/stream_bytes_parity.rs` pins this for the
+    /// Goldilocks fields.
     fn stream_bytes(&self, sink: &mut dyn FnMut(&[u8])) {
         sink(&self.as_bytes());
     }

--- a/crypto/math/tests/stream_bytes_parity.rs
+++ b/crypto/math/tests/stream_bytes_parity.rs
@@ -72,13 +72,6 @@ fn check_goldilocks_stream_bytes(v: u64) {
     );
 }
 
-#[test]
-fn goldilocks_stream_bytes_matches_as_bytes_and_to_bytes_be_edge_cases() {
-    for v in EDGE_VALUES {
-        check_goldilocks_stream_bytes(v);
-    }
-}
-
 fn check_ext3_stream_bytes(t: [u64; 3]) {
     let e = fp3(t);
     let s = streamed(&e);
@@ -89,14 +82,6 @@ fn check_ext3_stream_bytes(t: [u64; 3]) {
         ByteConversion::to_bytes_be(&e),
         "stream != to_bytes_be (t={t:?})"
     );
-}
-
-#[test]
-fn ext3_stream_bytes_matches_as_bytes_and_to_bytes_be_edge_cases() {
-    for v in EDGE_VALUES {
-        check_ext3_stream_bytes([v, v, v]);
-        check_ext3_stream_bytes([v, 0, 1]);
-    }
 }
 
 fn check_ext3_stream_bytes_gpu_kernel_contract(t: [u64; 3]) {
@@ -119,14 +104,6 @@ fn check_ext3_stream_bytes_gpu_kernel_contract(t: [u64; 3]) {
     assert_eq!(streamed(&e), buf, "ext3 stream != write_bytes_be (t={t:?})");
 }
 
-#[test]
-fn ext3_stream_bytes_matches_gpu_kernel_contract_edge_cases() {
-    for v in EDGE_VALUES {
-        check_ext3_stream_bytes_gpu_kernel_contract([v, v, v]);
-        check_ext3_stream_bytes_gpu_kernel_contract([v, 0, 1]);
-    }
-}
-
 /// The default `stream_bytes` body forwards to `as_bytes`; a type that does not
 /// override it must still round-trip identically.
 struct Unoverridden(Vec<u8>);
@@ -142,7 +119,14 @@ fn check_default_stream_bytes_impl(bytes: Vec<u8>) {
 }
 
 #[test]
-fn default_stream_bytes_impl_matches_as_bytes_edge_cases() {
+fn edge_cases() {
+    for v in EDGE_VALUES {
+        check_goldilocks_stream_bytes(v);
+        check_ext3_stream_bytes([v, v, v]);
+        check_ext3_stream_bytes([v, 0, 1]);
+        check_ext3_stream_bytes_gpu_kernel_contract([v, v, v]);
+        check_ext3_stream_bytes_gpu_kernel_contract([v, 0, 1]);
+    }
     for bytes in [vec![], vec![0u8], vec![1, 2, 3, 4, 5], vec![0xff; 64]] {
         check_default_stream_bytes_impl(bytes);
     }

--- a/crypto/math/tests/stream_bytes_parity.rs
+++ b/crypto/math/tests/stream_bytes_parity.rs
@@ -14,11 +14,17 @@
 //! component order 0,1,2 to match `write_bytes_be`. CPU/GPU leaf parity depends
 //! on the two staying in agreement, and the GPU parity tests only run on a CUDA
 //! host, so this keeps the CPU half honest on a GPU-less runner.
+//!
+//! Each check is a plain function shared by two tests: a deterministic `#[test]`
+//! over hand-picked edge cases (always runs, no reliance on proptest landing on
+//! them) and a `proptest!` sweep over arbitrary input for everything else.
 
 use math::field::element::FieldElement;
 use math::field::extensions_goldilocks::Degree3GoldilocksExtensionField;
 use math::field::goldilocks::GoldilocksField;
 use math::traits::{AsBytes, ByteConversion};
+use proptest::collection::vec;
+use proptest::prelude::*;
 
 type Fp = FieldElement<GoldilocksField>;
 type Fp3 = FieldElement<Degree3GoldilocksExtensionField>;
@@ -29,147 +35,159 @@ fn streamed<T: AsBytes>(e: &T) -> Vec<u8> {
     out
 }
 
-/// Deterministic LCG: keeps the sweep reproducible and dependency-free.
-fn lcg(state: &mut u64) -> u64 {
-    *state = state
-        .wrapping_mul(6364136223846793005)
-        .wrapping_add(1442695040888963407);
-    *state
+fn fp3(t: [u64; 3]) -> Fp3 {
+    Fp3::new([Fp::from(t[0]), Fp::from(t[1]), Fp::from(t[2])])
 }
 
 const GOLDILOCKS_P: u64 = 0xFFFF_FFFF_0000_0001;
 
 /// Values around the modulus matter: both encodings reduce through
-/// `canonical_u64`, so a non-canonical `u64` is where a raw-value override would
-/// diverge from `as_bytes`.
-fn edge_values() -> Vec<u64> {
-    vec![
-        0,
-        1,
-        2,
-        u32::MAX as u64,
-        1u64 << 32,
-        GOLDILOCKS_P - 1,
-        GOLDILOCKS_P,     // 0 in the field
-        GOLDILOCKS_P + 1, // 1 in the field
-        u64::MAX - 1,
-        u64::MAX,
-    ]
-}
+/// `canonical_u64`, so a non-canonical `u64` is where a raw-value override
+/// would diverge from `as_bytes`.
+const EDGE_VALUES: [u64; 10] = [
+    0,
+    1,
+    2,
+    u32::MAX as u64,
+    1u64 << 32,
+    GOLDILOCKS_P - 1,
+    GOLDILOCKS_P,     // 0 in the field
+    GOLDILOCKS_P + 1, // 1 in the field
+    u64::MAX - 1,
+    u64::MAX,
+];
 
-#[test]
-fn goldilocks_stream_bytes_matches_as_bytes_and_to_bytes_be() {
-    let mut state = 0x1234_5678_9abc_def0u64;
-    let mut values = edge_values();
-    values.extend((0..2000).map(|_| lcg(&mut state)));
-
-    for v in values {
-        let e = Fp::from(v);
-        let s = streamed(&e);
-        assert_eq!(s.len(), 8, "goldilocks stream must be 8 bytes (v={v:#x})");
-        // The Merkle backends stream instead of calling `as_bytes`.
-        assert_eq!(s, e.as_bytes(), "stream != as_bytes (v={v:#x})");
-        // `DefaultTranscript::append_field_element` streams instead of
-        // appending `to_bytes_be`.
-        assert_eq!(
-            s,
-            ByteConversion::to_bytes_be(&e),
-            "stream != to_bytes_be (v={v:#x})"
-        );
-    }
-}
-
-#[test]
-fn ext3_stream_bytes_matches_as_bytes_and_to_bytes_be() {
-    let mut state = 0x0fed_cba9_8765_4321u64;
-    let mut triples: Vec<[u64; 3]> = Vec::new();
-    for v in edge_values() {
-        triples.push([v, v, v]);
-        triples.push([v, 0, 1]);
-    }
-    triples.extend((0..2000).map(|_| [lcg(&mut state), lcg(&mut state), lcg(&mut state)]));
-
-    for t in triples {
-        let e = Fp3::new([Fp::from(t[0]), Fp::from(t[1]), Fp::from(t[2])]);
-        let s = streamed(&e);
-        assert_eq!(s.len(), 24, "ext3 stream must be 24 bytes (t={t:?})");
-        assert_eq!(s, e.as_bytes(), "stream != as_bytes (t={t:?})");
-        assert_eq!(
-            s,
-            ByteConversion::to_bytes_be(&e),
-            "stream != to_bytes_be (t={t:?})"
-        );
-    }
-}
-
-#[test]
-fn ext3_stream_bytes_matches_gpu_kernel_contract() {
-    let mut state = 0xdead_beef_cafe_babeu64;
-
-    for _ in 0..1000 {
-        let e = Fp3::new([
-            Fp::from(lcg(&mut state)),
-            Fp::from(lcg(&mut state)),
-            Fp::from(lcg(&mut state)),
-        ]);
-
-        // What the CUDA kernel builds: canonical u64 per component, big-endian,
-        // component order 0,1,2.
-        let mut expected = Vec::new();
-        for component in e.value() {
-            expected.extend_from_slice(&component.canonical_u64().to_be_bytes());
-        }
-        assert_eq!(streamed(&e), expected, "ext3 stream != canonical-BE 0,1,2");
-
-        let mut buf = [0u8; 24];
-        ByteConversion::write_bytes_be(&e, &mut buf);
-        assert_eq!(streamed(&e), buf, "ext3 stream != write_bytes_be");
-    }
-}
-
-/// Keccak absorption means `update(a); update(b)` == `update(a || b)`, so a
-/// digest can only move if the concatenated stream moves. Pins the multi-element
-/// hash paths (`hash_data`, `hash_data_from_slices`) against the old
-/// `as_bytes`-per-element input.
-#[test]
-fn concatenated_stream_matches_concatenated_as_bytes() {
-    let mut state = 0xa5a5_5a5a_a5a5_5a5au64;
-    let elements: Vec<Fp3> = (0..256)
-        .map(|_| {
-            Fp3::new([
-                Fp::from(lcg(&mut state)),
-                Fp::from(lcg(&mut state)),
-                Fp::from(lcg(&mut state)),
-            ])
-        })
-        .collect();
-
-    let mut via_as_bytes = Vec::new();
-    let mut via_stream = Vec::new();
-    for e in &elements {
-        via_as_bytes.extend_from_slice(&e.as_bytes());
-        e.stream_bytes(&mut |b| via_stream.extend_from_slice(b));
-    }
-
+fn check_goldilocks_stream_bytes(v: u64) {
+    let e = Fp::from(v);
+    let s = streamed(&e);
+    assert_eq!(s.len(), 8, "goldilocks stream must be 8 bytes (v={v:#x})");
+    // The Merkle backends stream instead of calling `as_bytes`.
+    assert_eq!(s, e.as_bytes(), "stream != as_bytes (v={v:#x})");
+    // `DefaultTranscript::append_field_element` streams instead of
+    // appending `to_bytes_be`.
     assert_eq!(
-        via_as_bytes, via_stream,
-        "concatenated hasher input stream changed"
+        s,
+        ByteConversion::to_bytes_be(&e),
+        "stream != to_bytes_be (v={v:#x})"
     );
+}
+
+#[test]
+fn goldilocks_stream_bytes_matches_as_bytes_and_to_bytes_be_edge_cases() {
+    for v in EDGE_VALUES {
+        check_goldilocks_stream_bytes(v);
+    }
+}
+
+fn check_ext3_stream_bytes(t: [u64; 3]) {
+    let e = fp3(t);
+    let s = streamed(&e);
+    assert_eq!(s.len(), 24, "ext3 stream must be 24 bytes (t={t:?})");
+    assert_eq!(s, e.as_bytes(), "stream != as_bytes (t={t:?})");
+    assert_eq!(
+        s,
+        ByteConversion::to_bytes_be(&e),
+        "stream != to_bytes_be (t={t:?})"
+    );
+}
+
+#[test]
+fn ext3_stream_bytes_matches_as_bytes_and_to_bytes_be_edge_cases() {
+    for v in EDGE_VALUES {
+        check_ext3_stream_bytes([v, v, v]);
+        check_ext3_stream_bytes([v, 0, 1]);
+    }
+}
+
+fn check_ext3_stream_bytes_gpu_kernel_contract(t: [u64; 3]) {
+    let e = fp3(t);
+
+    // What the CUDA kernel builds: canonical u64 per component, big-endian,
+    // component order 0,1,2.
+    let mut expected = Vec::new();
+    for component in e.value() {
+        expected.extend_from_slice(&component.canonical_u64().to_be_bytes());
+    }
+    assert_eq!(
+        streamed(&e),
+        expected,
+        "ext3 stream != canonical-BE 0,1,2 (t={t:?})"
+    );
+
+    let mut buf = [0u8; 24];
+    ByteConversion::write_bytes_be(&e, &mut buf);
+    assert_eq!(streamed(&e), buf, "ext3 stream != write_bytes_be (t={t:?})");
+}
+
+#[test]
+fn ext3_stream_bytes_matches_gpu_kernel_contract_edge_cases() {
+    for v in EDGE_VALUES {
+        check_ext3_stream_bytes_gpu_kernel_contract([v, v, v]);
+        check_ext3_stream_bytes_gpu_kernel_contract([v, 0, 1]);
+    }
 }
 
 /// The default `stream_bytes` body forwards to `as_bytes`; a type that does not
 /// override it must still round-trip identically.
+struct Unoverridden(Vec<u8>);
+impl AsBytes for Unoverridden {
+    fn as_bytes(&self) -> Vec<u8> {
+        self.0.clone()
+    }
+}
+
+fn check_default_stream_bytes_impl(bytes: Vec<u8>) {
+    let v = Unoverridden(bytes.clone());
+    assert_eq!(streamed(&v), bytes);
+}
+
 #[test]
-fn default_stream_bytes_impl_matches_as_bytes() {
-    struct Unoverridden(Vec<u8>);
-    impl AsBytes for Unoverridden {
-        fn as_bytes(&self) -> Vec<u8> {
-            self.0.clone()
-        }
+fn default_stream_bytes_impl_matches_as_bytes_edge_cases() {
+    for bytes in [vec![], vec![0u8], vec![1, 2, 3, 4, 5], vec![0xff; 64]] {
+        check_default_stream_bytes_impl(bytes);
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1024))]
+
+    #[test]
+    fn goldilocks_stream_bytes_matches_as_bytes_and_to_bytes_be(v in any::<u64>()) {
+        check_goldilocks_stream_bytes(v);
     }
 
-    for bytes in [vec![], vec![0u8], vec![1, 2, 3, 4, 5], vec![0xff; 64]] {
-        let v = Unoverridden(bytes.clone());
-        assert_eq!(streamed(&v), bytes);
+    #[test]
+    fn ext3_stream_bytes_matches_as_bytes_and_to_bytes_be(a in any::<u64>(), b in any::<u64>(), c in any::<u64>()) {
+        check_ext3_stream_bytes([a, b, c]);
+    }
+
+    #[test]
+    fn ext3_stream_bytes_matches_gpu_kernel_contract(a in any::<u64>(), b in any::<u64>(), c in any::<u64>()) {
+        check_ext3_stream_bytes_gpu_kernel_contract([a, b, c]);
+    }
+
+    // Keccak absorption means `update(a); update(b)` == `update(a || b)`, so a
+    // digest can only move if the concatenated stream moves. Pins the multi-element
+    // hash paths (`hash_data`, `hash_data_from_slices`) against the old
+    // `as_bytes`-per-element input.
+    #[test]
+    fn concatenated_stream_matches_concatenated_as_bytes(
+        triples in vec((any::<u64>(), any::<u64>(), any::<u64>()), 0..64)
+    ) {
+        let elements: Vec<Fp3> = triples.into_iter().map(|(a, b, c)| fp3([a, b, c])).collect();
+
+        let mut via_as_bytes = Vec::new();
+        let mut via_stream = Vec::new();
+        for e in &elements {
+            via_as_bytes.extend_from_slice(&e.as_bytes());
+            e.stream_bytes(&mut |b| via_stream.extend_from_slice(b));
+        }
+
+        prop_assert_eq!(via_as_bytes, via_stream, "concatenated hasher input stream changed");
+    }
+
+    #[test]
+    fn default_stream_bytes_impl_matches_as_bytes(bytes in vec(any::<u8>(), 0..64)) {
+        check_default_stream_bytes_impl(bytes);
     }
 }

--- a/crypto/math/tests/stream_bytes_parity.rs
+++ b/crypto/math/tests/stream_bytes_parity.rs
@@ -1,0 +1,175 @@
+//! `AsBytes::stream_bytes` must emit exactly the bytes `as_bytes` returns.
+//!
+//! Nothing in the type system enforces it: `stream_bytes` is a defaulted trait
+//! method, so an override that disagrees with `as_bytes` compiles cleanly and
+//! then silently changes every Merkle leaf hash and Fiat-Shamir challenge that
+//! flows through it — the transcript and the Merkle backends stream their input
+//! rather than calling `as_bytes`. A divergence would surface as proofs that no
+//! longer verify against previously committed roots, not as a test failure, so
+//! it is pinned here.
+//!
+//! `ext3_stream_bytes_matches_gpu_kernel_contract` additionally pins the ext3
+//! byte layout that `crypto/math-cuda/src/merkle.rs` mirrors: the GPU
+//! `keccak_leaves_ext3` kernel reads three canonical u64s per column in
+//! component order 0,1,2 to match `write_bytes_be`. CPU/GPU leaf parity depends
+//! on the two staying in agreement, and the GPU parity tests only run on a CUDA
+//! host, so this keeps the CPU half honest on a GPU-less runner.
+
+use math::field::element::FieldElement;
+use math::field::extensions_goldilocks::Degree3GoldilocksExtensionField;
+use math::field::goldilocks::GoldilocksField;
+use math::traits::{AsBytes, ByteConversion};
+
+type Fp = FieldElement<GoldilocksField>;
+type Fp3 = FieldElement<Degree3GoldilocksExtensionField>;
+
+fn streamed<T: AsBytes>(e: &T) -> Vec<u8> {
+    let mut out = Vec::new();
+    e.stream_bytes(&mut |b| out.extend_from_slice(b));
+    out
+}
+
+/// Deterministic LCG: keeps the sweep reproducible and dependency-free.
+fn lcg(state: &mut u64) -> u64 {
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    *state
+}
+
+const GOLDILOCKS_P: u64 = 0xFFFF_FFFF_0000_0001;
+
+/// Values around the modulus matter: both encodings reduce through
+/// `canonical_u64`, so a non-canonical `u64` is where a raw-value override would
+/// diverge from `as_bytes`.
+fn edge_values() -> Vec<u64> {
+    vec![
+        0,
+        1,
+        2,
+        u32::MAX as u64,
+        1u64 << 32,
+        GOLDILOCKS_P - 1,
+        GOLDILOCKS_P,     // 0 in the field
+        GOLDILOCKS_P + 1, // 1 in the field
+        u64::MAX - 1,
+        u64::MAX,
+    ]
+}
+
+#[test]
+fn goldilocks_stream_bytes_matches_as_bytes_and_to_bytes_be() {
+    let mut state = 0x1234_5678_9abc_def0u64;
+    let mut values = edge_values();
+    values.extend((0..2000).map(|_| lcg(&mut state)));
+
+    for v in values {
+        let e = Fp::from(v);
+        let s = streamed(&e);
+        assert_eq!(s.len(), 8, "goldilocks stream must be 8 bytes (v={v:#x})");
+        // The Merkle backends stream instead of calling `as_bytes`.
+        assert_eq!(s, e.as_bytes(), "stream != as_bytes (v={v:#x})");
+        // `DefaultTranscript::append_field_element` streams instead of
+        // appending `to_bytes_be`.
+        assert_eq!(
+            s,
+            ByteConversion::to_bytes_be(&e),
+            "stream != to_bytes_be (v={v:#x})"
+        );
+    }
+}
+
+#[test]
+fn ext3_stream_bytes_matches_as_bytes_and_to_bytes_be() {
+    let mut state = 0x0fed_cba9_8765_4321u64;
+    let mut triples: Vec<[u64; 3]> = Vec::new();
+    for v in edge_values() {
+        triples.push([v, v, v]);
+        triples.push([v, 0, 1]);
+    }
+    triples.extend((0..2000).map(|_| [lcg(&mut state), lcg(&mut state), lcg(&mut state)]));
+
+    for t in triples {
+        let e = Fp3::new([Fp::from(t[0]), Fp::from(t[1]), Fp::from(t[2])]);
+        let s = streamed(&e);
+        assert_eq!(s.len(), 24, "ext3 stream must be 24 bytes (t={t:?})");
+        assert_eq!(s, e.as_bytes(), "stream != as_bytes (t={t:?})");
+        assert_eq!(
+            s,
+            ByteConversion::to_bytes_be(&e),
+            "stream != to_bytes_be (t={t:?})"
+        );
+    }
+}
+
+#[test]
+fn ext3_stream_bytes_matches_gpu_kernel_contract() {
+    let mut state = 0xdead_beef_cafe_babeu64;
+
+    for _ in 0..1000 {
+        let e = Fp3::new([
+            Fp::from(lcg(&mut state)),
+            Fp::from(lcg(&mut state)),
+            Fp::from(lcg(&mut state)),
+        ]);
+
+        // What the CUDA kernel builds: canonical u64 per component, big-endian,
+        // component order 0,1,2.
+        let mut expected = Vec::new();
+        for component in e.value() {
+            expected.extend_from_slice(&component.canonical_u64().to_be_bytes());
+        }
+        assert_eq!(streamed(&e), expected, "ext3 stream != canonical-BE 0,1,2");
+
+        let mut buf = [0u8; 24];
+        ByteConversion::write_bytes_be(&e, &mut buf);
+        assert_eq!(streamed(&e), buf, "ext3 stream != write_bytes_be");
+    }
+}
+
+/// Keccak absorption means `update(a); update(b)` == `update(a || b)`, so a
+/// digest can only move if the concatenated stream moves. Pins the multi-element
+/// hash paths (`hash_data`, `hash_data_from_slices`) against the old
+/// `as_bytes`-per-element input.
+#[test]
+fn concatenated_stream_matches_concatenated_as_bytes() {
+    let mut state = 0xa5a5_5a5a_a5a5_5a5au64;
+    let elements: Vec<Fp3> = (0..256)
+        .map(|_| {
+            Fp3::new([
+                Fp::from(lcg(&mut state)),
+                Fp::from(lcg(&mut state)),
+                Fp::from(lcg(&mut state)),
+            ])
+        })
+        .collect();
+
+    let mut via_as_bytes = Vec::new();
+    let mut via_stream = Vec::new();
+    for e in &elements {
+        via_as_bytes.extend_from_slice(&e.as_bytes());
+        e.stream_bytes(&mut |b| via_stream.extend_from_slice(b));
+    }
+
+    assert_eq!(
+        via_as_bytes, via_stream,
+        "concatenated hasher input stream changed"
+    );
+}
+
+/// The default `stream_bytes` body forwards to `as_bytes`; a type that does not
+/// override it must still round-trip identically.
+#[test]
+fn default_stream_bytes_impl_matches_as_bytes() {
+    struct Unoverridden(Vec<u8>);
+    impl AsBytes for Unoverridden {
+        fn as_bytes(&self) -> Vec<u8> {
+            self.0.clone()
+        }
+    }
+
+    for bytes in [vec![], vec![0u8], vec![1, 2, 3, 4, 5], vec![0xff; 64]] {
+        let v = Unoverridden(bytes.clone());
+        assert_eq!(streamed(&v), bytes);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #828, which rewired the two Merkle backends and `DefaultTranscript::append_field_element` from `as_bytes()`/`to_bytes_be()` to the new `AsBytes::stream_bytes`. That rewire is only sound because `stream_bytes` emits byte-identical output — it does, I checked both fields — but nothing enforces it, and #828 shipped without tests.

`stream_bytes` is a **defaulted** trait method. An override that disagrees with `as_bytes` compiles cleanly and then silently changes every Merkle root and Fiat-Shamir challenge that flows through it. The failure mode is proofs that no longer verify against previously committed roots, discovered at integration time — not a red test.

- Adds `crypto/math/tests/stream_bytes_parity.rs`: asserts `stream_bytes == as_bytes == to_bytes_be` for `FieldElement<GoldilocksField>` and `FieldElement<Degree3GoldilocksExtensionField>` over ~2k pseudorandom values plus edge cases. The edge cases deliberately include non-canonical `u64`s (`p`, `p+1`, `u64::MAX`), since both encodings reduce through `canonical_u64` and that is exactly where a raw-value override would diverge.
- Pins the ext3 layout that `math-cuda`'s `keccak_leaves_ext3` kernel mirrors (canonical u64 per component, big-endian, order 0,1,2 — matching `write_bytes_be`). The GPU parity tests in `math-cuda/tests/keccak_leaves.rs` only run on a CUDA host, and `gpu-tests` was SKIPPED on #828, so this keeps the CPU half of that contract honest on a GPU-less runner.
- Covers the defaulted fallback path for a type that does not override `stream_bytes`.
- Documents the invariant on the trait method in `traits.rs`, where an implementor would actually look for it.

## Comment fix

The `stream_bytes` comment in `extensions_goldilocks.rs` said it makes "one sink call over a stack buffer instead of three (one per limb)" and that "call count — not indirection — is the cost being cut". The previous code never made three calls: `as_bytes()` returned a single 24-byte `Vec`, which became a single `Digest::update`. The three-call version was a considered alternative, never what shipped. What the override actually removes is the per-element heap allocation. Corrected, and noted that the layout is load-bearing for CPU/GPU leaf parity.

No behavior change — docs and tests only.

## Test plan

- [x] `cargo test -p math --test stream_bytes_parity` — 5/5
- [x] Mutation-checked that the test can actually fail: flipping Goldilocks `stream_bytes` to little-endian fails 1 test; swapping the ext3 component order in `write_bytes_be` fails 3, including the GPU-contract test.
- [x] `cargo test -p math -p crypto -p stark --lib` — 418/418
- [x] `make lint` — clean (exit 0; all four clippy configs including the cuda-feature pass)