### PR TITLE
harden the deep-composition fuse: pin its two panic guards, make them local

### DIFF
--- a/crypto/stark/src/tests/small_trace_tests.rs
+++ b/crypto/stark/src/tests/small_trace_tests.rs
@@ -11,10 +11,11 @@ use crate::{
     },
     proof::options::ProofOptions,
     prover::{IsStarkProver, Prover},
-    tests::trace_test_helpers::make_valid_simple_proof,
+    tests::trace_test_helpers::{make_valid_logup_proof, make_valid_simple_proof},
     traits::AIR,
     verifier::{IsStarkVerifier, Verifier},
 };
+use math::field::extensions_goldilocks::Degree3GoldilocksExtensionField;
 
 type Felt = FieldElement<GoldilocksField>;
 
@@ -379,6 +380,112 @@ fn test_verify_rejects_opening_column_count_mismatch() {
             &mut DefaultTranscript::<GoldilocksField>::new(&[])
         ),
         "Verifier must reject when an opening's column count does not match the OOD table width"
+    );
+}
+
+/// A malformed proof whose symmetric opening splits its columns between the
+/// base and auxiliary segments differently from the regular opening, while
+/// keeping the same total column count.
+///
+/// `reconstruct_deep_composition_poly_evaluation_pair` bounds its base-column
+/// branch by the REGULAR `num_base` but resolves the symmetric column through
+/// `base_at_sym`, which indexes the SYMMETRIC slices. The
+/// `num_base != num_base_sym` guard is the only thing standing between this
+/// proof and an out-of-bounds index panic in release builds, and it runs in
+/// step 3 — before step 4's Merkle openings could reject the tampering.
+///
+/// The total width is deliberately preserved (one column moved from the
+/// symmetric main trace to the symmetric aux trace) so that the width guards
+/// cannot fire: only the base/aux split guard can reject this.
+#[test_log::test]
+fn test_verify_rejects_asymmetric_base_aux_split() {
+    let (air, mut proof) = make_valid_logup_proof();
+
+    // Sanity: the unmodified proof must verify first.
+    assert!(
+        Verifier::verify(
+            &proof,
+            &air,
+            &mut DefaultTranscript::<Degree3GoldilocksExtensionField>::new(&[])
+        ),
+        "precondition: valid LogUp proof must verify"
+    );
+
+    let opening = proof
+        .deep_poly_openings
+        .first_mut()
+        .expect("test precondition: a valid proof has at least one deep poly opening");
+    let aux = opening
+        .aux_trace_polys
+        .as_mut()
+        .expect("test precondition: the LogUp RAP has an auxiliary trace segment");
+
+    // Move one column from the symmetric main trace into the symmetric aux
+    // trace: `num_base_sym` drops by one while `num_base_sym + aux_sym.len()`
+    // still equals the OOD table width.
+    let moved = opening
+        .main_trace_polys
+        .evaluations_sym
+        .pop()
+        .expect("test precondition: the main trace opening has at least one column");
+    aux.evaluations_sym.push(moved.to_extension());
+
+    assert!(
+        !Verifier::verify(
+            &proof,
+            &air,
+            &mut DefaultTranscript::<Degree3GoldilocksExtensionField>::new(&[])
+        ),
+        "Verifier must reject when the regular and symmetric base-column counts disagree"
+    );
+}
+
+/// A malformed proof whose symmetric composition-poly opening is shorter than
+/// the proof-level `number_of_parts`.
+///
+/// The composition loop in `reconstruct_deep_composition_poly_evaluation_pair`
+/// is bounded by `number_of_parts` (derived from
+/// `composition_poly_parts_ood_evaluation`) and indexes both the regular and
+/// symmetric per-query slices with it, so a short symmetric slice would index
+/// out of bounds and panic in release builds. The length guard is the sole
+/// protection and runs before step 4's Merkle openings.
+///
+/// Uses the LogUp RAP (`composition_poly_degree_bound == 2 * trace_length`) so
+/// the multi-part loop is exercised rather than the degenerate one-part case.
+#[test_log::test]
+fn test_verify_rejects_truncated_symmetric_composition_opening() {
+    let (air, mut proof) = make_valid_logup_proof();
+
+    // Sanity: the unmodified proof must verify first.
+    assert!(
+        Verifier::verify(
+            &proof,
+            &air,
+            &mut DefaultTranscript::<Degree3GoldilocksExtensionField>::new(&[])
+        ),
+        "precondition: valid LogUp proof must verify"
+    );
+    assert!(
+        proof.composition_poly_parts_ood_evaluation.len() > 1,
+        "test precondition: the LogUp RAP must have more than one composition part, \
+         so the multi-part loop is covered"
+    );
+
+    // Drop one symmetric part so the per-query opening is shorter than the
+    // proof-level part count the loop is bounded by.
+    proof.deep_poly_openings[0]
+        .composition_poly
+        .evaluations_sym
+        .pop()
+        .expect("test precondition: the composition opening has at least one part");
+
+    assert!(
+        !Verifier::verify(
+            &proof,
+            &air,
+            &mut DefaultTranscript::<Degree3GoldilocksExtensionField>::new(&[])
+        ),
+        "Verifier must reject when a symmetric composition opening is shorter than number_of_parts"
     );
 }
 

--- a/crypto/stark/src/tests/trace_test_helpers.rs
+++ b/crypto/stark/src/tests/trace_test_helpers.rs
@@ -1,3 +1,6 @@
+use crate::examples::read_only_memory_logup::{
+    LogReadOnlyPublicInputs, LogReadOnlyRAP, read_only_logup_trace,
+};
 use crate::examples::simple_addition::{
     SimpleAdditionAIR, SimpleAdditionPublicInputs, simple_addition_trace,
 };
@@ -10,6 +13,7 @@ use crypto::fiat_shamir::default_transcript::DefaultTranscript;
 use itertools::Itertools;
 use math::field::{
     element::FieldElement,
+    extensions_goldilocks::Degree3GoldilocksExtensionField,
     goldilocks::GoldilocksField,
     traits::{IsField, IsSubFieldOf},
 };
@@ -43,6 +47,52 @@ pub fn make_valid_simple_proof() -> (
         &mut DefaultTranscript::<GoldilocksField>::new(&[]),
     )
     .unwrap();
+    (air, proof)
+}
+
+/// Builds a valid 8-row `LogReadOnlyRAP` proof. Unlike
+/// [`make_valid_simple_proof`], this AIR has both auxiliary trace columns
+/// (`trace_layout() == (5, 1)`) and more than one composition part
+/// (`composition_poly_degree_bound() == 2 * trace_length`), which the deep
+/// composition rejection tests in `small_trace_tests` need in order to reach
+/// the base/aux split and the multi-part composition loop.
+pub type LogupProof = crate::proof::stark::StarkProof<
+    GoldilocksField,
+    Degree3GoldilocksExtensionField,
+    LogReadOnlyPublicInputs<GoldilocksField>,
+>;
+
+pub fn make_valid_logup_proof() -> (
+    LogReadOnlyRAP<GoldilocksField, Degree3GoldilocksExtensionField>,
+    LogupProof,
+) {
+    let address_col: Vec<FieldElement<GoldilocksField>> = [3u64, 2, 2, 3, 4, 5, 1, 3]
+        .iter()
+        .map(|a| (*a).into())
+        .collect();
+    let value_col: Vec<FieldElement<GoldilocksField>> = [30u64, 20, 20, 30, 40, 50, 10, 30]
+        .iter()
+        .map(|v| (*v).into())
+        .collect();
+
+    let pub_inputs = LogReadOnlyPublicInputs {
+        a0: FieldElement::from(3u64),
+        v0: FieldElement::from(30u64),
+        a_sorted_0: FieldElement::from(1u64),
+        v_sorted_0: FieldElement::from(10u64),
+        m0: FieldElement::from(1u64),
+    };
+    let mut trace = read_only_logup_trace(address_col, value_col);
+    let proof_options = ProofOptions::default_test_options();
+    let air =
+        LogReadOnlyRAP::<GoldilocksField, Degree3GoldilocksExtensionField>::new(&proof_options);
+    let proof = Prover::prove(
+        &air,
+        &mut trace,
+        &pub_inputs,
+        &mut DefaultTranscript::<Degree3GoldilocksExtensionField>::new(&[]),
+    )
+    .expect("prover must succeed on the LogUp read-only-memory RAP");
     (air, proof)
 }
 

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -678,9 +678,20 @@ pub trait IsStarkVerifier<
         let ood_data = trace_ood_evaluations.row_major_data();
         let trace_term_coeffs = &challenges.trace_term_coeffs;
 
-        if trace_term_coeffs.is_empty()
-            || trace_term_coeffs.len() * trace_term_coeffs[0].len()
-                != ood_evaluations_table_height * ood_evaluations_table_width
+        // Check the exact shape the code relies on rather than the product of
+        // the dimensions: this function and
+        // `reconstruct_deep_composition_poly_evaluation_pair` both
+        // direct-index `trace_term_coeffs[col][row]` for every `col < width`,
+        // `row < height`, and a product check accepts shapes that transpose
+        // those bounds. Checking the shape here keeps their panic-freedom
+        // local, rather than resting on #815's OOD-table guard in
+        // `multi_verify_views` plus the unasserted `trace_columns ==
+        // trace_layout.0 + trace_layout.1` convention. Runs once per proof and
+        // is integer compares only — no per-query cost.
+        if trace_term_coeffs.len() != ood_evaluations_table_width
+            || trace_term_coeffs
+                .iter()
+                .any(|coeff_col| coeff_col.len() != ood_evaluations_table_height)
         {
             return None;
         }

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -752,8 +752,9 @@ pub trait IsStarkVerifier<
         let mut deep_poly_evaluations_sym = Vec::with_capacity(num_queries);
 
         // Build the base-field LDE evaluations as concatenated slice (precomputed + main)
-        // without lifting to the extension field. The helper now subtracts directly via
-        // the F: IsSubFieldOf<E> Sub impl, so we avoid a per-query base->extension lift.
+        // without lifting to the extension field. The helper multiplies each base column
+        // straight into its extension-field coefficient via the F: IsSubFieldOf<E> Mul
+        // impl, so we avoid a per-query base->extension lift.
         let primitive_root = &Field::get_primitive_root_of_unity(domain.root_order as u64)
             .expect("verifier domain root_order is a valid power of two");
 
@@ -816,9 +817,9 @@ pub trait IsStarkVerifier<
 
     /// Reconstructs the deep composition polynomial evaluation at a query's
     /// point and its symmetric counterpart together. Rewriting the per-element
-    /// trace term `coeff*(base-ood)*denom` as `denom*(coeff*base - coeff*ood)`
+    /// trace term `coeff*(lde-ood)*denom` as `denom*(coeff*lde - coeff*ood)`
     /// isolates `coeff*ood` (identical for both points, hoisted into
-    /// `query_invariant_terms`) from `coeff*base` (per-point), so both points
+    /// `query_invariant_terms`) from `coeff*lde` (per-point), so both points
     /// share the OOD walk and a single batch-inverse for their denominators.
     #[allow(clippy::too_many_arguments)]
     fn reconstruct_deep_composition_poly_evaluation_pair<'b>(
@@ -897,22 +898,22 @@ pub trait IsStarkVerifier<
         let mut trace_term_sym = FieldElement::<FieldExtension>::zero();
         for row_idx in 0..ood_evaluations_table_height {
             let ood_row_sum = &query_invariant_terms.ood_row_sum[row_idx];
-            let mut base_row_sum = FieldElement::<FieldExtension>::zero();
-            let mut base_row_sum_sym = FieldElement::<FieldExtension>::zero();
+            let mut lde_row_sum = FieldElement::<FieldExtension>::zero();
+            let mut lde_row_sum_sym = FieldElement::<FieldExtension>::zero();
             for (col_idx, coeff_col) in trace_term_coeffs.iter().enumerate() {
                 let coeff = &coeff_col[row_idx];
                 if col_idx < num_base {
                     // F: IsSubFieldOf<E> gives the cheap asymmetric F * E -> E product.
-                    base_row_sum += base_at(col_idx) * coeff;
-                    base_row_sum_sym += base_at_sym(col_idx) * coeff;
+                    lde_row_sum += base_at(col_idx) * coeff;
+                    lde_row_sum_sym += base_at_sym(col_idx) * coeff;
                 } else {
                     let aux_idx = col_idx - num_base;
-                    base_row_sum += coeff * &lde_trace_aux_evaluations[aux_idx];
-                    base_row_sum_sym += coeff * &lde_trace_aux_evaluations_sym[aux_idx];
+                    lde_row_sum += coeff * &lde_trace_aux_evaluations[aux_idx];
+                    lde_row_sum_sym += coeff * &lde_trace_aux_evaluations_sym[aux_idx];
                 }
             }
-            trace_term += &denoms_trace[row_idx] * &(&base_row_sum - ood_row_sum);
-            trace_term_sym += &denoms_trace_sym[row_idx] * &(&base_row_sum_sym - ood_row_sum);
+            trace_term += &denoms_trace[row_idx] * &(&lde_row_sum - ood_row_sum);
+            trace_term_sym += &denoms_trace_sym[row_idx] * &(&lde_row_sum_sym - ood_row_sum);
         }
 
         let number_of_parts = query_invariant_terms.number_of_parts;

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -84,6 +84,22 @@ where
 
 pub type DeepPolynomialEvaluations<F> = (Vec<FieldElement<F>>, Vec<FieldElement<F>>);
 
+/// Deep-composition sums that are identical across all FRI queries of a
+/// single proof (see `compute_query_invariant_deep_terms`).
+pub struct QueryInvariantDeepTerms<FieldExtension>
+where
+    FieldExtension: Send + Sync + IsField,
+{
+    /// `ood_row_sum[row] = sum_col trace_term_coeffs[col][row] * ood(row, col)`.
+    ood_row_sum: Vec<FieldElement<FieldExtension>>,
+    /// Derived from `proof.composition_poly_parts_ood_evaluation().len()`.
+    number_of_parts: usize,
+    /// `challenges.z.pow(number_of_parts)`.
+    z_pow: FieldElement<FieldExtension>,
+    /// `sum_j composition_poly_parts_ood_evaluation[j] * challenges.gammas[j]`.
+    h_sum_zpow: FieldElement<FieldExtension>,
+}
+
 // The verifier reads proofs in place from their rkyv archive; archived field
 // elements are viewed as native ones, which is only valid on little-endian.
 #[cfg(not(target_endian = "little"))]
@@ -649,6 +665,60 @@ pub trait IsStarkVerifier<
         openings_ok & terminal_ok
     }
 
+    /// Sums that depend only on `challenges` and proof-level OOD/gamma data —
+    /// identical for every FRI query — computed once instead of once per
+    /// query.
+    fn compute_query_invariant_deep_terms(
+        challenges: &Challenges<FieldExtension>,
+        proof: StarkProofView<'_, Field, FieldExtension, PI>,
+    ) -> Option<QueryInvariantDeepTerms<FieldExtension>> {
+        let trace_ood_evaluations = proof.trace_ood_evaluations();
+        let ood_evaluations_table_height = trace_ood_evaluations.height();
+        let ood_evaluations_table_width = trace_ood_evaluations.width();
+        let ood_data = trace_ood_evaluations.row_major_data();
+        let trace_term_coeffs = &challenges.trace_term_coeffs;
+
+        if trace_term_coeffs.is_empty()
+            || trace_term_coeffs.len() * trace_term_coeffs[0].len()
+                != ood_evaluations_table_height * ood_evaluations_table_width
+        {
+            return None;
+        }
+
+        let mut ood_row_sum = Vec::with_capacity(ood_evaluations_table_height);
+        for row_idx in 0..ood_evaluations_table_height {
+            let ood_row = &ood_data[row_idx * ood_evaluations_table_width
+                ..(row_idx + 1) * ood_evaluations_table_width];
+            let mut sum = FieldElement::<FieldExtension>::zero();
+            for col_idx in 0..ood_evaluations_table_width {
+                sum += &trace_term_coeffs[col_idx][row_idx] * &ood_row[col_idx];
+            }
+            ood_row_sum.push(sum);
+        }
+
+        let composition_parts_ood = proof.composition_poly_parts_ood_evaluation();
+        let number_of_parts = composition_parts_ood.len();
+        let z_pow = challenges.z.pow(number_of_parts);
+
+        // A malformed proof/challenge set can advertise more composition
+        // parts than sampled gammas; reject rather than silently truncate
+        // the sum below.
+        if challenges.gammas.len() < number_of_parts {
+            return None;
+        }
+        let mut h_sum_zpow = FieldElement::<FieldExtension>::zero();
+        for (h_i_zpower, gamma) in composition_parts_ood.iter().zip(challenges.gammas.iter()) {
+            h_sum_zpow += h_i_zpower * gamma;
+        }
+
+        Some(QueryInvariantDeepTerms {
+            ood_row_sum,
+            number_of_parts,
+            z_pow,
+            h_sum_zpow,
+        })
+    }
+
     fn reconstruct_deep_composition_poly_evaluations_for_all_queries(
         challenges: &Challenges<FieldExtension>,
         domain: &VerifierDomain<Field>,
@@ -676,6 +746,8 @@ pub trait IsStarkVerifier<
         let primitive_root = &Field::get_primitive_root_of_unity(domain.root_order as u64)
             .expect("verifier domain root_order is a valid power of two");
 
+        let query_invariant_terms = Self::compute_query_invariant_deep_terms(challenges, proof)?;
+
         for (i, iota) in challenges.iotas.iter().enumerate() {
             let opening = proof.deep_poly_opening(i);
 
@@ -694,19 +766,6 @@ pub trait IsStarkVerifier<
                 .map(|a| a.evaluations())
                 .unwrap_or(&[]);
 
-            let evaluation_point = Self::query_challenge_to_evaluation_point(*iota, false, domain);
-            deep_poly_evaluations.push(Self::reconstruct_deep_composition_poly_evaluation(
-                proof,
-                &evaluation_point,
-                primitive_root,
-                challenges,
-                lde_precomputed,
-                lde_main,
-                lde_aux,
-                opening.composition_poly().evaluations(),
-            )?);
-
-            // Mirror for the symmetric query point.
             let lde_precomputed_sym: &[FieldElement<Field>] = opening
                 .precomputed_trace_polys()
                 .map(|p| p.evaluations_sym())
@@ -718,43 +777,62 @@ pub trait IsStarkVerifier<
                 .map(|a| a.evaluations_sym())
                 .unwrap_or(&[]);
 
-            let evaluation_point = Self::query_challenge_to_evaluation_point(*iota, true, domain);
-            deep_poly_evaluations_sym.push(Self::reconstruct_deep_composition_poly_evaluation(
-                proof,
-                &evaluation_point,
-                primitive_root,
-                challenges,
-                lde_precomputed_sym,
-                lde_main_sym,
-                lde_aux_sym,
-                opening.composition_poly().evaluations_sym(),
-            )?);
+            let evaluation_point = Self::query_challenge_to_evaluation_point(*iota, false, domain);
+            let evaluation_point_sym =
+                Self::query_challenge_to_evaluation_point(*iota, true, domain);
+            let (evaluation, evaluation_sym) =
+                Self::reconstruct_deep_composition_poly_evaluation_pair(
+                    proof,
+                    &evaluation_point,
+                    &evaluation_point_sym,
+                    primitive_root,
+                    challenges,
+                    &query_invariant_terms,
+                    lde_precomputed,
+                    lde_main,
+                    lde_aux,
+                    opening.composition_poly().evaluations(),
+                    lde_precomputed_sym,
+                    lde_main_sym,
+                    lde_aux_sym,
+                    opening.composition_poly().evaluations_sym(),
+                )?;
+            deep_poly_evaluations.push(evaluation);
+            deep_poly_evaluations_sym.push(evaluation_sym);
         }
         Some((deep_poly_evaluations, deep_poly_evaluations_sym))
     }
 
+    /// Reconstructs the deep composition polynomial evaluation at a query's
+    /// point and its symmetric counterpart together. Rewriting the per-element
+    /// trace term `coeff*(base-ood)*denom` as `denom*(coeff*base - coeff*ood)`
+    /// isolates `coeff*ood` (identical for both points, hoisted into
+    /// `query_invariant_terms`) from `coeff*base` (per-point), so both points
+    /// share the OOD walk and a single batch-inverse for their denominators.
     #[allow(clippy::too_many_arguments)]
-    fn reconstruct_deep_composition_poly_evaluation<'b>(
+    fn reconstruct_deep_composition_poly_evaluation_pair<'b>(
         proof: StarkProofView<'_, Field, FieldExtension, PI>,
         evaluation_point: &FieldElement<Field>,
+        evaluation_point_sym: &FieldElement<Field>,
         primitive_root: &FieldElement<Field>,
         challenges: &Challenges<FieldExtension>,
+        query_invariant_terms: &QueryInvariantDeepTerms<FieldExtension>,
         lde_trace_precomputed_evaluations: &'b [FieldElement<Field>],
         lde_trace_main_evaluations: &'b [FieldElement<Field>],
         lde_trace_aux_evaluations: &[FieldElement<FieldExtension>],
         lde_composition_poly_parts_evaluation: &[FieldElement<FieldExtension>],
-    ) -> Option<FieldElement<FieldExtension>> {
-        let trace_ood_evaluations = proof.trace_ood_evaluations();
-        let ood_evaluations_table_height = trace_ood_evaluations.height();
-        let ood_evaluations_table_width = trace_ood_evaluations.width();
-        // Hot loop below: resolve the OOD data to one flat slice once instead
-        // of re-deriving a row slice per element.
-        let ood_data = trace_ood_evaluations.row_major_data();
+        lde_trace_precomputed_evaluations_sym: &'b [FieldElement<Field>],
+        lde_trace_main_evaluations_sym: &'b [FieldElement<Field>],
+        lde_trace_aux_evaluations_sym: &[FieldElement<FieldExtension>],
+        lde_composition_poly_parts_evaluation_sym: &[FieldElement<FieldExtension>],
+    ) -> Option<(FieldElement<FieldExtension>, FieldElement<FieldExtension>)> {
+        let ood_evaluations_table_height = query_invariant_terms.ood_row_sum.len();
+        let ood_evaluations_table_width = proof.trace_ood_evaluations().width();
         let trace_term_coeffs = &challenges.trace_term_coeffs;
 
         // Base columns are supplied as two slices (precomputed ‖ main) that the
-        // prover concatenated in this order; `num_base` is their combined width
-        // and `base_at` indexes into them as if concatenated, without allocating.
+        // prover concatenated in this order; `num_base`/`base_at` index into
+        // them as if concatenated, without allocating.
         let num_precomputed = lde_trace_precomputed_evaluations.len();
         let num_base = num_precomputed + lde_trace_main_evaluations.len();
         let base_at = move |col: usize| -> &'b FieldElement<Field> {
@@ -764,68 +842,97 @@ pub trait IsStarkVerifier<
                 &lde_trace_main_evaluations[col - num_precomputed]
             }
         };
+        let num_precomputed_sym = lde_trace_precomputed_evaluations_sym.len();
+        let num_base_sym = num_precomputed_sym + lde_trace_main_evaluations_sym.len();
+        let base_at_sym = move |col: usize| -> &'b FieldElement<Field> {
+            if col < num_precomputed_sym {
+                &lde_trace_precomputed_evaluations_sym[col]
+            } else {
+                &lde_trace_main_evaluations_sym[col - num_precomputed_sym]
+            }
+        };
 
-        // Runtime guard: a malformed proof may supply opening evaluations whose
-        // column count does not match the OOD table width, or whose composition
-        // poly parts count does not match the proof's `composition_poly_parts_ood_evaluation`.
-        // Without these checks the indexing below would panic in release builds.
-        if num_base + lde_trace_aux_evaluations.len() != ood_evaluations_table_width {
+        // Runtime guards: a malformed proof may supply opening evaluations
+        // whose column count does not match the OOD table width, or whose
+        // regular/symmetric base-column split disagree. Without these checks
+        // the indexing below would panic in release builds.
+        if num_base != num_base_sym {
             return None;
         }
-        if trace_term_coeffs.is_empty()
-            || trace_term_coeffs.len() * trace_term_coeffs[0].len()
-                != ood_evaluations_table_height * ood_evaluations_table_width
+        if num_base + lde_trace_aux_evaluations.len() != ood_evaluations_table_width
+            || num_base + lde_trace_aux_evaluations_sym.len() != ood_evaluations_table_width
         {
             return None;
         }
 
-        let mut denoms_trace = Vec::with_capacity(ood_evaluations_table_height);
+        // Build both denominator sets (regular, then symmetric) and invert
+        // them together in a single batch.
+        let mut denoms = Vec::with_capacity(2 * ood_evaluations_table_height);
         let mut current_z = challenges.z.clone();
         for _ in 0..ood_evaluations_table_height {
-            denoms_trace.push(evaluation_point - &current_z);
+            denoms.push(evaluation_point - &current_z);
+            current_z = primitive_root * &current_z;
+        }
+        let mut current_z = challenges.z.clone();
+        for _ in 0..ood_evaluations_table_height {
+            denoms.push(evaluation_point_sym - &current_z);
             current_z = primitive_root * &current_z;
         }
         // A malformed proof can land an OOD evaluation point on the LDE coset, reject.
-        FieldElement::inplace_batch_inverse(&mut denoms_trace).ok()?;
+        FieldElement::inplace_batch_inverse(&mut denoms).ok()?;
+        let (denoms_trace, denoms_trace_sym) = denoms.split_at(ood_evaluations_table_height);
 
-        let trace_term = (0..ood_evaluations_table_width)
-            .zip(&challenges.trace_term_coeffs)
-            .fold(FieldElement::zero(), |trace_terms, (col_idx, coeff_row)| {
-                let trace_i = (0..ood_evaluations_table_height).zip(coeff_row).fold(
-                    FieldElement::zero(),
-                    |trace_t, (row_idx, coeff)| {
-                        let ood_val = &ood_data[row_idx * ood_evaluations_table_width + col_idx];
-                        // Stay in base when we can: F: IsSubFieldOf<E> gives F - E -> E.
-                        let diff: FieldElement<FieldExtension> = if col_idx < num_base {
-                            base_at(col_idx) - ood_val
-                        } else {
-                            &lde_trace_aux_evaluations[col_idx - num_base] - ood_val
-                        };
-                        let poly_evaluation = diff * &denoms_trace[row_idx];
-                        trace_t + &poly_evaluation * coeff
-                    },
-                );
-                trace_terms + trace_i
-            });
-
-        let composition_parts_ood = proof.composition_poly_parts_ood_evaluation();
-        let number_of_parts = lde_composition_poly_parts_evaluation.len();
-        let z_pow = &challenges.z.pow(number_of_parts);
-
-        // A malformed proof can make evaluation_point == z^N, reject.
-        let denom_composition = (evaluation_point - z_pow).inv().ok()?;
-        let mut h_terms = FieldElement::zero();
-        for (j, h_i_upsilon) in lde_composition_poly_parts_evaluation.iter().enumerate() {
-            // Bounds-check via `.get(j)?`: a malformed opening may have more
-            // parts than the proof header advertises.
-            let h_i_zpower = composition_parts_ood.get(j)?;
-            let gamma = challenges.gammas.get(j)?;
-            let h_i_term = (h_i_upsilon - h_i_zpower) * gamma;
-            h_terms += h_i_term;
+        let mut trace_term = FieldElement::<FieldExtension>::zero();
+        let mut trace_term_sym = FieldElement::<FieldExtension>::zero();
+        for row_idx in 0..ood_evaluations_table_height {
+            let ood_row_sum = &query_invariant_terms.ood_row_sum[row_idx];
+            let mut base_row_sum = FieldElement::<FieldExtension>::zero();
+            let mut base_row_sum_sym = FieldElement::<FieldExtension>::zero();
+            for (col_idx, coeff_col) in trace_term_coeffs.iter().enumerate() {
+                let coeff = &coeff_col[row_idx];
+                if col_idx < num_base {
+                    // F: IsSubFieldOf<E> gives the cheap asymmetric F * E -> E product.
+                    base_row_sum += base_at(col_idx) * coeff;
+                    base_row_sum_sym += base_at_sym(col_idx) * coeff;
+                } else {
+                    let aux_idx = col_idx - num_base;
+                    base_row_sum += coeff * &lde_trace_aux_evaluations[aux_idx];
+                    base_row_sum_sym += coeff * &lde_trace_aux_evaluations_sym[aux_idx];
+                }
+            }
+            trace_term += &denoms_trace[row_idx] * &(&base_row_sum - ood_row_sum);
+            trace_term_sym += &denoms_trace_sym[row_idx] * &(&base_row_sum_sym - ood_row_sum);
         }
-        h_terms *= denom_composition;
 
-        Some(trace_term + h_terms)
+        let number_of_parts = query_invariant_terms.number_of_parts;
+        // Also rejects a per-query opening length that disagrees with the
+        // proof-level `number_of_parts`, not just a regular/symmetric mismatch.
+        if lde_composition_poly_parts_evaluation.len() != number_of_parts
+            || lde_composition_poly_parts_evaluation_sym.len() != number_of_parts
+        {
+            return None;
+        }
+        let z_pow = &query_invariant_terms.z_pow;
+
+        // A malformed proof can make evaluation_point == z_pow, reject.
+        let mut denom_composition_pair = [evaluation_point - z_pow, evaluation_point_sym - z_pow];
+        FieldElement::inplace_batch_inverse(&mut denom_composition_pair).ok()?;
+        let [denom_composition, denom_composition_sym] = denom_composition_pair;
+
+        let mut h_sum = FieldElement::<FieldExtension>::zero();
+        let mut h_sum_sym = FieldElement::<FieldExtension>::zero();
+        for j in 0..number_of_parts {
+            let h_i_upsilon = &lde_composition_poly_parts_evaluation[j];
+            let h_i_upsilon_sym = &lde_composition_poly_parts_evaluation_sym[j];
+            let gamma = &challenges.gammas[j];
+            h_sum += h_i_upsilon * gamma;
+            h_sum_sym += h_i_upsilon_sym * gamma;
+        }
+        let h_terms = (&h_sum - &query_invariant_terms.h_sum_zpow) * denom_composition;
+        let h_terms_sym =
+            (&h_sum_sym - &query_invariant_terms.h_sum_zpow) * denom_composition_sym;
+
+        Some((trace_term + h_terms, trace_term_sym + h_terms_sym))
     }
 
     /// Verifies one or more STARK proofs with their corresponding AIRs.

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -92,6 +92,9 @@ where
 {
     /// `ood_row_sum[row] = sum_col trace_term_coeffs[col][row] * ood(row, col)`.
     ood_row_sum: Vec<FieldElement<FieldExtension>>,
+    /// `proof.trace_ood_evaluations().width()`, checked against the
+    /// `trace_term_coeffs` shape below.
+    ood_width: usize,
     /// Derived from `proof.composition_poly_parts_ood_evaluation().len()`.
     number_of_parts: usize,
     /// `challenges.z.pow(number_of_parts)`.
@@ -724,6 +727,7 @@ pub trait IsStarkVerifier<
 
         Some(QueryInvariantDeepTerms {
             ood_row_sum,
+            ood_width: ood_evaluations_table_width,
             number_of_parts,
             z_pow,
             h_sum_zpow,
@@ -761,53 +765,17 @@ pub trait IsStarkVerifier<
         let query_invariant_terms = Self::compute_query_invariant_deep_terms(challenges, proof)?;
 
         for (i, iota) in challenges.iotas.iter().enumerate() {
-            let opening = proof.deep_poly_opening(i);
-
-            // Base-field portion as two borrowed slices in commit order —
-            // precomputed columns FIRST, then main trace columns. The callee
-            // resolves a base column via `base_at`, so there is no per-query
-            // concat allocation.
-            let lde_precomputed: &[FieldElement<Field>] = opening
-                .precomputed_trace_polys()
-                .map(|p| p.evaluations())
-                .unwrap_or(&[]);
-            let lde_main = opening.main_trace_polys().evaluations();
-
-            let lde_aux: &[FieldElement<FieldExtension>] = opening
-                .aux_trace_polys()
-                .map(|a| a.evaluations())
-                .unwrap_or(&[]);
-
-            let lde_precomputed_sym: &[FieldElement<Field>] = opening
-                .precomputed_trace_polys()
-                .map(|p| p.evaluations_sym())
-                .unwrap_or(&[]);
-            let lde_main_sym = opening.main_trace_polys().evaluations_sym();
-
-            let lde_aux_sym: &[FieldElement<FieldExtension>] = opening
-                .aux_trace_polys()
-                .map(|a| a.evaluations_sym())
-                .unwrap_or(&[]);
-
             let evaluation_point = Self::query_challenge_to_evaluation_point(*iota, false, domain);
             let evaluation_point_sym =
                 Self::query_challenge_to_evaluation_point(*iota, true, domain);
             let (evaluation, evaluation_sym) =
                 Self::reconstruct_deep_composition_poly_evaluation_pair(
-                    proof,
+                    proof.deep_poly_opening(i),
                     &evaluation_point,
                     &evaluation_point_sym,
                     primitive_root,
                     challenges,
                     &query_invariant_terms,
-                    lde_precomputed,
-                    lde_main,
-                    lde_aux,
-                    opening.composition_poly().evaluations(),
-                    lde_precomputed_sym,
-                    lde_main_sym,
-                    lde_aux_sym,
-                    opening.composition_poly().evaluations_sym(),
                 )?;
             deep_poly_evaluations.push(evaluation);
             deep_poly_evaluations_sym.push(evaluation_sym);
@@ -821,25 +789,43 @@ pub trait IsStarkVerifier<
     /// isolates `coeff*ood` (identical for both points, hoisted into
     /// `query_invariant_terms`) from `coeff*lde` (per-point), so both points
     /// share the OOD walk and a single batch-inverse for their denominators.
-    #[allow(clippy::too_many_arguments)]
     fn reconstruct_deep_composition_poly_evaluation_pair<'b>(
-        proof: StarkProofView<'_, Field, FieldExtension, PI>,
+        opening: DeepPolynomialOpeningView<'b, Field, FieldExtension>,
         evaluation_point: &FieldElement<Field>,
         evaluation_point_sym: &FieldElement<Field>,
         primitive_root: &FieldElement<Field>,
         challenges: &Challenges<FieldExtension>,
         query_invariant_terms: &QueryInvariantDeepTerms<FieldExtension>,
-        lde_trace_precomputed_evaluations: &'b [FieldElement<Field>],
-        lde_trace_main_evaluations: &'b [FieldElement<Field>],
-        lde_trace_aux_evaluations: &[FieldElement<FieldExtension>],
-        lde_composition_poly_parts_evaluation: &[FieldElement<FieldExtension>],
-        lde_trace_precomputed_evaluations_sym: &'b [FieldElement<Field>],
-        lde_trace_main_evaluations_sym: &'b [FieldElement<Field>],
-        lde_trace_aux_evaluations_sym: &[FieldElement<FieldExtension>],
-        lde_composition_poly_parts_evaluation_sym: &[FieldElement<FieldExtension>],
     ) -> Option<(FieldElement<FieldExtension>, FieldElement<FieldExtension>)> {
+        // Base-field portion as two borrowed slices in commit order —
+        // precomputed columns FIRST, then main trace columns. A base column is
+        // resolved via `base_at` below, so there is no per-query concat
+        // allocation.
+        let lde_trace_precomputed_evaluations: &'b [FieldElement<Field>] = opening
+            .precomputed_trace_polys()
+            .map(|p| p.evaluations())
+            .unwrap_or(&[]);
+        let lde_trace_main_evaluations = opening.main_trace_polys().evaluations();
+        let lde_trace_aux_evaluations: &[FieldElement<FieldExtension>] = opening
+            .aux_trace_polys()
+            .map(|a| a.evaluations())
+            .unwrap_or(&[]);
+        let lde_composition_poly_parts_evaluation = opening.composition_poly().evaluations();
+
+        let lde_trace_precomputed_evaluations_sym: &'b [FieldElement<Field>] = opening
+            .precomputed_trace_polys()
+            .map(|p| p.evaluations_sym())
+            .unwrap_or(&[]);
+        let lde_trace_main_evaluations_sym = opening.main_trace_polys().evaluations_sym();
+        let lde_trace_aux_evaluations_sym: &[FieldElement<FieldExtension>] = opening
+            .aux_trace_polys()
+            .map(|a| a.evaluations_sym())
+            .unwrap_or(&[]);
+        let lde_composition_poly_parts_evaluation_sym =
+            opening.composition_poly().evaluations_sym();
+
         let ood_evaluations_table_height = query_invariant_terms.ood_row_sum.len();
-        let ood_evaluations_table_width = proof.trace_ood_evaluations().width();
+        let ood_evaluations_table_width = query_invariant_terms.ood_width;
         let trace_term_coeffs = &challenges.trace_term_coeffs;
 
         // Base columns are supplied as two slices (precomputed ‖ main) that the

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -929,8 +929,7 @@ pub trait IsStarkVerifier<
             h_sum_sym += h_i_upsilon_sym * gamma;
         }
         let h_terms = (&h_sum - &query_invariant_terms.h_sum_zpow) * denom_composition;
-        let h_terms_sym =
-            (&h_sum_sym - &query_invariant_terms.h_sum_zpow) * denom_composition_sym;
+        let h_terms_sym = (&h_sum_sym - &query_invariant_terms.h_sum_zpow) * denom_composition_sym;
 
         Some((trace_term + h_terms, trace_term_sym + h_terms_sym))
     }

--- a/crypto/stark/src/verifier.rs
+++ b/crypto/stark/src/verifier.rs
@@ -860,7 +860,7 @@ pub trait IsStarkVerifier<
             return None;
         }
         if num_base + lde_trace_aux_evaluations.len() != ood_evaluations_table_width
-            || num_base + lde_trace_aux_evaluations_sym.len() != ood_evaluations_table_width
+            || num_base_sym + lde_trace_aux_evaluations_sym.len() != ood_evaluations_table_width
         {
             return None;
         }


### PR DESCRIPTION
Stacks onto #826 (`perf/deep-composition-fuse-hoist`). Hardening and polish only — **the algebra of the fuse/hoist is untouched**. It was independently verified as exact, and this PR does not change it.

### Tests: two guards that had no coverage

The fuse made two guards in `reconstruct_deep_composition_poly_evaluation_pair` the sole protection against a release-mode out-of-bounds panic on a malformed proof. Both run in step 3, **before** step 4's Merkle openings could reject the tampering, so nothing else stands between a malicious proof and the panic:

- **`num_base != num_base_sym`** — the base-column branch is bounded by the regular `num_base` but resolves symmetric columns through `base_at_sym`, which indexes the *symmetric* slices.
- **the composition-part length check** — the part loop is bounded by the proof-level `number_of_parts` and indexes both the regular and symmetric per-query slices with it.

Both tests use the LogUp read-only-memory RAP (`trace_layout() == (5, 1)`, `composition_poly_degree_bound() == 2 * trace_length`) so they exercise the base/aux split and the multi-part loop rather than the degenerate one-part case.

Each test was verified by removing the guard it pins and confirming it fails with an index out of bounds — not merely a `false` verdict:

| Guard removed | Result |
|---|---|
| `num_base != num_base_sym` | panic at `base_at_sym`: `len is 4 but the index is 4` |
| composition-part length check | panic at `..._sym[j]`: `len is 1 but the index is 1` |

The second panic's `len 1` (popped from 2) confirms the multi-part loop is genuinely covered.

Note on the first test: it moves one column from the symmetric main trace into the symmetric aux trace rather than simply popping. A plain pop is caught by the *width* guard once that guard is fixed (below), so it would no longer pin the base/aux split guard. Preserving the total width isolates the guard under test.

### `num_base_sym` in the width guard

The second guard's symmetric arm reused the regular `num_base`, so it was correct only because the guard above it had already run. It now checks `num_base_sym`, making the two guards independently correct instead of order-dependent.

No behavior change: the guard above forces `num_base == num_base_sym` before this arm is reached, so the two forms agree on every input that gets here. This is unobservable by design and therefore has no test of its own — a test would have to remove the other guard to see it.

### Shape guard instead of a dimension product

`compute_query_invariant_deep_terms` and `reconstruct_deep_composition_poly_evaluation_pair` direct-index `trace_term_coeffs[col][row]` for `col < ood_width`, `row < ood_height`. The product guard (`len * [0].len() != height * width`) accepts shapes that transpose those bounds and only inspected column 0's length. It was sufficient only through a three-link chain across files: #815's OOD-table guard in `multi_verify_views` pins the width, `replay_rounds_after_round_1` builds the coefficients by exact division, and every AIR happens to satisfy the unasserted `trace_columns == trace_layout.0 + trace_layout.1` convention. **Nothing was exploitable** — this makes panic-freedom local rather than dependent on a guard in another function.

The new check is **integer compares, once per proof** — no per-query cost, no field operations. Dropping `is_empty()` is safe because the new form never indexes `[0]`: an empty `trace_term_coeffs` is rejected by the length compare whenever `width > 0`, and the degenerate `width == 0` case indexes nothing (#815 already rejects `height == 0`).

### Nits

- `base_row_sum`/`base_row_sum_sym` → `lde_row_sum`/`lde_row_sum_sym`: they accumulate base **and** aux columns, while `num_base`/`base_at` in the same function mean "base-field, not aux". The name asserted a partition the code does not implement, right at the identity under review. Pure rename.
- The comment above `primitive_root` still described the pre-fuse code: the per-element `base_at(col) - ood_val` subtraction is now `base_at(col) * coeff`, a Mul. Reworded for the trace-term path only — `F`→`E` subtractions via `IsSubFieldOf` do still exist in the helper (the `evaluation_point - current_z` denominators).

### Last commit is droppable

`refactor(verifier): pass the opening view instead of eight derived slices` reduces the signature from 14 args to 6 and **deletes** `#[allow(clippy::too_many_arguments)]` rather than inheriting it. The inner row/column accumulation is textually unchanged; slice resolution happens once per query either way, just on the other side of the call, and the per-query `proof.trace_ood_evaluations().width()` call becomes a struct read. Drop this commit if the signature change is unwelcome in the hot loop.

Caveat: I could not measure the in-VM recursion cycle count locally, so "no regression" for that commit rests on the inner loop being textually identical and the moved work being per-query, not per-element — not on a profile.

### Checks

`cargo test --release -p stark --lib` — 187 passed (185 pre-existing + 2 new). `cargo clippy -p stark --all-targets` clean (the 19 remaining warnings are pre-existing, in `prover_tests.rs` / `fri_tests.rs` / `row_pair_opening_tests.rs`). `cargo fmt --check` clean.
