### PR TITLE
fix(stark): review follow-ups for OOD pruning (docs, saturating_sub, hard assert)

### DIFF
--- a/crypto/stark/src/logup_gpu.rs
+++ b/crypto/stark/src/logup_gpu.rs
@@ -989,7 +989,7 @@ mod tests {
         let mut out = Vec::with_capacity(num_rows);
         for row in 0..num_rows {
             // Forward accumulation: acc[0] = 0, fold the current row afterwards.
-            out.push(acc.clone());
+            out.push(acc);
             let mut rs = FieldElement::<E>::zero();
             for c in cols {
                 rs = &rs + &c[row];

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -2432,11 +2432,11 @@ mod logup_single_source_tests {
         let n_fe = Fp3::from(n_rows as u64);
         for i in 0..n_rows {
             let mut row_sum = Fp3::zero();
-            for c in 0..n_term_cols {
-                row_sum = row_sum + &term_columns[c][i];
+            for col in &term_columns {
+                row_sum = row_sum + &col[i];
             }
-            let acc_i = trace.get_aux(i, acc_col_idx).clone();
-            let acc_next = trace.get_aux((i + 1) % n_rows, acc_col_idx).clone();
+            let acc_i = *trace.get_aux(i, acc_col_idx);
+            let acc_next = *trace.get_aux((i + 1) % n_rows, acc_col_idx);
             let lhs = (acc_next - acc_i) * &n_fe;
             let rhs = row_sum * &n_fe - &l;
             assert_eq!(lhs, rhs, "forward circular recurrence broken at row {i}");

--- a/crypto/stark/src/lookup.rs
+++ b/crypto/stark/src/lookup.rs
@@ -2346,7 +2346,7 @@ mod logup_single_source_tests {
     //! (verifier) — all bit-for-bit.
     //!
     //! Coverage: the accumulated constraint's 1-absorbed AND 2-absorbed branches
-    //! (the latter reads `aux(1, ·)` next-row cells), the batched-term
+    //! (the latter folds two absorbed interactions, degree 3), the batched-term
     //! constraint, and every [`Packing`] variant's fingerprint contribution.
     use super::*;
     use crate::constraint_ir::{eval_program, eval_program_verifier};

--- a/crypto/stark/src/ood.rs
+++ b/crypto/stark/src/ood.rs
@@ -45,7 +45,7 @@ pub fn num_surviving_trace_openings(
 /// Build the rectangular `num_total_cols x num_eval_points` DEEP trace-term
 /// coefficient grid from `powers` (the `num_surviving_trace_openings` gamma
 /// powers drained for the trace terms). Surviving positions receive a power in a
-/// fixed order; pruned next-row positions stay zero. A rectangular DEEP
+/// fixed order; pruned next-row positions receive zero. A rectangular DEEP
 /// evaluation over the full grid therefore yields the identical polynomial as
 /// summing only the survivors — which is what lets the prover keep its
 /// (GPU-friendly) rectangular DEEP unchanged.
@@ -53,8 +53,8 @@ pub fn num_surviving_trace_openings(
 /// Precondition: `powers.len() == num_surviving_trace_openings(num_total_cols,
 /// num_eval_points, step_size, next_row_cols.len())` for the same layout args —
 /// every power binds to exactly one surviving position and every surviving
-/// position consumes exactly one power. The function asserts this; a mismatch is
-/// a programmer bug in the layout (invariant I3), never a proof-controlled input.
+/// position consumes exactly one power. Both operands are AIR-metadata-derived
+/// (invariant I3), so this holds for every real AIR; a debug build checks it.
 ///
 /// Assignment order (mirrored exactly by [`num_surviving_trace_openings`]):
 ///   1. current-row block — for every column `j`, rows `0..step_size`;
@@ -72,28 +72,24 @@ pub fn build_pruned_trace_term_coeffs<E: IsField>(
     // Current-row block: all columns, rows 0..step_size.
     for col in coeffs.iter_mut() {
         for slot in col.iter_mut().take(step_size) {
-            *slot = powers[p].clone();
-            p += 1;
+            if p < powers.len() {
+                *slot = powers[p].clone();
+                p += 1;
+            }
         }
     }
     // Next-row block(s): masked columns only, rows step_size..num_eval_points.
     for (j, col) in coeffs.iter_mut().enumerate() {
         if flags[j] {
             for slot in col.iter_mut().take(num_eval_points).skip(step_size) {
-                *slot = powers[p].clone();
-                p += 1;
+                if p < powers.len() {
+                    *slot = powers[p].clone();
+                    p += 1;
+                }
             }
         }
     }
-    // Both the number of assignments and `powers.len()` are pure functions of AIR
-    // shape metadata (invariant I3), never proof-controlled, so a mismatch is a
-    // programmer bug in an AIR's `trace_ood_next_row_columns` override — panic
-    // hard rather than silently leave surplus gammas unbound.
-    assert_eq!(
-        p,
-        powers.len(),
-        "power count must match num_surviving_trace_openings for this layout"
-    );
+    debug_assert_eq!(p, powers.len(), "power assignment must consume every power");
     coeffs
 }
 

--- a/crypto/stark/src/ood.rs
+++ b/crypto/stark/src/ood.rs
@@ -1,11 +1,12 @@
 //! Shared, prover = verifier-identical helpers for out-of-domain (OOD) trace
 //! opening pruning.
 //!
-//! The frame OOD table has `num_offsets * step_size` rows (offsets `[0, 1]`,
-//! offset-major: the first `step_size` rows are the current-row block, the rest
-//! are next-row blocks) and one column per trace column. Only the columns a
-//! transition constraint actually reads at the next row — the AIR's transition
-//! window, [`crate::traits::AIR::trace_ood_next_row_columns`] — need to be
+//! The frame OOD table has `num_offsets * step_size` rows (offset-major: the
+//! first `step_size` rows are offset 0's current-row block, and every later
+//! offset contributes a `step_size`-row next-row block) and one column per
+//! trace column. Only the columns a transition constraint actually reads at the
+//! next row — the AIR's transition window,
+//! [`crate::traits::AIR::trace_ood_next_row_columns`] — need to be
 //! opened in the next-row block(s). Every other next-row entry is redundant and
 //! is pruned from the proof.
 //!
@@ -44,10 +45,16 @@ pub fn num_surviving_trace_openings(
 /// Build the rectangular `num_total_cols x num_eval_points` DEEP trace-term
 /// coefficient grid from `powers` (the `num_surviving_trace_openings` gamma
 /// powers drained for the trace terms). Surviving positions receive a power in a
-/// fixed order; pruned next-row positions receive zero. A rectangular DEEP
+/// fixed order; pruned next-row positions stay zero. A rectangular DEEP
 /// evaluation over the full grid therefore yields the identical polynomial as
 /// summing only the survivors — which is what lets the prover keep its
 /// (GPU-friendly) rectangular DEEP unchanged.
+///
+/// Precondition: `powers.len() == num_surviving_trace_openings(num_total_cols,
+/// num_eval_points, step_size, next_row_cols.len())` for the same layout args —
+/// every power binds to exactly one surviving position and every surviving
+/// position consumes exactly one power. The function asserts this; a mismatch is
+/// a programmer bug in the layout (invariant I3), never a proof-controlled input.
 ///
 /// Assignment order (mirrored exactly by [`num_surviving_trace_openings`]):
 ///   1. current-row block — for every column `j`, rows `0..step_size`;
@@ -65,24 +72,28 @@ pub fn build_pruned_trace_term_coeffs<E: IsField>(
     // Current-row block: all columns, rows 0..step_size.
     for col in coeffs.iter_mut() {
         for slot in col.iter_mut().take(step_size) {
-            if p < powers.len() {
-                *slot = powers[p].clone();
-                p += 1;
-            }
+            *slot = powers[p].clone();
+            p += 1;
         }
     }
     // Next-row block(s): masked columns only, rows step_size..num_eval_points.
     for (j, col) in coeffs.iter_mut().enumerate() {
         if flags[j] {
             for slot in col.iter_mut().take(num_eval_points).skip(step_size) {
-                if p < powers.len() {
-                    *slot = powers[p].clone();
-                    p += 1;
-                }
+                *slot = powers[p].clone();
+                p += 1;
             }
         }
     }
-    debug_assert_eq!(p, powers.len(), "power assignment must consume every power");
+    // Both the number of assignments and `powers.len()` are pure functions of AIR
+    // shape metadata (invariant I3), never proof-controlled, so a mismatch is a
+    // programmer bug in an AIR's `trace_ood_next_row_columns` override — panic
+    // hard rather than silently leave surplus gammas unbound.
+    assert_eq!(
+        p,
+        powers.len(),
+        "power count must match num_surviving_trace_openings for this layout"
+    );
     coeffs
 }
 
@@ -226,7 +237,14 @@ mod tests {
         let full = Table::new(vec![fe(10), fe(11), fe(20), fe(21)], 2);
         let (b0, b1) = split_ood_blocks(&full, 1, &[]);
         assert_eq!(b1.width, 0);
-        let recon = reconstruct_ood_full(b0.row_major_data(), b0.width, b1.row_major_data(), 2, 1, &[]);
+        let recon = reconstruct_ood_full(
+            b0.row_major_data(),
+            b0.width,
+            b1.row_major_data(),
+            2,
+            1,
+            &[],
+        );
         assert_eq!(recon.get_row(0), full.get_row(0));
         assert_eq!(recon.get_row(1), &[Fe::zero(), Fe::zero()]);
     }

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -157,7 +157,7 @@ pub trait IsStarkVerifier<
         let expected_next_height = if expected_next_width == 0 {
             0
         } else {
-            num_eval_points - step_size
+            num_eval_points.saturating_sub(step_size)
         };
         let ood_current = proof.trace_ood_evaluations();
         let ood_next = proof.trace_ood_next_evaluations();


### PR DESCRIPTION
Review follow-ups for #823 (forward LogUp accumulation + next-row OOD opening pruning). Docs and consistency only; no behavior change.

- **Stale doc in `logup_single_source_tests` (`lookup.rs`)**: the module doc claimed the 2-absorbed branch "reads `aux(1, ·)` next-row cells". That described pre-#823 backward accumulation; after forward accumulation both branches' only next-row read is `acc_next`, and absorbed operands read offset 0. Replaced with the branch's real distinction — it folds two absorbed interactions (degree 3).
- **Narrow doc in `ood.rs` module header**: reworded the OOD-table illustration so it is no longer pinned to `offsets [0, 1]`. The layout is generic over `transition_offsets.len()` (repo has `[0]` and `[0,1,2]` example AIRs): offset 0 is the current-row block, every later offset contributes a next-row block.
- **Consistency nit in `verifier.rs`**: `num_eval_points - step_size` → `num_eval_points.saturating_sub(step_size)`, matching the shared `ood.rs` helper for the identical quantity. Purely defensive; the underflow is unreachable (would require an AIR with empty `transition_offsets`, which does not exist and is not proof-controlled).
- **Doc-only precondition note in `build_pruned_trace_term_coeffs` (`ood.rs`)**: added a `Precondition:` line to the doc comment stating that `powers.len()` must equal `num_surviving_trace_openings(...)` for the same layout args (both AIR-metadata-derived, invariant I3), checked in debug builds. Code is unchanged: the per-slot `if p < powers.len()` guards and the `debug_assert_eq!` power-count check stay. Rationale: this is a shared helper the verifier calls, and the verifier must never contain a panic path — an invalid proof is a false proof, not a crash — so the release-mode bounds check is intentional and stays.

**Also in this PR** (clears the base branch's latent `Lint` failure, which is inherited here):
- Clippy fixes in the #823-added forward-accumulation tests (`lookup.rs` `accumulated_column_is_forward_and_circular`, `logup_gpu.rs` `reference_accumulate`): iterate slices directly instead of `0..n` (needless_range_loop) and deref instead of `.clone()` on `Copy` field elements (clone_on_copy). `make lint` runs `cargo clippy --workspace --all-targets`; `--all-targets` covers these test targets. The `logup_gpu.rs` one only surfaces under the cuda-feature clippy pass.
- A one-line rustfmt reflow of an over-width test call in `ood.rs`, the only `cargo fmt --check --all` violation on the base.

Validation: `make lint` (fmt `--check --all` + all four `--workspace --all-targets` clippy passes incl. cuda) green; `cargo test --release -p stark` passes `ood::` (4), `logup_single_source` (7), and `bus_tests` (75).